### PR TITLE
Update the README badges so the npm version and license indicators link directly to the published package and license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/npm/v/chartgpu" alt="npm">
-  <img src="https://img.shields.io/npm/l/chartgpu" alt="license">
+  <a href="https://www.npmjs.com/package/chartgpu">
+    <img src="https://img.shields.io/npm/v/chartgpu" alt="npm">
+  </a>
+  <a href="https://github.com/hunterg325/ChartGPU/blob/main/LICENSE">
+    <img src="https://img.shields.io/npm/l/chartgpu" alt="license">
+  </a>
   <a href="https://chartgpu.github.io/ChartGPU/">
     <img src="https://img.shields.io/badge/demo-live-brightgreen" alt="Live Demo">
   </a>


### PR DESCRIPTION
## Description
Update the README badges so the npm version and license indicators link directly to the published package and license file.[page:2]

## Changes
- Wrapped the npm version shield in a link to the npm package page for `chartgpu`.[page:2]
- Wrapped the license shield in a link to the repository’s LICENSE file on GitHub.[page:2]

## Motivation
- Makes it easier for users to jump directly to the npm package details and license information from the README header badges.[page:2]
