### PR TITLE
updated bundle size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ High-performance charts powered by WebGPU.
 
 ![npm](https://img.shields.io/npm/v/chartgpu)
 ![license](https://img.shields.io/npm/l/chartgpu)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/chartgpu?label=bundle%20size&style=flat)](https://bundlephobia.com/package/chartgpu)
+![npm bundle size](https://img.shields.io/bundlephobia/minzip/chartgpu)
 
 ChartGPU is a TypeScript charting library built on WebGPU for smooth, interactive rendering—especially when you have lots of data.
 


### PR DESCRIPTION
- Update README npm bundle size badge to use the direct `bundlephobia/minzip/chartgpu` shield with a concise label and flat style.
