### PR TITLE
version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartgpu",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Description
Bump the ChartGPU package version from `0.2.2` to `0.2.3` in `package.json` for the next release.[page:1]

## Type of Change
- [x] Other (versioning / release prep)

## Related Issues
- N/A (version-only update)

## Testing
- [ ] Tested in Chrome/Edge 113+  
- [ ] Tested in Safari 18+  
- [ ] Verified WebGPU validation is clean (no console warnings)  

## Documentation
- [ ] Updated `CHANGELOG.md` if needed  
- [ ] Updated README (if relevant)  

## Additional Notes
- No functional or API changes included in this PR; single-line version increment in `package.json`.[page:1]
