### PR TITLE
Enhance ChartGPU API with crosshair synchronization and event handling

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -105,7 +105,7 @@ Chart instances can also show an internal HTML tooltip overlay on hover when `Ch
 
 Chart instances also render a built-in hover highlight ring when the pointer is inside the plot grid and a nearest data point can be determined; this is part of the internal render pipeline in [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) (see hover highlight notes in [`API.md`](./API.md#highlight-renderer-internal--contributor-notes)).
 
-Chart instances expose event listeners via `on()` and `off()` methods for handling clicks and hover interactions (`'click'`, `'mouseover'`, `'mouseout'`). See [`API.md`](./API.md#event-handling) for event handling documentation.
+Chart instances expose event listeners via `on()` and `off()` methods for handling clicks, hover interactions, and crosshair syncing (`'click'`, `'mouseover'`, `'mouseout'`, `'crosshairMove'`). See [`API.md`](./API.md#event-handling) for event handling documentation (note that `'crosshairMove'` uses a minimal payload `{ x, source? }` and is emitted for both pointer-driven and programmatic interaction-x updates).
 
 The `hello-world` example demonstrates continuous rendering by animating the clear color through the full color spectrum, proving that the render loop is working correctly. See [hello-world/main.ts](../examples/hello-world/main.ts) for implementation.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,13 @@ export const version = '1.0.0';
 export { ChartGPU } from './ChartGPU';
 export type { ChartGPUInstance } from './ChartGPU';
 export type {
+  ChartGPUEventName,
+  ChartGPUEventPayload,
+  ChartGPUCrosshairMovePayload,
+  ChartGPUEventCallback,
+  ChartGPUCrosshairMoveCallback,
+} from './ChartGPU';
+export type {
   AreaStyleConfig,
   AxisConfig,
   AxisType,


### PR DESCRIPTION
Added support for a new `crosshairMove` event to synchronize crosshair interactions across multiple charts. Updated the `ChartGPU` interface to include `setCrosshairX()` and corresponding event handling methods. Enhanced API documentation to reflect these changes, detailing the new event payload and its integration within the chart synchronization features.