### PR TITLE
Update Vite config base path to match project naming convention

### DIFF
--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -22,7 +22,7 @@ exampleDirs.forEach((dir) => {
 });
 
 export default defineConfig({
-  base: '/chartgpu/',
+  base: '/ChartGPU/',
   build: {
     outDir: resolve(__dirname, 'dist'),  // Absolute path
     rollupOptions: {


### PR DESCRIPTION
### Update Vite config base path to match project naming convention

This PR updates the Vite configuration for the examples to use a base path that matches the repository’s naming convention.[page:1]

#### Changes
- Change the `base` option in `examples/vite.config.ts` from `/chartgpu/` to `/ChartGPU/`.[page:1]

#### Rationale
- Aligns the built example assets’ base path with the exact GitHub Pages project name `ChartGPU`, helping ensure correct asset resolution when deployed.[page:1]
