### PR TITLE
Added org scope for chartgpu npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chartgpu",
+  "name": "@chartgpu/chartgpu",
   "version": "0.2.5",
   "description": "High-performance WebGPU charting library",
   "keywords": [
@@ -32,6 +32,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "vite",
     "test": "vitest",


### PR DESCRIPTION
## Description
Add an npm organization scope for the ChartGPU package and configure publish settings for public access.

## Changes
- Rename package from `chartgpu` to `@chartgpu/chartgpu` in `package.json`.
- Add `publishConfig.access = "public"` to ensure the scoped package can be published under the `@chartgpu` org.

## Type of Change
- [x] Other (package metadata / publishing configuration)

## Related Issues
- N/A

## Testing
- Package.json builds and tooling continue to recognize the updated package name.
- Verified that the new scoped name and `publishConfig` are valid for npm publishing.

## Documentation
- [ ] Updated `docs/` when public API or behavior changes  
- [ ] Updated `CHANGELOG.md` when public behavior changes  
- [ ] Updated README (if relevant)  

## Additional Notes
- This prepares ChartGPU for publishing under the `@chartgpu` npm organization namespace.
