### PR TITLE
Update README.md live demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![npm version](https://img.shields.io/npm/v/chartgpu?style=for-the-badge&color=blue)](https://www.npmjs.com/package/chartgpu)
 [![NPM Downloads](https://img.shields.io/npm/dm/chartgpu?style=for-the-badge&color=%2368cc49)](https://www.npmjs.com/package/chartgpu)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://github.com/chartgpu/chartgpu/blob/main/LICENSE)
-[![Live Demo](https://img.shields.io/badge/demo-live-brightgreen?style=for-the-badge)](https://chartgpu.github.io/chartgpu/)
+[![Live Demo](https://img.shields.io/badge/demo-live-brightgreen?style=for-the-badge)](https://chartgpu.github.io/ChartGPU/examples/)
 [![Examples](https://img.shields.io/badge/Examples-Code%20Samples-blue?style=for-the-badge)](https://github.com/chartgpu/chartgpu/tree/main/examples)
 [![Documentation](https://img.shields.io/badge/Documentation-Getting%20Started-blue?style=for-the-badge)](https://github.com/chartgpu/chartgpu/blob/main/docs/GETTING_STARTED.md)
 


### PR DESCRIPTION
### Summary

Update the README live demo badge link to point to the correct examples page.

### Details

- Updated the **Live Demo** badge URL in `README.md` from `https://chartgpu.github.io/chartgpu/` to `https://chartgpu.github.io/ChartGPU/examples/` to direct users to the current live examples page.[page:1]
- No other files or behavior were changed in this PR.[page:1]

### Notes

- This is a documentation-only change intended to improve discoverability of the live demo for new users.[page:1]
