### PR TITLE
Add GitHub link to examples page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -20,6 +20,7 @@
     .container {
       max-width: 800px;
       padding: 2rem;
+      position: relative;
     }
     h1 {
       margin-top: 0;
@@ -58,10 +59,55 @@
       font-size: 0.9rem;
       color: #aaa;
     }
+    .github-link {
+      position: absolute;
+      top: 2rem;
+      right: 2rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+      transform: translateY(-1px);
+    }
+    .github-icon {
+      width: 18px;
+      height: 18px;
+      fill: currentColor;
+    }
+    @media (max-width: 600px) {
+      .github-link {
+        position: static;
+        display: inline-flex;
+        margin-bottom: 1rem;
+      }
+      .container {
+        padding: 1rem;
+      }
+      h1 {
+        font-size: 2rem;
+      }
+    }
   </style>
 </head>
 <body>
   <div class="container">
+    <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+      <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+      </svg>
+      <span>View on GitHub</span>
+    </a>
     <h1>ChartGPU Examples</h1>
     <ul class="examples-list">
       <li class="example-item">


### PR DESCRIPTION
This PR adds a prominent **View on GitHub** link to the ChartGPU examples page so visitors can easily navigate from the live examples to the source repository.[page:1] It introduces a styled GitHub button positioned in the top-right of the container on larger screens and reflows it within the content for smaller viewports to maintain responsiveness.[page:1] The change consists of new CSS for the button and icon, along with an accessible external link pointing to the ChartGPU GitHub repo in the `examples/index.html` file.[page:1]
