### PR TITLE
This PR adds automated deployment of the examples site to GitHub Pages and wires it into the existing build setup.

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,54 @@
+name: Deploy Examples to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build library
+        run: npm run build
+      
+      - name: Build examples
+        run: npm run build:examples
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './examples/dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 # Build output
 dist/
+examples/dist/
 *.tsbuildinfo
 *.tgz
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "acceptance:line-style-color": "tsx examples/acceptance/line-style-color.ts",
     "acceptance:area-style-color": "tsx examples/acceptance/area-style-color.ts",
     "build": "tsc && vite build",
+    "build:examples": "vite build examples --outDir examples/dist --base /chartgpu/",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds automated deployment of the examples site to GitHub Pages and wires it into the existing build setup.[page:1]

- Introduces a **Deploy Examples to GitHub Pages** workflow that builds the library and examples on pushes to `main`, then uploads and deploys the built examples to the `github-pages` environment.[page:1]
- Adds `examples/dist/` to `.gitignore` to exclude the generated examples build output from version control.[page:1]
- Adds a `build:examples` npm script using `vite build examples --outDir examples/dist --base /chartgpu/` to produce the static examples bundle consumed by the deployment workflow.[page:1]
