### PR TITLE
Update API documentation to include scatter point symbol shader details

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -577,7 +577,8 @@ Hover highlight behavior is orchestrated by the render coordinator in [`createRe
 
 Notes:
 
-- **Example shader compilation smoke-check**: the hello-world example imports `line.wgsl` and `area.wgsl` via `?raw` and (when supported) uses `GPUShaderModule.getCompilationInfo()` to fail fast on shader compilation errors. See [`examples/hello-world/main.ts`](../examples/hello-world/main.ts).
+- **Scatter point symbol shader**: [`scatter.wgsl`](../src/shaders/scatter.wgsl) expands instanced points into quads in the vertex stage and draws anti-aliased circles in the fragment stage using an SDF + `smoothstep`. It expects per-instance `center` + `radiusPx`, plus uniforms for `transform`, `viewportPx`, and `color` (see the shader source).
+- **Example shader compilation smoke-check**: the hello-world example imports `line.wgsl`, `area.wgsl`, and `scatter.wgsl` via `?raw` and (when supported) uses `GPUShaderModule.getCompilationInfo()` to fail fast on shader compilation errors. See [`examples/hello-world/main.ts`](../examples/hello-world/main.ts).
 - **Render target format**: a renderer pipeline’s target format must match the render pass color attachment format (otherwise WebGPU raises a pipeline/attachment format mismatch validation error). `createAxisRenderer`, `createGridRenderer`, and `createLineRenderer` each accept `options.targetFormat` (typically `GPUContextState.preferredFormat`) and default to `'bgra8unorm'` for backward compatibility.
 - **Scale output space**: `prepare(...)` treats scales as affine and uses `scale(...)` samples to build a clip-space transform. Scales that output pixels (or non-linear scales) will require a different transform strategy.
 - **Line width and alpha**: line primitives are effectively 1px-class across implementations; wide lines require triangle-based extrusion. `createLineRenderer` enables standard alpha blending so `lineStyle.opacity` composites as expected.


### PR DESCRIPTION
Enhanced the API.md to document the new scatter point symbol shader, detailing its functionality and expected inputs. Updated the hello-world example to include the scatter shader in the compilation smoke-check, ensuring users are informed about shader validation and usage.