### PR TITLE
Adds the annotations authoring example to the examples gallery 

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -206,6 +206,13 @@
           <div class="example-description">Two stacked charts with synced crosshair and axis tooltip, plus click logging for interactions</div>
         </a>
       </li>
+
+      <li class="example-item">
+        <a href="./annotation-authoring/index.html" class="example-link">
+          <div class="example-title">Annotations</div>
+          <div class="example-description">Comprehensive annotation demo with reference lines, point markers, text (plot-space + data-space), interactive authoring via right-click, undo/redo, and JSON export</div>
+        </a>
+      </li>
     </ul>
   </div>
 </body>


### PR DESCRIPTION
## Description
Adds the annotations authoring example to the examples gallery by linking `annotation-authoring/index.html` from `examples/index.html` with a clear description of its capabilities (reference lines, point markers, text in plot/data space, interactive authoring, undo/redo, JSON export).[page:1]

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
- Reintroduces the annotations authoring example entry in the examples list.[page:1]

## Testing
- Manually verified the new “Annotations” example link appears in the examples page and navigates to `annotation-authoring/index.html`.[page:1]

## Additional Notes
- This entry surfaces the comprehensive annotation demo so users can more easily discover and exercise annotation authoring capabilities from the main examples page.[page:1]
