### PR TITLE
Update API docs and examples for BarChart

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in ChartGPU
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below to help us diagnose and fix the issue.
+
+  - type: checkboxes
+    id: browser-support
+    attributes:
+      label: Browser Support Verification
+      description: Please confirm you've tested in a supported browser
+      options:
+        - label: I have verified this bug occurs in a supported browser (Chrome/Edge 113+, Safari 18+)
+          required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and Version
+      description: Which browser and version are you using?
+      placeholder: e.g., Chrome 120, Edge 119, Safari 18.1
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: What OS are you running?
+      placeholder: e.g., macOS 14.2, Windows 11, Ubuntu 22.04
+    validations:
+      required: true
+
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU (if known)
+      description: Your graphics card or GPU model (if you know it)
+      placeholder: e.g., Apple M2, NVIDIA RTX 3080, Intel Iris Xe
+
+  - type: input
+    id: version
+    attributes:
+      label: ChartGPU Version
+      description: Which version of ChartGPU are you using?
+      placeholder: e.g., 0.1.0, main branch commit hash
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of what the bug is
+      placeholder: Describe the issue you're experiencing
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Detailed steps to reproduce the behavior
+      placeholder: |
+        1. Create a chart with...
+        2. Call method...
+        3. Observe that...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: I expected the chart to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Instead, the chart...
+    validations:
+      required: true
+
+  - type: textarea
+    id: console-errors
+    attributes:
+      label: Console Errors / WebGPU Validation Errors
+      description: Any errors or warnings in the browser console or WebGPU validation layer
+      placeholder: |
+        Paste console output here. Include WebGPU validation errors if present.
+      render: shell
+
+  - type: input
+    id: reproduction-link
+    attributes:
+      label: Minimal Reproduction Link
+      description: |
+        A link to a minimal reproduction (StackBlitz, CodeSandbox, JSFiddle) or a PR that adds/modifies an example in `examples/`
+        
+        **Tip**: PRs modifying `examples/` are the fastest way to get bugs fixed!
+      placeholder: https://stackblitz.com/... or https://github.com/.../pull/123
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or information about the problem

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Getting Started Guide
+    url: https://github.com/hunterg325/ChartGPU/blob/main/docs/GETTING_STARTED.md
+    about: New to ChartGPU? Start here to learn the basics
+  - name: API Reference
+    url: https://github.com/hunterg325/ChartGPU/blob/main/docs/API.md
+    about: Complete API documentation and examples
+  - name: GitHub Discussions
+    url: https://github.com/hunterg325/ChartGPU/discussions
+    about: Ask questions, share ideas, and discuss with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,88 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for ChartGPU
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! We appreciate ideas that make ChartGPU better.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm frustrated when... / It would be useful if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+      placeholder: I'd like to see...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: I've tried... / Another option could be...
+
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Type
+      description: What kind of feature is this?
+      options:
+        - New chart type (e.g., heatmap, candlestick)
+        - Performance improvement
+        - API enhancement
+        - Documentation improvement
+        - Developer experience
+        - Visual/styling improvement
+        - Interaction/events
+        - Data handling
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: breaking-change
+    attributes:
+      label: API Impact
+      options:
+        - label: This feature might require API changes or breaking changes
+
+  - type: textarea
+    id: api-sketch
+    attributes:
+      label: API Sketch (optional)
+      description: If you have an idea of what the API could look like, sketch it here
+      placeholder: |
+        ```typescript
+        chart.setOption({
+          series: [{
+            type: 'heatmap',
+            // ...
+          }]
+        });
+        ```
+      render: typescript
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe your use case or scenario where this would be helpful
+      placeholder: I'm building a dashboard that needs...
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, examples, or resources that might be helpful

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Supported Versions
+
+We currently support the following versions with security updates:
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in ChartGPU, please report it responsibly:
+
+1. **Do NOT open a public issue** - Security issues should remain private until resolved
+2. **Email us at**: `security@example.com` (replace with actual contact email) with:
+   - A clear description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact assessment
+   - Any suggested fixes (if applicable)
+3. **Allow reasonable time** for us to respond and address the issue before public disclosure
+
+We aim to respond to security reports within **72 hours** and will keep you updated throughout the resolution process.
+
+## Known Security Considerations
+
+### Tooltip Content Safety
+
+ChartGPU's tooltip overlay uses `innerHTML` to render tooltip content. When providing custom tooltip formatters via `ChartGPUOptions.tooltip.formatter`, **only return trusted and sanitized HTML strings**.
+
+**Risk**: Unsanitized user input in tooltip formatters can lead to XSS (Cross-Site Scripting) vulnerabilities.
+
+**Mitigation**:
+- Always sanitize user-provided data before including it in tooltip content
+- Use text-only formatters when displaying untrusted data
+- Consider using a dedicated HTML sanitization library (e.g., DOMPurify) if you must render user content
+
+**Safe usage patterns**:
+- SAFE: Static content like `formatter: (params) => 'Value: ' + params.value[1]`
+- SAFE: Sanitized content using `escapeHtml()` or similar sanitization functions before including in HTML
+- UNSAFE: Directly embedding unsanitized user input in HTML strings
+
+See [`docs/API.md`](https://github.com/hunterg325/ChartGPU/blob/main/docs/API.md) for complete tooltip configuration details and [examples/interactive/main.ts](../examples/interactive/main.ts) for working tooltip implementations.
+
+### WebGPU Security Model
+
+ChartGPU operates within the browser's WebGPU security sandbox. The WebGPU specification includes built-in protections against:
+- Memory access violations
+- Cross-origin resource access
+- GPU-level exploits
+
+Users should ensure they're using up-to-date browsers with the latest WebGPU security patches.
+
+## Security Best Practices
+
+When using ChartGPU:
+
+1. **Keep dependencies updated** - Regularly update ChartGPU and browser versions
+2. **Validate user input** - Always sanitize data before passing it to chart options
+3. **Use Content Security Policy (CSP)** - Configure CSP headers appropriately for your application
+4. **Review custom code** - Audit any custom formatters, event handlers, or extensions
+
+## Acknowledgments
+
+We appreciate the security research community's efforts in making ChartGPU safer. Security researchers who responsibly disclose vulnerabilities will be acknowledged (with permission) in our release notes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,78 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Check all that apply -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Code refactoring
+- [ ] Other (please describe):
+
+## Related Issues
+
+<!-- Link to any related issues, e.g., "Fixes #123" or "Closes #456" -->
+
+## Testing
+
+<!-- Describe the testing you've performed -->
+
+- [ ] Tested in Chrome/Edge 113+
+- [ ] Tested in Safari 18+
+- [ ] Added or updated examples in `examples/` (when behavior changes)
+- [ ] Verified WebGPU validation is clean (no console warnings)
+- [ ] Tested on different GPUs/platforms (if applicable)
+
+## Documentation
+
+<!-- Documentation updates for public-facing changes -->
+
+- [ ] Updated `docs/` when public API or behavior changes
+- [ ] Updated `CHANGELOG.md` when public behavior changes
+- [ ] Updated README (if relevant)
+- [ ] Added code comments for complex logic
+
+## WebGPU Correctness
+
+<!-- Important checks for WebGPU code -->
+
+- [ ] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
+- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes)
+- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
+- [ ] Render pipeline target formats match render pass attachment formats
+- [ ] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)
+
+## Browser Testing Checklist
+
+<!-- Check the browsers you've tested in -->
+
+- [ ] Chrome 113+
+- [ ] Edge 113+
+- [ ] Safari 18+
+- [ ] Other (specify): 
+
+## Screenshots / Videos
+
+<!-- If applicable, add screenshots or videos demonstrating the changes -->
+
+## Performance Impact
+
+<!-- If this change affects performance, describe the impact and any measurements -->
+
+## Additional Notes
+
+<!-- Any additional information, context, or concerns -->
+
+---
+
+**For Reviewers:**
+
+- Does this PR follow the functional-first architecture patterns?
+- Are WebGPU resources properly managed?
+- Are examples updated and working?
+- Is documentation complete and accurate?

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,28 @@ node_modules/
 
 # Build output
 dist/
