### PR TITLE
Implement Scatter Shader

### DIFF
--- a/examples/hello-world/main.ts
+++ b/examples/hello-world/main.ts
@@ -1,6 +1,7 @@
 import { GPUContext } from '../../src/index';
 import lineWgsl from '../../src/shaders/line.wgsl?raw';
 import areaWgsl from '../../src/shaders/area.wgsl?raw';
+import scatterWgsl from '../../src/shaders/scatter.wgsl?raw';
 
 /**
  * Hello World example - Animated clear color
@@ -92,6 +93,20 @@ async function main() {
           .map((m) => `${m.lineNum ?? 0}:${m.linePos ?? 0} ${m.message}`)
           .join('\n');
         throw new Error(`area.wgsl compilation failed:\n${formatted}`);
+      }
+    }
+
+    // Example-only smoke check: compile the scatter shader at runtime.
+    const scatterShaderModule = device.createShaderModule({ code: scatterWgsl, label: 'scatter.wgsl' });
+    const getScatterCompilationInfo = scatterShaderModule.getCompilationInfo?.bind(scatterShaderModule);
+    if (getScatterCompilationInfo) {
+      const info = await getScatterCompilationInfo();
+      const errors = info.messages.filter((m) => m.type === 'error');
+      if (errors.length > 0) {
+        const formatted = errors
+          .map((m) => `${m.lineNum ?? 0}:${m.linePos ?? 0} ${m.message}`)
+          .join('\n');
+        throw new Error(`scatter.wgsl compilation failed:\n${formatted}`);
       }
     }
 

--- a/src/shaders/scatter.wgsl
+++ b/src/shaders/scatter.wgsl
@@ -1,0 +1,86 @@
+// scatter.wgsl
+// Instanced anti-aliased circle shader (SDF):
+// - Per-instance vertex input:
+//   - center   = vec2<f32> point center (transformed by VSUniforms.transform)
+//   - radiusPx = f32 circle radius in pixels
+// - Draw call: draw(6, instanceCount) using triangle-list expansion in VS
+// - Uniforms:
+//   - @group(0) @binding(0): VSUniforms { transform, viewportPx }
+//   - @group(0) @binding(1): FSUniforms { color }
+//
+// Notes:
+// - `viewportPx` is the current render target size in pixels (width, height).
+// - The quad is expanded in clip space using `radiusPx` and `viewportPx`.
+
+struct VSUniforms {
+  transform: mat4x4<f32>,
+  viewportPx: vec2<f32>,
+  // Pad to 16-byte alignment (mat4x4 is 64B; vec2 adds 8B; pad to 80B).
+  _pad0: vec2<f32>,
+};
+
+@group(0) @binding(0) var<uniform> vsUniforms: VSUniforms;
+
+struct FSUniforms {
+  color: vec4<f32>,
+};
+
+@group(0) @binding(1) var<uniform> fsUniforms: FSUniforms;
+
+struct VSIn {
+  @location(0) center: vec2<f32>,
+  @location(1) radiusPx: f32,
+};
+
+struct VSOut {
+  @builtin(position) clipPosition: vec4<f32>,
+  @location(0) localPx: vec2<f32>,
+  @location(1) radiusPx: f32,
+};
+
+@vertex
+fn vsMain(in: VSIn, @builtin(vertex_index) vertexIndex: u32) -> VSOut {
+  // Fixed local corners for 2 triangles (triangle-list).
+  // `localNdc` is a quad in [-1, 1]^2; we convert it to pixel offsets via radiusPx.
+  let localNdc = array<vec2<f32>, 6>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>(-1.0,  1.0),
+    vec2<f32>( 1.0, -1.0),
+    vec2<f32>( 1.0,  1.0)
+  );
+
+  let corner = localNdc[vertexIndex];
+  let localPx = corner * in.radiusPx;
+
+  // Convert pixel offset to clip-space offset.
+  // Clip space spans [-1, 1] across the viewport, so px -> clip is (2 / viewportPx).
+  let localClip = localPx * (2.0 / vsUniforms.viewportPx);
+
+  let centerClip = (vsUniforms.transform * vec4<f32>(in.center, 0.0, 1.0)).xy;
+
+  var out: VSOut;
+  out.clipPosition = vec4<f32>(centerClip + localClip, 0.0, 1.0);
+  out.localPx = localPx;
+  out.radiusPx = in.radiusPx;
+  return out;
+}
+
+@fragment
+fn fsMain(in: VSOut) -> @location(0) vec4<f32> {
+  // Signed distance to the circle boundary (negative inside).
+  let dist = length(in.localPx) - in.radiusPx;
+
+  // Analytic-ish AA: smooth edge based on derivative of dist in screen space.
+  let w = fwidth(dist);
+  let a = 1.0 - smoothstep(0.0, w, dist);
+
+  // Discard fully outside to avoid unnecessary blending work.
+  if (a <= 0.0) {
+    discard;
+  }
+
+  return vec4<f32>(fsUniforms.color.rgb, fsUniforms.color.a * a);
+}
+


### PR DESCRIPTION
Included a runtime compilation check for the scatter shader in the hello-world example. This addition ensures that any compilation errors are captured and reported, enhancing the robustness of the example and providing immediate feedback on shader validity.