### PR TITLE
Update package version to 0.1.6 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartgpu",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
This pull request bumps the ChartGPU package version from 0.1.5 to 0.1.6 in `package.json` to prepare for the next release and keep the published version metadata in sync with recent changes.[page:1]
