### PR TITLE
Optimize the library build output, tighten TypeScript declaration settings, and ignore local Cursor workspace files to keep the repo clean and the distributed bundle lean.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 node_modules/
 
+# Cursor
+.cursor/
+
 # Build output
 dist/
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
+    "emitDeclarationOnly": true,
     "declarationMap": true,
     "outDir": "./dist",
     "rootDir": "./src",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,47 @@
 import { defineConfig } from 'vite';
+import fs from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
+const pkgJsonPath = resolve(__dirname, 'package.json');
+const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')) as {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const externalDeps = Array.from(
+  new Set([
+    ...Object.keys(pkgJson.dependencies ?? {}),
+    ...Object.keys(pkgJson.peerDependencies ?? {})
+  ])
+);
+
+function isExternal(id: string): boolean {
+  if (id.startsWith('node:')) return true;
+  for (const dep of externalDeps) {
+    if (id === dep || id.startsWith(`${dep}/`)) return true;
+  }
+  return false;
+}
+
 export default defineConfig({
   build: {
+    emptyOutDir: false,
+    minify: true,
+    sourcemap: true,
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'ChartGPU',
-      fileName: 'index',
+      fileName: () => 'index.js',
       formats: ['es']
     },
     rollupOptions: {
-      external: []
+      external: isExternal,
+      output: {
+        entryFileNames: 'index.js'
+      }
     }
   },
   server: {


### PR DESCRIPTION
### Summary

Optimize the library build output, tighten TypeScript declaration settings, and ignore local Cursor workspace files to keep the repo clean and the distributed bundle lean.[page:1]

### Details

- Update `.gitignore` to exclude the `.cursor/` directory, preventing local Cursor workspace metadata from being committed.[page:1]  
- Enable `emitDeclarationOnly` in `tsconfig.json` so the TypeScript compiler only outputs type declarations into `dist`, aligning TS output with the library distribution.[page:1]  
- Enhance `vite.config.ts` to:
  - Read `dependencies` and `peerDependencies` from `package.json` and treat them as external via an `isExternal` helper.[page:1]
  - Keep `dist` between builds with `emptyOutDir: false` and generate minified bundles with sourcemaps enabled.[page:1]
  - Normalize the library output to a single `index.js` entry file via `fileName: () => 'index.js'` and an explicit `entryFileNames: 'index.js'` in Rollup output.[page:1]
