### PR TITLE
Chore: add scope for GitHub packages and sync version from release tag

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://npm.pkg.github.com
+          scope: "@chartgpu"
 
       - name: Install dependencies
         run: npm ci
@@ -28,6 +29,13 @@ jobs:
 
       - name: Copy dist to GitHub package
         run: cp -r dist packages/github/dist
+
+      - name: Sync version from release tag
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          jq --arg v "$VERSION" '.version = $v' packages/github/package.json > packages/github/package.json.tmp
+          mv packages/github/package.json.tmp packages/github/package.json
 
       - name: Publish to GitHub Packages
         working-directory: packages/github


### PR DESCRIPTION
## Description
Update the GitHub Packages publish workflow to ensure packages are correctly scoped and versioned from release tags.

## Changes
- Configure npm to use the `@chartgpu` scope when publishing to GitHub Packages.
- Add a step to read the release tag (`github.event.release.tag_name`), strip the leading `v`, and sync the version field in `packages/github/package.json` before publishing.
- Keep the existing build and publish steps intact, only extending the workflow with scoping and version-sync logic.

## Rationale
- Ensures published GitHub packages use the correct organization scope.
- Guarantees the package version matches the GitHub release tag, reducing the risk of mismatched versions between releases and published artifacts.

## Testing
- Triggered the workflow via a release event and verified:
  - The computed version matches the release tag without the `v` prefix.
  - The updated `packages/github/package.json` is used by `npm publish` when publishing to GitHub Packages.
