### PR TITLE
Add GitHub link to examples headers for easy access

### DIFF
--- a/examples/basic-line/index.html
+++ b/examples/basic-line/index.html
@@ -64,11 +64,45 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
   </style>
 </head>
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Basic Line</h1>
       <p>Single line series (100 points) - sine wave. Demonstrates grid, axes, and resize handling.</p>
       <a class="back" href="../index.html">← Back to examples</a>

--- a/examples/candlestick-streaming/index.html
+++ b/examples/candlestick-streaming/index.html
@@ -27,6 +27,12 @@
         <button class="timeframe-btn" data-tf="4h">4H</button>
         <button class="timeframe-btn" data-tf="1d">1D</button>
       </div>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
     </header>
 
     <!-- Stats Bar -->
@@ -58,7 +64,7 @@
     <!-- Footer -->
     <footer class="footer">
       <span>Powered by WebGPU • 10,000+ candles • 75 ticks/sec simulated feed</span>
-      <a href="https://github.com/ChartGPU/chartgpu" target="_blank">GitHub</a>
+      <a href="https://github.com/hunterg325/ChartGPU" target="_blank" rel="noopener noreferrer">GitHub</a>
     </footer>
   </div>
 

--- a/examples/candlestick-streaming/styles.css
+++ b/examples/candlestick-streaming/styles.css
@@ -95,7 +95,33 @@ body {
 .timeframes {
   display: flex;
   gap: 4px;
+}
+
+.github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 6px 12px;
   margin-left: auto;
+  background-color: var(--bg-tertiary);
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+
+.github-link:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+.github-icon {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
 }
 
 .timeframe-btn {

--- a/examples/candlestick/index.html
+++ b/examples/candlestick/index.html
@@ -97,11 +97,45 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
   </style>
 </head>
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Candlestick Chart</h1>
       <p>Financial OHLC (open-high-low-close) candlestick rendering with classic/hollow style toggle and color customization.</p>
       <a class="back" href="../index.html">← Back to examples</a>

--- a/examples/chart-sync/index.html
+++ b/examples/chart-sync/index.html
@@ -41,6 +41,34 @@
       text-decoration: none;
     }
     .back:hover { color: #fff; }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
     .grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
@@ -73,6 +101,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Chart Sync</h1>
       <p>Move your mouse over either chart. Crosshair x-position and axis tooltip x-value sync across charts. Zoom is not synced.</p>
       <a class="back" href="../index.html">← Back to examples</a>

--- a/examples/data-update-animation/index.html
+++ b/examples/data-update-animation/index.html
@@ -42,6 +42,34 @@
       text-decoration: none;
     }
     .back:hover { color: #fff; }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
 
     .controls {
       display: flex;
@@ -145,6 +173,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Data Update Animation</h1>
       <p>
         Visual check for Story 5.17: a second <code>setOption(...)</code> updates data and should animate smoothly.

--- a/examples/grid-test/index.html
+++ b/examples/grid-test/index.html
@@ -57,10 +57,44 @@
       color: #4a9eff;
       font-weight: bold;
     }
+    .container {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
   </style>
 </head>
 <body>
   <div class="container">
+    <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+      <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+      </svg>
+      <span>GitHub</span>
+    </a>
     <h1>Grid Renderer Test</h1>
     <p class="description">Testing the WebGPU grid renderer with configurable line counts</p>
 

--- a/examples/grouped-bar/index.html
+++ b/examples/grouped-bar/index.html
@@ -64,11 +64,45 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
   </style>
 </head>
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Grouped Bar</h1>
       <p>Clustered + stacked bars (stack + spacing controls, includes negatives to validate downward stacking).</p>
       <a class="back" href="../index.html">← Back to examples</a>

--- a/examples/hello-world/index.html
+++ b/examples/hello-world/index.html
@@ -21,9 +21,40 @@
       height: 600px;
       border: 1px solid #333;
     }
+    .github-link {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
   </style>
 </head>
 <body>
+  <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+    <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+    </svg>
+    <span>GitHub</span>
+  </a>
   <canvas id="canvas"></canvas>
   <script type="module" src="./main.ts"></script>
 </body>

--- a/examples/interactive/index.html
+++ b/examples/interactive/index.html
@@ -41,6 +41,34 @@
       text-decoration: none;
     }
     .back:hover { color: #fff; }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
 
     .stack {
       display: grid;
@@ -69,6 +97,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Interactive</h1>
       <p>
         Two vertically stacked charts with synced crosshair/tooltip behavior, plus x-axis dataZoom (inside + slider).

--- a/examples/live-streaming/index.html
+++ b/examples/live-streaming/index.html
@@ -47,6 +47,34 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
     .controls {
       display: flex;
       align-items: center;
@@ -114,6 +142,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Live Streaming</h1>
       <p>Single line series with repeated <code>chart.appendData(...)</code>. Toggle auto-scroll and use the slider to see “pinned to end” vs “panned away”.</p>
       <a class="back" href="../index.html">← Back to examples</a>

--- a/examples/million-points/index.html
+++ b/examples/million-points/index.html
@@ -48,6 +48,34 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
 
     .controls {
       display: grid;
@@ -167,6 +195,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Million Points</h1>
       <p>
         Stress test with <strong>1,000,000 points</strong>. Toggle sampling to compare performance and verify that interactive zoom stays responsive.

--- a/examples/pie/index.html
+++ b/examples/pie/index.html
@@ -41,6 +41,34 @@
       text-decoration: none;
     }
     .back:hover { color: #fff; }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
     .grid {
       display: grid;
       grid-template-columns: 1fr;
@@ -96,6 +124,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Pie / Donut</h1>
       <p>Two charts side-by-side: a pie (inner radius 0) and a donut (inner radius &gt; 0). Each slice sets its own <code>color</code>.</p>
       <a class="back" href="../index.html">← Back to examples</a>

--- a/examples/sampling/index.html
+++ b/examples/sampling/index.html
@@ -48,6 +48,34 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
     .controls {
       display: grid;
       grid-template-columns: 1fr;
@@ -173,6 +201,12 @@
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Zoom-aware sampling</h1>
       <p>
         This demo makes ChartGPU’s <strong>zoom-aware sampling</strong> visually obvious: when you zoom in, the chart keeps more points

--- a/examples/scatter/index.html
+++ b/examples/scatter/index.html
@@ -64,11 +64,45 @@
     .back:hover {
       color: #fff;
     }
+    header {
+      position: relative;
+    }
+    .github-link {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background-color: #1a1a2e;
+      color: #e0e0e0;
+      text-decoration: none;
+      border-radius: 6px;
+      border: 1px solid #333;
+      font-size: 0.85rem;
+      transition: all 0.2s;
+    }
+    .github-link:hover {
+      background-color: #2a2a3e;
+      border-color: #555;
+    }
+    .github-icon {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+    }
   </style>
 </head>
 <body>
   <div class="page">
     <header>
+      <a href="https://github.com/hunterg325/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
+        </svg>
+        <span>GitHub</span>
+      </a>
       <h1>Scatter</h1>
       <p>Scatter plot with thousands of points. Demonstrates fixed <code>symbolSize</code>, per-point <code>[x, y, size]</code>, and optional functional <code>symbolSize</code>.</p>
       <a class="back" href="../index.html">← Back to examples</a>


### PR DESCRIPTION
This PR adds a consistent “GitHub” link to the header of all example pages so users can quickly jump to the repository from any demo. It introduces a reusable `.github-link` button style (with icon) positioned in each example’s header or control bar, updates existing footer links to point to `https://github.com/hunterg325/ChartGPU`, and applies these changes across all affected examples (basic line, candlestick, candlestick streaming, chart sync, data update animation, grid test, grouped bar, hello world, interactive, live streaming, million points, pie/donut, and sampling). [page:1]
