### PR TITLE
Implement chart synchronization features and update API documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,6 +26,9 @@ See [ChartGPU.ts](../src/ChartGPU.ts) for the full interface and lifecycle behav
 - `dispose(): void`: cancels any pending frame, disposes internal render resources, destroys the WebGPU context, and removes the canvas.
 - `on(eventName: ChartGPUEventName, callback: ChartGPUEventCallback): void`: registers an event listener. See [Event handling](#event-handling) below.
 - `off(eventName: ChartGPUEventName, callback: ChartGPUEventCallback): void`: unregisters an event listener. See [Event handling](#event-handling) below.
+- `getInteractionX(): number | null`: returns the current “interaction x” in domain units (or `null` when inactive). See [`ChartGPU.ts`](../src/ChartGPU.ts).
+- `setInteractionX(x: number | null, source?: unknown): void`: drives the chart’s crosshair/tooltip interaction from a domain x value; pass `null` to clear. See [`ChartGPU.ts`](../src/ChartGPU.ts) and the internal implementation in [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts).
+- `onInteractionXChange(callback: (x: number | null, source?: unknown) => void): () => void`: subscribes to interaction x updates and returns an unsubscribe function. See [`ChartGPU.ts`](../src/ChartGPU.ts).
 
 Data upload and scale/bounds derivation occur during [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) `RenderCoordinator.render()` (not during `setOption(...)` itself).
 
@@ -60,6 +63,16 @@ All callbacks receive a `ChartGPUEventPayload` object with:
 **Legend (automatic):**
 
 ChartGPU currently mounts a small legend panel as an internal HTML overlay (series swatch + series name) alongside the canvas. The legend is created and managed by the render pipeline in [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) (default position: `'right'`), updates when `setOption(...)` is called, and is disposed with the chart. Series labels come from `series[i].name` (trimmed), falling back to `Series N`; swatch colors come from `series[i].color` when provided, otherwise the resolved theme palette (see internal [`createLegend`](../src/components/createLegend.ts)).
+
+### Chart sync (interaction)
+
+ChartGPU supports a small “connect API” for syncing interaction between multiple charts (crosshair x-position + tooltip x-value). This is driven by the chart instance’s `getInteractionX()` / `setInteractionX(...)` hooks.
+
+See [`createChartSync.ts`](../src/interaction/createChartSync.ts).
+
+#### `connectCharts(charts: ChartGPU[]): () => void`
+
+Connects charts so pointer movement in one chart drives the “interaction x” of the other charts. Returns a `disconnect()` function that removes listeners and clears any synced interaction state.
 
 ### `ChartGPUOptions`
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -97,6 +97,8 @@ Now that you have a GPU context initialized, you can:
 
 See the [examples directory](../examples/) for complete working examples.
 
+ChartGPU also supports syncing interaction across multiple charts (crosshair x-position + tooltip x-value). See the public `connectCharts(...)` helper in [`createChartSync.ts`](../src/interaction/createChartSync.ts) and the API notes in [`API.md`](./API.md).
+
 Chart instances also mount an internal legend panel by default (series swatches + names) alongside the canvas. Series labels come from `series[i].name` (trimmed), falling back to `Series N`; see [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) and the internal [`createLegend.ts`](../src/components/createLegend.ts).
 
 Chart instances can also show an internal HTML tooltip overlay on hover when `ChartGPUOptions.tooltip.show !== false`; see the tooltip option types in [`types.ts`](../src/config/types.ts) and tooltip behavior notes in [`API.md`](./API.md#tooltip-configuration-type-definitions).

--- a/examples/chart-sync/index.html
+++ b/examples/chart-sync/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chart Sync - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #0a0a0a;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+    .page {
+      min-height: 100%;
+      display: grid;
+      grid-template-rows: auto 1fr;
+      gap: 16px;
+      padding: 20px;
+      box-sizing: border-box;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.4rem;
+      color: #fff;
+    }
+    header p {
+      margin: 8px 0 0;
+      color: #aaa;
+      line-height: 1.4;
+    }
+    .back {
+      display: inline-block;
+      margin-top: 10px;
+      color: #aaa;
+      text-decoration: none;
+    }
+    .back:hover { color: #fff; }
+    .grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+      align-items: stretch;
+    }
+    .chart-shell {
+      border: 1px solid #333;
+      border-radius: 12px;
+      background: #0f0f14;
+      overflow: hidden;
+      min-height: 340px;
+      height: min(62vh, 620px);
+    }
+    .chart {
+      width: 100%;
+      height: 100%;
+    }
+    .error {
+      padding: 16px;
+      color: #ffb4b4;
+      white-space: pre-wrap;
+    }
+    @media (max-width: 900px) {
+      .grid { grid-template-columns: 1fr; }
+      .chart-shell { height: min(48vh, 520px); }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <h1>Chart Sync</h1>
+      <p>Move your mouse over either chart. Crosshair x-position and axis tooltip x-value sync across charts. Zoom is not synced.</p>
+      <a class="back" href="../index.html">← Back to examples</a>
+    </header>
+
+    <div class="grid">
+      <div class="chart-shell">
+        <div id="chart-a" class="chart"></div>
+      </div>
+      <div class="chart-shell">
+        <div id="chart-b" class="chart"></div>
+      </div>
+    </div>
+
+    <div id="error" class="error" style="display:none;"></div>
+  </div>
+
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>
+

--- a/examples/chart-sync/main.ts
+++ b/examples/chart-sync/main.ts
@@ -1,0 +1,104 @@
+import { ChartGPU, connectCharts } from '../../src/index';
+import type { ChartGPUOptions, DataPoint, ChartGPUInstance } from '../../src/index';
+
+const createWave = (
+  count: number,
+  opts: Readonly<{ phase: number; amplitude: number; fn: 'sin' | 'cos' }>
+): ReadonlyArray<DataPoint> => {
+  const n = Math.max(2, Math.floor(count));
+  const out: DataPoint[] = new Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const x = t * Math.PI * 2;
+    const base = opts.fn === 'sin' ? Math.sin(x + opts.phase) : Math.cos(x + opts.phase);
+    out[i] = [x, base * opts.amplitude] as const;
+  }
+
+  return out;
+};
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+const createOptions = (title: string, data: ReadonlyArray<DataPoint>, color: string): ChartGPUOptions => {
+  const xMax = Math.PI * 2;
+  return {
+    grid: { left: 70, right: 24, top: 24, bottom: 56 },
+    xAxis: { type: 'value', min: 0, max: xMax, name: 'Angle (rad)' },
+    yAxis: { type: 'value', min: -1.2, max: 1.2, name: title },
+    palette: [color],
+    tooltip: { trigger: 'axis' },
+    series: [
+      {
+        type: 'line',
+        name: title,
+        data,
+        color,
+        lineStyle: { width: 2, opacity: 1 },
+      },
+    ],
+  };
+};
+
+async function main() {
+  const containerA = document.getElementById('chart-a');
+  const containerB = document.getElementById('chart-b');
+  if (!containerA || !containerB) throw new Error('Chart containers not found');
+
+  const dataA = createWave(400, { fn: 'sin', phase: 0, amplitude: 1 });
+  const dataB = createWave(400, { fn: 'cos', phase: Math.PI / 6, amplitude: 0.9 });
+
+  const chartA = await ChartGPU.create(containerA, createOptions('sin(x)', dataA, '#4a9eff'));
+  const chartB = await ChartGPU.create(containerB, createOptions('cos(x + π/6)', dataB, '#ff4ab0'));
+
+  const disconnect = connectCharts([chartA, chartB]);
+
+  const attachResizeObserver = (container: HTMLElement, chart: ChartGPUInstance): ResizeObserver => {
+    let scheduled = false;
+    const ro = new ResizeObserver(() => {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        chart.resize();
+      });
+    });
+    ro.observe(container);
+    return ro;
+  };
+
+  const roA = attachResizeObserver(containerA, chartA);
+  const roB = attachResizeObserver(containerB, chartB);
+
+  // Initial sizing/render.
+  chartA.resize();
+  chartB.resize();
+
+  window.addEventListener('beforeunload', () => {
+    roA.disconnect();
+    roB.disconnect();
+    disconnect();
+    chartA.dispose();
+    chartB.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    });
+  });
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}
+

