### PR TITLE
Document data update transition animations and their visual acceptance example across README, API, and Getting Started guides. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ChartGPU leverages WebGPU to provide hardware-accelerated rendering for complex 
 - **TypeScript**: Full type safety and excellent IDE support
 - **High Performance**: Optimized for rendering large datasets
 - **Browser Support**: Works in Chrome 113+, Edge 113+, and Safari 18+
+- **Data update transitions**: subsequent `setOption(...)` calls that change series data can animate transitions when `ChartGPUOptions.animation` is enabled (see [`examples/data-update-animation/`](examples/data-update-animation/) and internal implementation in [`createRenderCoordinator.ts`](src/core/createRenderCoordinator.ts))
 - **Live streaming**: append points at runtime via `ChartGPUInstance.appendData(...)` with optional `ChartGPUOptions.autoScroll` behavior (see [`examples/live-streaming/`](examples/live-streaming/) and [API.md](docs/API.md))
 - **Data zoom (x-axis)**: inside zoom gestures and optional slider UI via `ChartGPUOptions.dataZoom` (see [API.md](docs/API.md) and [ChartGPU.ts](src/ChartGPU.ts))
 - **Zoom-aware sampling (cartesian)**: when sampling is enabled, ChartGPU resamples the visible x-range on zoom (debounced ~100ms). Axis auto-bounds remain derived from raw (unsampled) series data. See [API.md](docs/API.md).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -119,6 +119,8 @@ The `scatter` example demonstrates instanced scatter rendering with thousands of
 
 The `grouped-bar` example demonstrates clustered + stacked bar rendering (via `series[i].stack`, including negative values) and bar layout options (`barWidth`, `barGap`, `barCategoryGap`). See [grouped-bar/main.ts](../examples/grouped-bar/main.ts).
 
+The `data-update-animation` example is the visual verification for data update transition animations: subsequent `setOption(...)` calls that change series data (cartesian and pie) animate when `ChartGPUOptions.animation` is enabled. See [data-update-animation/main.ts](../examples/data-update-animation/main.ts).
+
 The `sampling` example demonstrates cartesian series sampling with x-axis data zoom: as the percent-space zoom window \([0, 100]\) changes, ChartGPU resamples the **visible x-range** from raw (unsampled) data (debounced ~100ms). Axis auto-bounds remain derived from raw (unsampled) series data unless you set explicit axis `min`/`max`. See [sampling/main.ts](../examples/sampling/main.ts), [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts), and [`createZoomState.ts`](../src/interaction/createZoomState.ts).
 
 The `pie` example demonstrates pie/donut rendering and per-slice `PieDataItem.color?: string`. See [pie/main.ts](../examples/pie/main.ts) and the option types in [`types.ts`](../src/config/types.ts).


### PR DESCRIPTION
## Summary

Document data update transition animations and their visual acceptance example across README, API, and Getting Started guides. [page:1]

## Details

- Add a README feature bullet describing **data** update transitions via `setOption(...)` when `ChartGPUOptions.animation` is enabled, with pointers to the data update animation example and internal render coordinator implementation. [page:1]  
- Expand `docs/API.md` with a dedicated section on data update transition animation, including when it triggers, what animates for cartesian and pie series, how derived domains behave, and key constraints such as index-based matching and large-series safeguards. [page:1]  
- Update `docs/GETTING_STARTED.md` to call out the `data-update-animation` example as the visual verification for animated transitions on subsequent `setOption(...)` calls. [page:1]
