### PR TITLE
This PR updates the GitHub Pages deployment workflow to add a root-level redirect for the examples site.[

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,9 @@ jobs:
       
       - name: Build examples
         run: npm run build:examples
+
+      - name: Add root redirect
+        run: cp examples/root-redirect.html examples/dist/index.html
       
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/examples/root-redirect.html
+++ b/examples/root-redirect.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=./examples/">
+  <link rel="canonical" href="./examples/">
+</head>
+<body>
+  <p>Redirecting to <a href="./examples/">examples</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Description
This PR updates the GitHub Pages deployment workflow to add a root-level redirect for the examples site.[page:1] A new `root-redirect.html` file is introduced and copied into the built examples output as `index.html`, ensuring that visits to the root of the deployed site immediately redirect to the `/examples/` path.[page:1]

## Changes
- Update `.github/workflows/deploy-pages.yml` to add a new step after building examples that copies `examples/root-redirect.html` to `examples/dist/index.html`.[page:1]
- Add `examples/root-redirect.html`, an HTML file that performs an instant redirect to `./examples/` and sets a canonical link to the examples path.[page:1]

## Rationale
- Ensures users hitting the site root are redirected to the interactive examples without needing to know the full `/examples/` path.[page:1]
- Avoids 404s or blank pages at the root of the GitHub Pages deployment by always serving a redirecting index.[page:1]

## Testing
- Verified that the workflow still builds examples successfully and includes the new `index.html` artifact in `examples/dist/`.[page:1]
- Manually confirmed that loading the built `index.html` performs an immediate redirect to
