### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Description
Bump `@chartgpu/chartgpu` package version from `0.2.5` to `0.2.6` in `package.json` to prepare for the next release.[page:1]

## Type of Change
- [x] Other (release version bump)

## Related Issues
- N/A

## Testing
- [ ] Tested in Chrome/Edge 113+
- [ ] Tested in Safari 18+
- [ ] Added or updated examples in `examples/` (when behavior changes)
- [ ] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested on different GPUs/platforms (if applicable)

## Documentation
- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)
- [ ] Added code comments for complex logic

## WebGPU Correctness
- [ ] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [ ] Render pipeline target formats match render pass attachment formats
- [ ] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)

## Browser Testing Checklist
- [ ] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify):

## Screenshots / Videos
- N/A

## Performance Impact
- No functional or performance changes; version bump only.[page:1]

## Additional Notes
- This PR contains a single commit and a single-line change in `package.json` to update the published version.[page:1]
