### PR TITLE
update repo information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hunterg325/ChartGPU.git"
+    "url": "https://github.com/chartgpu/chartgpu.git"
   },
   "bugs": {
-    "url": "https://github.com/hunterg325/ChartGPU/issues"
+    "url": "https://github.com/ChartGPU/chartgpu/issues"
   },
-  "homepage": "https://github.com/hunterg325/ChartGPU#readme",
+  "homepage": "https://github.com/ChartGPU/chartgpu#readme",
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",


### PR DESCRIPTION
Update repository metadata in `package.json` to point to the canonical `ChartGPU/ChartGPU` GitHub URLs, including the `repository.url`, `bugs.url`, and `homepage` fields, so links correctly reference the organization-owned repo instead of the personal fork. [page:1]
