### PR TITLE
Add a React integration section to `README.md` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ await ChartGPU.create(container, {
 
 `npm install chartgpu`
 
+## React Integration
+
+React bindings are available via [`chartgpu-react`](https://github.com/ChartGPU/chartgpu-react):
+
+```bash
+npm install chartgpu-react chartgpu react react-dom
+```
+
+```tsx
+import { ChartGPUChart } from 'chartgpu-react';
+
+function MyChart() {
+  return (
+    <ChartGPUChart
+      options={{
+        series: [{ type: 'line', data: [[0, 1], [1, 3], [2, 2]] }],
+      }}
+    />
+  );
+}
+```
+
+See the [chartgpu-react repository](https://github.com/ChartGPU/chartgpu-react) for full documentation and examples.
+
 ## Browser support (WebGPU required)
 
 - Chrome 113+ or Edge 113+ (WebGPU enabled by default)


### PR DESCRIPTION
Add a React integration section to `README.md` with installation instructions and a minimal usage example for the `chartgpu-react` bindings, including a simple line chart component that demonstrates how to pass `options` into `ChartGPUChart`, and links to the `chartgpu-react` repository for full documentation and examples. [[github]