### PR TITLE
Refactor GPUContext to remove OffscreenCanvas support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [<img src="https://hackerbadge.now.sh/api?id=46706528" alt="Featured on Hacker News" height="60" />](https://news.ycombinator.com/item?id=46706528)
 
-[<img src="https://awesome.re/mentioned-badge.svg" alt="Featured in Awesome WebGPU" height="50" />](https://github.com/mikbry/awesome-webgpu)
+[<img src="https://awesome.re/mentioned-badge.svg" alt="Featured in Awesome WebGPU" style="height: 50px;" />](https://github.com/mikbry/awesome-webgpu)
 
 </div>
 


### PR DESCRIPTION
This PR refactors `GPUContext` and related rendering infrastructure to remove `OffscreenCanvas` support and standardize on `HTMLCanvasElement` for all chart rendering paths.[page:1]

- Simplifies the `GPUContext` API by narrowing `SupportedCanvas` to `HTMLCanvasElement` and updating state, factory functions, and the `GPUContext` class constructor/signature accordingly.[page:1]
- Removes OffscreenCanvas-specific dimension handling in favor of `clientWidth`/`clientHeight`-based sizing with validated fallbacks to `canvas.width`/`canvas.height` for display dimensions.[page:1]
- Updates `createRenderCoordinator` and `GPUContextLike` to assume an `HTMLCanvasElement`, simplifying CSS pixel calculations, tooltip anchoring, overlay sizing, and DOM-dependent event handling.[page:1]
- Cleans up OffscreenCanvas-related branches, comments, and MSAA/offscreen pipeline notes, reducing complexity around device-pixel vs CSS-pixel conversions while keeping WebGPU correctness checks intact.[page:1]
- Adjusts README badge styling to use inline `style="height: 50px;"` instead of the `height` attribute for the Awesome WebGPU badge.[page:1]

Overall, this change tightens the canvas abstraction to the primary DOM canvas use case, making layout, events, and annotation overlays more predictable while removing unused OffscreenCanvas code paths.[page:1]
