### PR TITLE
Update installation instructions in README to simplify React bindings setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ await ChartGPU.create(container, {
 React bindings are available via [`chartgpu-react`](https://github.com/ChartGPU/chartgpu-react):
 
 ```bash
-npm install chartgpu-react chartgpu react react-dom
+npm install chartgpu-react
 ```
 
 ```tsx


### PR DESCRIPTION
Update installation instructions in README to simplify React bindings setup.

- Streamlined the React bindings installation command to only require `chartgpu-react`, assuming `chartgpu`, `react`, and `react-dom` are managed separately by the host app.
- Keeps the README focused on the bindings package while reducing noise and potential confusion in the setup snippet.