--- a/examples/index.html
+++ b/examples/index.html
@@ -82,6 +82,12 @@
           <div class="example-description">Interactive grid renderer with configurable line counts - demonstrates grid rendering and clip-space coordinates</div>
         </a>
       </li>
+      <li class="example-item">
+        <a href="./chart-sync/index.html" class="example-link">
+          <div class="example-title">Chart Sync</div>
+          <div class="example-description">Two charts with synced crosshair x-position and axis tooltip x-value (via connectCharts)</div>
+        </a>
+      </li>
     </ul>
   </div>
 </body>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export const version = '1.0.0';
 
 // Chart API (Phase 1)
 export { ChartGPU } from './ChartGPU';
+export type { ChartGPUInstance } from './ChartGPU';
 export type {
   AreaStyleConfig,
   AxisConfig,
@@ -41,6 +42,9 @@ export type { ThemeName } from './themes';
 // Scales - Pure utilities
 export { createLinearScale } from './utils/scales';
 export type { LinearScale } from './utils/scales';
+
+// Chart sync (interaction)
+export { connectCharts } from './interaction/createChartSync';
 
 // Core exports - Functional API (preferred)
 export type { GPUContextState } from './core/GPUContext';

--- a/src/interaction/createChartSync.ts
+++ b/src/interaction/createChartSync.ts
@@ -1,0 +1,53 @@
+import type { ChartGPU } from '../ChartGPU';
+
+export type DisconnectCharts = () => void;
+
+/**
+ * Connects multiple charts so pointer movement in one chart drives crosshair/tooltip x
+ * in the other charts (domain x sync). Returns a `disconnect()` function.
+ *
+ * Notes:
+ * - Syncs interaction only (crosshair + tooltip x), not zoom/options.
+ * - Uses a per-connection loop guard to prevent feedback.
+ */
+export function connectCharts(charts: ChartGPU[]): DisconnectCharts {
+  const connectionToken = Symbol('ChartGPU.connectCharts');
+
+  let disconnected = false;
+  const unsubscribeFns: Array<() => void> = [];
+
+  const broadcast = (sourceChart: ChartGPU, x: number | null): void => {
+    for (const chart of charts) {
+      if (chart === sourceChart) continue;
+      if (chart.disposed) continue;
+      chart.setInteractionX(x, connectionToken);
+    }
+  };
+
+  for (const chart of charts) {
+    if (chart.disposed) continue;
+
+    const unsub = chart.onInteractionXChange((x, source) => {
+      if (disconnected) return;
+      if (source === connectionToken) return;
+      if (chart.disposed) return;
+      broadcast(chart, x);
+    });
+    unsubscribeFns.push(unsub);
+  }
+
+  return () => {
+    if (disconnected) return;
+    disconnected = true;
+
+    for (const unsub of unsubscribeFns) unsub();
+    unsubscribeFns.length = 0;
+
+    // Clear any “stuck” remote interactions.
+    for (const chart of charts) {
+      if (chart.disposed) continue;
+      chart.setInteractionX(null, connectionToken);
+    }
+  };
+}
+


### PR DESCRIPTION
## Summary

Implement WebGPU-driven chart interaction sync primitives and documentation.

## Details

- Add `getInteractionX()`, `setInteractionX(...)`, and `onInteractionXChange(...)` to the `ChartGPUInstance` interface to expose domain-space interaction state and subscriptions.[page:1]  
- Extend the render coordinator with interaction-x state, pointer source tracking, and synthetic pointer projection so charts can be driven either by local mouse movement or external sync.[page:1]  
- Update tooltip and crosshair behavior to derive their position from the effective interaction state, with special handling when driven by synced interaction instead of a real pointer.[page:1]  
- Introduce a public `connectCharts(charts: ChartGPU[])` helper and `createChartSync` utilities to wire interaction-x across multiple charts, returning a `disconnect()` cleanup function.[page:1]  
- Add a new “Chart Sync” example (HTML + TS) that renders two trigonometric charts with shared crosshair x-position and axis tooltip x-value to demonstrate the sync API.[page:1]  
- Refresh `API.md`, `GETTING_STARTED.md`, and the examples index to document the interaction sync hooks and link to the new example.
