### PR TITLE
Update `.gitignore` to ignore generated `.tgz` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Build output
 dist/
 *.tsbuildinfo
+*.tgz
 
 # Vite
 .vite/


### PR DESCRIPTION
Update `.gitignore` to ignore generated `.tgz` archives for cleaner source control and easier management of temporary package artifacts.[page:1]
