### PR TITLE
 Add a GPU-accelerated scatter series renderer and fully integrate it into the WebGPU render coordinator pipeline.

### DIFF
--- a/src/renderers/createScatterRenderer.ts
+++ b/src/renderers/createScatterRenderer.ts
@@ -1,0 +1,387 @@
+import scatterWgsl from '../shaders/scatter.wgsl?raw';
+import type { ResolvedScatterSeriesConfig } from '../config/OptionResolver';
+import type { DataPoint, DataPointTuple, ScatterPointTuple } from '../config/types';
+import type { LinearScale } from '../utils/scales';
+import { parseCssColorToRgba01 } from '../utils/colors';
+import type { GridArea } from './createGridRenderer';
+import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
+
+export interface ScatterRenderer {
+  prepare(
+    seriesConfig: ResolvedScatterSeriesConfig,
+    data: ResolvedScatterSeriesConfig['data'],
+    xScale: LinearScale,
+    yScale: LinearScale,
+    gridArea?: GridArea
+  ): void;
+  render(passEncoder: GPURenderPassEncoder): void;
+  dispose(): void;
+}
+
+export interface ScatterRendererOptions {
+  /**
+   * Must match the canvas context format used for the render pass color attachment.
+   * Usually this is `gpuContext.preferredFormat`.
+   *
+   * Defaults to `'bgra8unorm'` for backward compatibility.
+   */
+  readonly targetFormat?: GPUTextureFormat;
+}
+
+type Rgba = readonly [r: number, g: number, b: number, a: number];
+
+const DEFAULT_TARGET_FORMAT: GPUTextureFormat = 'bgra8unorm';
+const DEFAULT_SCATTER_RADIUS_CSS_PX = 4;
+const INSTANCE_STRIDE_BYTES = 16; // center.xy, radiusPx, pad
+const INSTANCE_STRIDE_FLOATS = INSTANCE_STRIDE_BYTES / 4;
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
+const clampInt = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v | 0));
+
+const parseSeriesColorToRgba01 = (color: string): Rgba =>
+  parseCssColorToRgba01(color) ?? ([0, 0, 0, 1] as const);
+
+const nextPow2 = (v: number): number => {
+  if (!Number.isFinite(v) || v <= 0) return 1;
+  const n = Math.ceil(v);
+  return 2 ** Math.ceil(Math.log2(n));
+};
+
+const isTupleDataPoint = (point: DataPoint): point is DataPointTuple => Array.isArray(point);
+
+const getPointXY = (point: DataPoint): { readonly x: number; readonly y: number } => {
+  if (isTupleDataPoint(point)) return { x: point[0], y: point[1] };
+  return { x: point.x, y: point.y };
+};
+
+const getPointSizeCssPx = (point: DataPoint): number | null => {
+  if (isTupleDataPoint(point)) {
+    const s = point[2];
+    return typeof s === 'number' && Number.isFinite(s) ? s : null;
+  }
+  const s = point.size;
+  return typeof s === 'number' && Number.isFinite(s) ? s : null;
+};
+
+const toScatterTuple = (point: DataPoint): ScatterPointTuple => {
+  if (isTupleDataPoint(point)) return point;
+  return [point.x, point.y, point.size] as const;
+};
+
+const computeDataBounds = (
+  data: ReadonlyArray<DataPoint>
+): { readonly xMin: number; readonly xMax: number; readonly yMin: number; readonly yMax: number } => {
+  let xMin = Number.POSITIVE_INFINITY;
+  let xMax = Number.NEGATIVE_INFINITY;
+  let yMin = Number.POSITIVE_INFINITY;
+  let yMax = Number.NEGATIVE_INFINITY;
+
+  for (let i = 0; i < data.length; i++) {
+    const { x, y } = getPointXY(data[i]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    if (x < xMin) xMin = x;
+    if (x > xMax) xMax = x;
+    if (y < yMin) yMin = y;
+    if (y > yMax) yMax = y;
+  }
+
+  if (!Number.isFinite(xMin) || !Number.isFinite(xMax) || !Number.isFinite(yMin) || !Number.isFinite(yMax)) {
+    return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+  }
+
+  // Avoid degenerate domains for affine derivation (handled later too, but keep stable samples).
+  if (xMin === xMax) xMax = xMin + 1;
+  if (yMin === yMax) yMax = yMin + 1;
+
+  return { xMin, xMax, yMin, yMax };
+};
+
+const computeClipAffineFromScale = (
+  scale: LinearScale,
+  v0: number,
+  v1: number
+): { readonly a: number; readonly b: number } => {
+  const p0 = scale.scale(v0);
+  const p1 = scale.scale(v1);
+
+  // If the domain sample is degenerate or non-finite, fall back to constant output.
+  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
+    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
+  }
+
+  const a = (p1 - p0) / (v1 - v0);
+  const b = p0 - a * v0;
+  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
+};
+
+const createTransformMat4Buffer = (ax: number, bx: number, ay: number, by: number): ArrayBuffer => {
+  // Column-major mat4x4 for: clip = M * vec4(x, y, 0, 1)
+  const buffer = new ArrayBuffer(16 * 4);
+  new Float32Array(buffer).set([
+    ax,
+    0,
+    0,
+    0, // col0
+    0,
+    ay,
+    0,
+    0, // col1
+    0,
+    0,
+    1,
+    0, // col2
+    bx,
+    by,
+    0,
+    1, // col3
+  ]);
+  return buffer;
+};
+
+const computePlotScissorDevicePx = (
+  gridArea: GridArea
+): { readonly x: number; readonly y: number; readonly w: number; readonly h: number } => {
+  const dpr = window.devicePixelRatio || 1;
+  const { canvasWidth, canvasHeight } = gridArea;
+
+  const plotLeftDevice = gridArea.left * dpr;
+  const plotRightDevice = canvasWidth - gridArea.right * dpr;
+  const plotTopDevice = gridArea.top * dpr;
+  const plotBottomDevice = canvasHeight - gridArea.bottom * dpr;
+
+  const scissorX = clampInt(Math.floor(plotLeftDevice), 0, Math.max(0, canvasWidth));
+  const scissorY = clampInt(Math.floor(plotTopDevice), 0, Math.max(0, canvasHeight));
+  const scissorR = clampInt(Math.ceil(plotRightDevice), 0, Math.max(0, canvasWidth));
+  const scissorB = clampInt(Math.ceil(plotBottomDevice), 0, Math.max(0, canvasHeight));
+  const scissorW = Math.max(0, scissorR - scissorX);
+  const scissorH = Math.max(0, scissorB - scissorY);
+
+  return { x: scissorX, y: scissorY, w: scissorW, h: scissorH };
+};
+
+export function createScatterRenderer(device: GPUDevice, options?: ScatterRendererOptions): ScatterRenderer {
+  let disposed = false;
+  const targetFormat = options?.targetFormat ?? DEFAULT_TARGET_FORMAT;
+
+  const bindGroupLayout = device.createBindGroupLayout({
+    entries: [
+      { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+      { binding: 1, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } },
+    ],
+  });
+
+  // VSUniforms: mat4x4 (64) + viewportPx vec2 (8) + pad vec2 (8) = 80 bytes.
+  const vsUniformBuffer = createUniformBuffer(device, 80, { label: 'scatterRenderer/vsUniforms' });
+  const fsUniformBuffer = createUniformBuffer(device, 16, { label: 'scatterRenderer/fsUniforms' });
+
+  const bindGroup = device.createBindGroup({
+    layout: bindGroupLayout,
+    entries: [
+      { binding: 0, resource: { buffer: vsUniformBuffer } },
+      { binding: 1, resource: { buffer: fsUniformBuffer } },
+    ],
+  });
+
+  const pipeline = createRenderPipeline(device, {
+    label: 'scatterRenderer/pipeline',
+    bindGroupLayouts: [bindGroupLayout],
+    vertex: {
+      code: scatterWgsl,
+      label: 'scatter.wgsl',
+      buffers: [
+        {
+          arrayStride: INSTANCE_STRIDE_BYTES,
+          stepMode: 'instance',
+          attributes: [
+            { shaderLocation: 0, format: 'float32x2', offset: 0 },
+            { shaderLocation: 1, format: 'float32', offset: 8 },
+          ],
+        },
+      ],
+    },
+    fragment: {
+      code: scatterWgsl,
+      label: 'scatter.wgsl',
+      formats: targetFormat,
+      // Standard alpha blending (circle AA uses alpha, and series color may be translucent).
+      blend: {
+        color: { operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha' },
+        alpha: { operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-src-alpha' },
+      },
+    },
+    primitive: { topology: 'triangle-list', cullMode: 'none' },
+    multisample: { count: 1 },
+  });
+
+  let instanceBuffer: GPUBuffer | null = null;
+  let instanceCount = 0;
+  let cpuInstanceStagingBuffer = new ArrayBuffer(0);
+  let cpuInstanceStagingF32 = new Float32Array(cpuInstanceStagingBuffer);
+
+  let lastCanvasWidth = 0;
+  let lastCanvasHeight = 0;
+  let lastViewportPx: readonly [number, number] = [1, 1];
+  let lastScissor: { readonly x: number; readonly y: number; readonly w: number; readonly h: number } | null = null;
+
+  const assertNotDisposed = (): void => {
+    if (disposed) throw new Error('ScatterRenderer is disposed.');
+  };
+
+  const ensureCpuInstanceCapacityFloats = (requiredFloats: number): void => {
+    if (requiredFloats <= cpuInstanceStagingF32.length) return;
+    const nextFloats = Math.max(8, nextPow2(requiredFloats));
+    cpuInstanceStagingBuffer = new ArrayBuffer(nextFloats * 4);
+    cpuInstanceStagingF32 = new Float32Array(cpuInstanceStagingBuffer);
+  };
+
+  const writeVsUniforms = (transformMat4: ArrayBuffer, viewportW: number, viewportH: number): void => {
+    const w = Number.isFinite(viewportW) && viewportW > 0 ? viewportW : 1;
+    const h = Number.isFinite(viewportH) && viewportH > 0 ? viewportH : 1;
+
+    const buf = new ArrayBuffer(80);
+    const f32 = new Float32Array(buf);
+    f32.set(new Float32Array(transformMat4), 0);
+    f32[16] = w;
+    f32[17] = h;
+    writeUniformBuffer(device, vsUniformBuffer, buf);
+
+    lastViewportPx = [w, h];
+  };
+
+  const prepare: ScatterRenderer['prepare'] = (seriesConfig, data, xScale, yScale, gridArea) => {
+    assertNotDisposed();
+
+    const { xMin, xMax, yMin, yMax } = computeDataBounds(data);
+    const { a: ax, b: bx } = computeClipAffineFromScale(xScale, xMin, xMax);
+    const { a: ay, b: by } = computeClipAffineFromScale(yScale, yMin, yMax);
+    const transformBuffer = createTransformMat4Buffer(ax, bx, ay, by);
+
+    if (gridArea) {
+      lastCanvasWidth = gridArea.canvasWidth;
+      lastCanvasHeight = gridArea.canvasHeight;
+      writeVsUniforms(transformBuffer, gridArea.canvasWidth, gridArea.canvasHeight);
+      lastScissor = computePlotScissorDevicePx(gridArea);
+    } else {
+      // Backward-compatible: keep rendering with the last known viewport (or safe default).
+      writeVsUniforms(transformBuffer, lastViewportPx[0], lastViewportPx[1]);
+      lastScissor = null;
+    }
+
+    const [r, g, b, a] = parseSeriesColorToRgba01(seriesConfig.color);
+    const colorBuffer = new ArrayBuffer(4 * 4);
+    new Float32Array(colorBuffer).set([r, g, b, clamp01(a)]);
+    writeUniformBuffer(device, fsUniformBuffer, colorBuffer);
+
+    const dpr = window.devicePixelRatio || 1;
+    const hasValidDpr = dpr > 0 && Number.isFinite(dpr);
+
+    const seriesSymbolSize = seriesConfig.symbolSize;
+    const getSeriesSizeCssPx =
+      typeof seriesSymbolSize === 'function'
+        ? (point: DataPoint): number => {
+            const v = seriesSymbolSize(toScatterTuple(point));
+            return typeof v === 'number' && Number.isFinite(v) ? v : DEFAULT_SCATTER_RADIUS_CSS_PX;
+          }
+        : typeof seriesSymbolSize === 'number' && Number.isFinite(seriesSymbolSize)
+          ? (): number => seriesSymbolSize
+          : (): number => DEFAULT_SCATTER_RADIUS_CSS_PX;
+
+    ensureCpuInstanceCapacityFloats(data.length * INSTANCE_STRIDE_FLOATS);
+    const f32 = cpuInstanceStagingF32;
+    let outFloats = 0;
+
+    for (let i = 0; i < data.length; i++) {
+      const p = data[i];
+      const { x, y } = getPointXY(p);
+      if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+
+      const sizeCss = getPointSizeCssPx(p) ?? getSeriesSizeCssPx(p);
+      const radiusCss = Number.isFinite(sizeCss) ? Math.max(0, sizeCss) : DEFAULT_SCATTER_RADIUS_CSS_PX;
+      const radiusDevicePx = hasValidDpr ? radiusCss * dpr : radiusCss;
+      if (!(radiusDevicePx > 0)) continue;
+
+      f32[outFloats + 0] = x;
+      f32[outFloats + 1] = y;
+      f32[outFloats + 2] = radiusDevicePx;
+      f32[outFloats + 3] = 0; // pad
+      outFloats += INSTANCE_STRIDE_FLOATS;
+    }
+
+    instanceCount = outFloats / INSTANCE_STRIDE_FLOATS;
+    const requiredBytes = Math.max(4, instanceCount * INSTANCE_STRIDE_BYTES);
+
+    if (!instanceBuffer || instanceBuffer.size < requiredBytes) {
+      const grownBytes = Math.max(Math.max(4, nextPow2(requiredBytes)), instanceBuffer ? instanceBuffer.size : 0);
+      if (instanceBuffer) {
+        try {
+          instanceBuffer.destroy();
+        } catch {
+          // best-effort
+        }
+      }
+      instanceBuffer = device.createBuffer({
+        label: 'scatterRenderer/instanceBuffer',
+        size: grownBytes,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      });
+    }
+
+    if (instanceBuffer && instanceCount > 0) {
+      device.queue.writeBuffer(instanceBuffer, 0, cpuInstanceStagingBuffer, 0, instanceCount * INSTANCE_STRIDE_BYTES);
+    }
+  };
+
+  const render: ScatterRenderer['render'] = (passEncoder) => {
+    assertNotDisposed();
+    if (!instanceBuffer || instanceCount === 0) return;
+
+    // Clip to plot area when available.
+    if (lastScissor && lastCanvasWidth > 0 && lastCanvasHeight > 0) {
+      passEncoder.setScissorRect(lastScissor.x, lastScissor.y, lastScissor.w, lastScissor.h);
+    }
+
+    passEncoder.setPipeline(pipeline);
+    passEncoder.setBindGroup(0, bindGroup);
+    passEncoder.setVertexBuffer(0, instanceBuffer);
+    passEncoder.draw(6, instanceCount);
+
+    // Reset scissor to full canvas to avoid impacting later renderers.
+    if (lastScissor && lastCanvasWidth > 0 && lastCanvasHeight > 0) {
+      passEncoder.setScissorRect(0, 0, lastCanvasWidth, lastCanvasHeight);
+    }
+  };
+
+  const dispose: ScatterRenderer['dispose'] = () => {
+    if (disposed) return;
+    disposed = true;
+
+    if (instanceBuffer) {
+      try {
+        instanceBuffer.destroy();
+      } catch {
+        // best-effort
+      }
+    }
+    instanceBuffer = null;
+    instanceCount = 0;
+
+    try {
+      vsUniformBuffer.destroy();
+    } catch {
+      // best-effort
+    }
+    try {
+      fsUniformBuffer.destroy();
+    } catch {
+      // best-effort
+    }
+
+    lastCanvasWidth = 0;
+    lastCanvasHeight = 0;
+    lastViewportPx = [1, 1];
+    lastScissor = null;
+  };
+
+  return { prepare, render, dispose };
+}
+


### PR DESCRIPTION
## Summary

Add a GPU-accelerated scatter series renderer and fully integrate it into the WebGPU render coordinator pipeline.

## Changes

- Implemented a dedicated **scatter** renderer using a WGSL shader, instance buffers, and per-series uniforms for color and transform. [page:2]
- Added robust data handling utilities for scatter series, including tuple/object support, data bounds computation, and adaptive symbol sizing in CSS pixels. [page:2]
- Wired scatter rendering into the render coordinator with:
  - Lifecycle management (creation, resizing, disposal) alongside area and line renderers. [page:2]
  - Scatter `prepare` calls for `series.type === 'scatter'`. [page:2]
  - A dedicated render pass phase to draw scatter points between bars and lines in the render order. [page:2]
- Introduced plot-area scissoring for scatter series to clip markers cleanly to the grid area while restoring the full-canvas scissor afterward. [page:2]
- Ensured proper GPU resource cleanup for scatter buffers and uniforms when the coordinator is disposed. [page:2]

## Rationale

- Enable first-class scatter plots in ChartGPU with efficient, batched WebGPU rendering.
- Keep the render coordinator architecture consistent so future series types can plug into the same lifecycle and resource management patterns. [page:2]
