### PR TITLE
Update build script in package.json to use specific Vite config for examples

### DIFF
--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+import { readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+// Find all example directories with index.html
+const exampleDirs = readdirSync(__dirname).filter((file) => {
+  const path = resolve(__dirname, file);
+  return statSync(path).isDirectory() && 
+         readdirSync(path).includes('index.html');
+});
+
+// Build input object for rollup
+const input: Record<string, string> = {
+  main: resolve(__dirname, 'index.html'),
+};
+
+exampleDirs.forEach((dir) => {
+  input[dir] = resolve(__dirname, dir, 'index.html');
+});
+
+export default defineConfig({
+  base: '/chartgpu/',
+  build: {
+    outDir: 'dist',
+    rollupOptions: {
+      input,
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "acceptance:line-style-color": "tsx examples/acceptance/line-style-color.ts",
     "acceptance:area-style-color": "tsx examples/acceptance/area-style-color.ts",
     "build": "tsc && vite build",
-    "build:examples": "vite build examples --outDir examples/dist --base /chartgpu/",
+    "build:examples": "vite build --config examples/vite.config.ts",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
### Update build script in package.json to use specific Vite config for examples

This PR introduces a dedicated Vite config for building the examples and wires it into the npm scripts.[page:1]

#### Changes
- Add `examples/vite.config.ts` that:
  - Detects all example subdirectories containing an `index.html` and builds a Rollup `input` map for them plus the main `index.html`.[page:1]
  - Sets `base` to `/chartgpu/` and `build.outDir` to `dist` for the examples build.[page:1]
- Update the `build:examples` script in `package.json` to use `vite build --config examples/vite.config.ts` instead of passing `--outDir` and `--base` flags inline.[page:1]

#### Rationale
- Centralizes example build configuration in a sing
