### PR TITLE
version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartgpu",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
Bump the ChartGPU package version from `0.2.4` to `0.2.5` in `package.json` to prepare for the next release and reflect recent incremental changes.[page:2]