+*.tsbuildinfo
 
-# macOS
+# Vite
+.vite/
+vite.config.*.timestamp-*
+
+# Test coverage
+coverage/
+.nyc_output/
+*.lcov
+
+# Cache and temporary files
+.cache/
+tmp/
+temp/
+*.tmp
+*.temp
+
+# OS-specific
 .DS_Store
+Thumbs.db
+Desktop.ini
 
 # IDE
 .vscode/
@@ -21,8 +40,13 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
 
 # Environment variables
 .env
 .env.local
 .env.*.local
+
+# Optional: pnpm store (uncomment if using pnpm workspaces)
+# .pnpm-store/

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,384 @@
+# Performance Guide
+
+Optimize ChartGPU for large datasets and real-time streaming scenarios.
+
+## When to Use Sampling
+
+### Dataset Size Thresholds
+
+**Enable sampling when:**
+- Dataset exceeds 5,000 points per series (default `samplingThreshold`)
+- Frame rate drops below 60 FPS
+- User experience degrades during zoom/pan interactions
+
+**Sampling defaults:**
+- Per-series default: `sampling: 'lttb'` (Largest Triangle Three Buckets)
+- Default threshold: `samplingThreshold: 5000` when omitted
+- See [`src/config/OptionResolver.ts`](../src/config/OptionResolver.ts) for resolution logic
+
+**When sampling is not needed:**
+- Datasets under 2,000-3,000 points typically render at 60 FPS without sampling
+- Static visualizations where interaction performance is not critical
+- Bar charts with categorical x-axis (fewer bars naturally limit complexity)
+
+### Sampling Activation Rules
+
+Sampling triggers when:
+1. `series[i].data.length > samplingThreshold` AND
+2. `sampling !== 'none'`
+
+Sampling is automatically re-applied during zoom with increased detail for visible range.
+
+## Sampling Algorithms Compared
+
+ChartGPU provides four sampling strategies. See implementations in [`src/data/sampleSeries.ts`](../src/data/sampleSeries.ts) and [`src/data/lttbSample.ts`](../src/data/lttbSample.ts).
+
+### Algorithm Comparison Table
+
+| Algorithm | Best For | Visual Quality | Performance | Preserves |
+|-----------|----------|----------------|-------------|-----------|
+| **`lttb`** (default) | General time-series, curves | Excellent | Good | Shape, peaks, outliers |
+| **`average`** | Noisy data, trends | Good | Excellent | Trends, reduces noise |
+| **`max`** | Positive spikes, peaks | Fair | Excellent | Maximum values per bucket |
+| **`min`** | Negative spikes, valleys | Fair | Excellent | Minimum values per bucket |
+| **`none`** | Small datasets (<5K) | Perfect | Varies with size | All points |
+
+### Algorithm Details
+
+**LTTB (Largest Triangle Three Buckets):**
+- Preserves visual shape by selecting points that maximize triangle area
+- Keeps first and last points (critical for domain extent)
+- Best general-purpose algorithm for time-series data
+- Computational cost: O(n) where n = input size
+
+**Average/Min/Max (Bucketed):**
+- Divides data into uniform buckets, selects aggregate per bucket
+- Keeps first and last points
+- Faster than LTTB but may lose outliers (average) or shape detail (min/max)
+- Computational cost: O(n)
+
+### Configuration Example
+
+Set per-series sampling via `SeriesConfig` in [`src/config/types.ts`](../src/config/types.ts) by providing a `series` array entry with `sampling`, `samplingThreshold`, and `data` properties. See working examples in [`examples/sampling/`](../examples/sampling/) and [`examples/million-points/`](../examples/million-points/).
+
+## Zoom-Aware Sampling for Large Datasets
+
+ChartGPU automatically increases sampling detail when zoomed in, preserving outliers without re-uploading raw data.
+
+### How It Works
+
+**Zoom triggers resampling:**
+1. User zooms via mouse wheel, drag pan, or slider UI
+2. ChartGPU computes visible x-range from zoom window (`start`/`end` in percent space)
+3. Resampling applies to **visible range only** with increased target points
+4. Debounced ~100ms to avoid churn during continuous zoom gestures
+
+**Target scaling formula:**
+- Base target = `samplingThreshold` at full span (0-100%)
+- Zoomed target ≈ `samplingThreshold / spanFraction`
+- Capped by `MAX_TARGET_MULTIPLIER = 32` and `MAX_TARGET_POINTS_ABS = 200,000`
+- Minimum target = 2 points
+
+See implementation in [`src/core/createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) and example usage in [`examples/sampling/main.ts`](../examples/sampling/main.ts) and [`examples/million-points/main.ts`](../examples/million-points/main.ts).
+
+### Zoom Configuration
+
+Enable interactive zoom with data-driven resampling by providing `dataZoom` array with `{ type: 'inside' }` (wheel zoom + shift-drag pan) or `{ type: 'slider' }` (slider UI) entries, and configuring per-series `sampling` and `samplingThreshold` as described in [`docs/API.md`](./API.md).
+
+**Trade-offs:**
+- **Debounce delay (~100ms)**: Small UX lag during zoom vs. CPU/GPU efficiency
+- **Memory cap (200K points)**: Prevents pathological memory usage on extreme zoom
+- **Multiplier cap (32x)**: Balances detail preservation vs. performance
+
+### Axis Bounds Behavior
+
+**Critical:** Axis auto-bounds are derived from **raw (unsampled)** data, not sampled points. This ensures sampling cannot clip outliers or shrink visible range.
+
+Override with explicit bounds if needed by providing `xAxis: { min, max }` or `yAxis: { min, max }` in chart options. See [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) for bounds derivation logic.
+
+## Real-Time Streaming Best Practices
+
+Optimize for continuous data ingestion with bounded memory and responsive UI.
+
+### Recommended Configuration
+
+Based on [`examples/live-streaming/main.ts`](../examples/live-streaming/), configure streaming scenarios with:
+- `animation: false` to disable animations for streaming
+- `autoScroll: true` to keep view pinned to newest data
+- `dataZoom` array with inside and slider entries
+- Per-series `sampling: 'lttb'` and lower `samplingThreshold: 2500`
+
+**Configuration rationale:**
+- **`animation: false`**: Avoids animation overhead on every append
+- **`autoScroll: true`**: Keeps view "pinned to end" when zoom window is at 100%
+- **Lower `samplingThreshold` (2500)**: Reduces resampling work per append
+- **Slider with `start: 70`**: Provides zoom control while keeping recent data visible
+
+### Streaming Parameters
+
+**From live-streaming example:**
+- `pointsPerTick: 12` (batch size per append)
+- `tickMs: 60` (16-17 appends/second ≈ 60 FPS)
+- `maxPoints: 25_000` (memory bound)
+- `samplingThreshold: 2500` (triggers at 10% of max)
+
+**Adjust based on requirements:**
+- **Higher throughput**: Increase `pointsPerTick`, decrease `tickMs` (watch CPU usage)
+- **Smoother animation**: Match `tickMs` to frame time (16-17ms for 60 FPS)
+- **Longer retention**: Increase `maxPoints` (watch memory usage)
+
+### Memory Bounding Strategy
+
+Prevent unbounded growth with periodic trimming by calling `chart.appendData(seriesIndex, newPoints)` to add data, then when `rawData.length > maxPoints`, trim via `rawData = rawData.slice(rawData.length - maxPoints)` and call `chart.setOption({ series: [{ data: rawData }] })` to reset. See [`examples/live-streaming/main.ts`](../examples/live-streaming/main.ts) for complete implementation.
+
+**Trade-off:** `setOption` causes full data re-upload. For 25K points at 2500 threshold, overhead is acceptable when trimming infrequently (e.g., every 5-10 seconds).
+
+### Auto-Scroll Behavior
+
+**When enabled (`autoScroll: true`):**
+- **Pinned to end**: When zoom `end` is near 100%, new data shifts the view to keep `end` at 100%
+- **Panned away**: When user scrolls back, view stays fixed (does not yank back to newest data)
+- **Requirements**: x-axis data zoom must be enabled; `xAxis.min`/`xAxis.max` must not be set
+
+See auto-scroll implementation in [`src/core/createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts).
+
+## appendData vs setOption for Updates
+
+Choose the right update method based on your data pattern.
+
+### Method Comparison
+
+| Method | Use Case | GPU Upload | Recomputation | Animation |
+|--------|----------|------------|---------------|-----------|
+| **`appendData(index, newPoints)`** | Streaming, incremental | Incremental when possible | Partial (bounds + resample) | No |
+| **`setOption({ series })`** | Full replacement | Full re-upload | Full (resolve + bounds + resample) | Yes (if enabled) |
+
+### When to Use appendData
+
+**Ideal for:**
+- Real-time streaming scenarios
+- Incremental data ingestion
+- Append-only patterns (no modification of existing points)
+
+**Behavior:**
+- Updates internal runtime bounds incrementally
+- Triggers resampling only when zoom active or debounce matures
+- Schedules coalesced render (via `requestAnimationFrame`)
+- Respects `autoScroll` when enabled
+
+**Constraints:**
+- Cartesian series only (not supported for `type: 'pie'`)
+- Appends to **end** of series (not insertions or modifications)
+
+See [`ChartGPU.ts`](../src/ChartGPU.ts) and [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) for implementation.
+
+### When to Use setOption
+
+**Ideal for:**
+- Replacing entire dataset
+- Changing series configuration (type, color, sampling, etc.)
+- Animated data transitions
+- Non-append modifications (insertions, deletions, edits)
+
+**Behavior:**
+- Full option resolution via [`OptionResolver.ts`](../src/config/OptionResolver.ts)
+- Full data upload to GPU buffers
+- Triggers data transition animation when enabled
+- Schedules single on-demand render (coalesces multiple calls)
+
+**Animation support:**
+- Cartesian series: y-values interpolate by index
+- Pie series: slice values interpolate by angle
+- Requires `animation` not `false` and post-initial-render update
+
+See [`ChartGPU.ts`](../src/ChartGPU.ts) for lifecycle and [`createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts) for animation logic.
+
+### Incremental GPU Append Optimization
+
+**Current behavior:**
+- When `appendData` doesn't trigger buffer reallocation, only appended bytes are uploaded
+- Buffer growth uses geometric (power-of-two) policy to reduce reallocation frequency
+- 4-byte alignment enforced automatically (WebGPU requirement)
+
+**Safe conditions for incremental upload:**
+- No buffer reallocation needed
+- 8-byte aligned offsets (2 floats × 4 bytes = 8 bytes per point)
+
+See [`docs/INCREMENTAL_APPEND_OPTIMIZATION.md`](./INCREMENTAL_APPEND_OPTIMIZATION.md) for detailed analysis.
+
+## Memory Management and Disposal
+
+Prevent memory leaks and GPU resource exhaustion.
+
+### Disposal Checklist
+
+**When disposing a chart:** Call `chart.dispose()` to clean up resources.
+
+**What gets cleaned up:**
+- Cancels pending `requestAnimationFrame` render
+- Destroys internal render resources (pipelines, buffers)
+- Destroys WebGPU context via `device.destroy()`
+- Removes canvas element from DOM
+- Unregisters all event listeners
+
+See [`ChartGPU.ts`](../src/ChartGPU.ts) for disposal implementation.
+
+### Buffer Management
+
+**Automatic GPU buffer lifecycle:**
+- Per-series vertex buffers cached in [`createDataStore.ts`](../src/data/createDataStore.ts)
+- Lazy allocation on first data upload
+- Geometric growth (power-of-two) on reallocation
+- No shrinking (capacity persists until disposal)
+- Old buffers destroyed on growth via `buffer.destroy()`
+
+**Minimum buffer size:** 4 bytes (WebGPU requirement)
+
+### Device Loss Handling
+
+**GPU device can be lost due to:**
+- Driver crash or timeout detection and recovery (TDR)
+- System sleep/wake
+- GPU removed (external GPU disconnect)
+
+**Recommended handling:** Create chart instance via `ChartGPU.create(container, options)` and optionally access `chart.gpuContext?.device?.lost` promise for advanced device-loss handling. For examples using [`GPUContext`](../src/core/GPUContext.ts) directly, see device-loss handling in [`examples/million-points/main.ts`](../examples/million-points/main.ts).
+
+### Memory Profiling
+
+**Tools:**
+- Browser DevTools: Memory profiler (check for detached canvas, uncancelled RAF)
+- WebGPU DevTools: GPU buffer/texture tracking (Chrome/Edge)
+- Performance Monitor: GPU memory usage trends
+
+**Common leaks:**
+- Missing `dispose()` on chart instances
+- Uncancelled `requestAnimationFrame` loops
+- Event listeners not cleaned up
+- Large datasets accumulating in JavaScript arrays
+
+## Benchmark: How to Measure 1 Million Point Performance
+
+Run reproducible performance measurements for 1M point datasets.
+
+### Running the Benchmark
+
+**Location:** [`examples/million-points/`](../examples/million-points/)
+
+**Steps:**
+1. Start dev server: `npm run dev`
+2. Navigate to `http://localhost:5176/examples/million-points/`
+3. Wait for initial render (1-2 seconds for data generation)
+4. Observe stats panel (FPS, CPU submit time, GPU time, rendered point count)
+5. Toggle sampling on/off to compare performance
+6. Zoom in/out to test zoom-aware resampling
+
+**Reproducibility:**
+- Uses deterministic PRNG (xorshift32) for synthetic data generation
+- Same 1M points on every run (reproducible benchmarks)
+- Rolling average statistics (60-frame window)
+- DOM updates throttled to 250ms intervals
+
+See [`examples/million-points/main.ts`](../examples/million-points/main.ts) for implementation.
+
+### Understanding the Stats Panel
+
+**FPS (Frames Per Second):**
+- Target: 60 FPS (16.67ms per frame)
+- Sustained 60 FPS indicates smooth interaction
+- Below 30 FPS indicates noticeable lag
+
+**CPU Submit Time (ms):**
+- Time spent in `coordinator.render()` including:
+  - Data sampling/recomputation
+  - Buffer updates
+  - Renderer preparations
+  - GPU command encoding
+  - `queue.submit()` call
+- Lower is better
+
+**GPU Time (ms):**
+- End-to-end GPU completion time (submit → work done)
+- Measured via `queue.onSubmittedWorkDone()`
+- **If GPU time > CPU time:** GPU is the bottleneck
+- **If GPU time < CPU time:** CPU is the bottleneck
+- Includes queue latency + GPU execution + CPU sync overhead
+
+See [`docs/GPU_TIMING_IMPLEMENTATION.md`](./GPU_TIMING_IMPLEMENTATION.md) for timing methodology.
+
+**Rendered Point Count:**
+- Estimated points after sampling
+- At full zoom (0-100%): equals `samplingThreshold` when sampling enabled
+- At 1% zoom: up to 32× threshold (capped at 200K points via `MAX_TARGET_POINTS_ABS` in [`src/core/createRenderCoordinator.ts`](../src/core/createRenderCoordinator.ts))
+- With `sampling: 'none'`: equals visible raw points
+
+### Benchmark Configuration
+
+**From million-points example:**
+- Dataset: 1,000,000 points (deterministic sine + noise)
+- Explicit x-domain: `xAxis: { min: 0, max: 999999 }`
+- Explicit y-domain: `yAxis: { min: yMin, max: yMax }`
+- Sampling threshold: 8192 (default for benchmark)
+- Zoom controls: inside (wheel/drag) + slider
+- Animation: disabled (`animation: false`)
+- Tooltip: disabled (`tooltip: { show: false }`)
+
+**Why these settings:**
+- Explicit domains prevent auto-bounds recomputation overhead
+- Disabled animation/tooltip reduce measurement noise
+- Deterministic data ensures reproducible results
+
+### Interpreting Bottlenecks
+
+**CPU-bound scenario (CPU time > GPU time):**
+- Symptoms: High CPU submit time, GPU mostly idle
+- Solutions:
+  - Enable sampling (reduce point count)
+  - Lower sampling threshold (less resampling work)
+  - Reduce append batch size (streaming)
+  - Profile with DevTools to find hot paths
+
+**GPU-bound scenario (GPU time > CPU time):**
+- Symptoms: High GPU time, frame rate limited by GPU
+- Solutions:
+  - Enable sampling (reduce vertex/fragment work)
+  - Reduce canvas size or device pixel ratio
+  - Lower line width (less fragment shader cost)
+  - Upgrade GPU hardware (if feasible)
+
+**Balanced scenario (CPU time ≈ GPU time ≈ frame time):**
+- Optimal: Both CPU and GPU fully utilized
+- Limited headroom for more complex scenes
+- Consider sampling to add performance margin
+
+### Performance Factors (Machine-Dependent)
+
+Results vary significantly based on:
+- **Device pixel ratio:** High-DPI displays (2x-3x) increase GPU workload
+- **Canvas size:** Larger viewports increase fragment shader cost
+- **GPU tier:** Integrated vs discrete GPU (orders of magnitude difference)
+- **Browser:** Chrome/Edge typically faster than Safari (WebGPU maturity)
+
+Run the benchmark on your target hardware to establish baseline performance for your deployment environment.
+
+## Performance Optimization Checklist
+
+- [ ] Enable sampling for datasets >5K points
+- [ ] Choose appropriate sampling algorithm (`lttb` for general use)
+- [ ] Configure zoom for large datasets (inside + slider)
+- [ ] Disable animation for streaming scenarios
+- [ ] Use `appendData` for incremental updates
+- [ ] Bound memory with periodic trimming (streaming)
+- [ ] Call `dispose()` when chart no longer needed
+- [ ] Profile with browser DevTools and GPU tools
+- [ ] Test on target hardware (integrated vs discrete GPU)
+- [ ] Measure with 1M point benchmark as baseline
+
+## Related Documentation
+
+- [`docs/API.md`](./API.md) — Full API reference including sampling, zoom, and lifecycle APIs
+- [`docs/GETTING_STARTED.md`](./GETTING_STARTED.md) — Quick start guide and basic usage
+- [`docs/INCREMENTAL_APPEND_OPTIMIZATION.md`](./INCREMENTAL_APPEND_OPTIMIZATION.md) — Deep dive into GPU buffer append optimization
+- [`docs/GPU_TIMING_IMPLEMENTATION.md`](./GPU_TIMING_IMPLEMENTATION.md) — GPU timing methodology and interpretation
+- [`examples/sampling/`](../examples/sampling/) — Sampling strategies demonstration
+- [`examples/live-streaming/`](../examples/live-streaming/) — Real-time streaming best practices
+- [`examples/million-points/`](../examples/million-points/) — Performance benchmark with GPU timing


### PR DESCRIPTION
Update API documentation and build usage guide

This PR refreshes the API documentation to reflect the current public surface area of ChartGPU, clarifying prop names, default values, and configuration patterns for core chart types. It adds a concise build and bundling guide that demonstrates how to integrate ChartGPU with modern tooling (Vite, Webpack, and bundlers that support WebGPU/WebGL targeting) and documents recommended tree-shaking and code-splitting strategies. The changes also reorganize and tighten existing docs for readability, improve internal linking between sections, and fix minor spelling and formatting issues to make the docs easier to navigate for new contributors and users.
