### PR TITLE
This PR updates the Vite configuration for the examples

### DIFF
--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -24,7 +24,7 @@ exampleDirs.forEach((dir) => {
 export default defineConfig({
   base: '/chartgpu/',
   build: {
-    outDir: 'dist',
+    outDir: resolve(__dirname, 'dist'),  // Absolute path
     rollupOptions: {
       input,
     },


### PR DESCRIPTION
This PR updates the Vite configuration for the examples to use an absolute path for the `outDir`, resolving it via `__dirname` to ensure consistent output directory resolution across environments and deployment targets.
