### PR TITLE
Add a prominent live demo badge and link to the README to make the hosted ChartGPU examples easier to discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ High-performance charts powered by WebGPU.
 ![npm](https://img.shields.io/npm/v/chartgpu)
 ![license](https://img.shields.io/npm/l/chartgpu)
 ![install size](https://packagephobia.com/badge?p=chartgpu)
+[![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://chartgpu.github.io/ChartGPU/)
+
+**[📊 View Live Examples](https://chartgpu.github.io/ChartGPU/)**
 
 ChartGPU is a TypeScript charting library built on WebGPU for smooth, interactive rendering—especially when you have lots of data.
 


### PR DESCRIPTION
Add a prominent live demo badge and link to the README to make the hosted ChartGPU examples easier to discover.[page:2]

- Adds a **Live Demo** shields.io badge next to the existing npm, license, and install size badges, pointing to the GitHub Pages examples site.[page:2]
- Adds a bold **View Live Examples** call-to-action link near the top of the README that directs users to the same live examples URL.[page:2]
