### PR TITLE
fix: Legend options configuration has no effect

### DIFF
--- a/src/core/createRenderCoordinator.ts
+++ b/src/core/createRenderCoordinator.ts
@@ -1149,7 +1149,7 @@ export function createRenderCoordinator(
     setOptions({ ...currentOptions, series: updatedSeries });
   };
 
-  const legend: Legend | null = overlayContainer ? createLegend(overlayContainer, 'right', handleSeriesToggle) : null;
+  const legend: Legend | null = overlayContainer && options.legend?.show!==false ? createLegend(overlayContainer, options.legend?.position, handleSeriesToggle) : null;
   // Text measurement for axis labels. Requires DOM context.
   const tickMeasureCtx: CanvasRenderingContext2D | null = (() => {
     if (typeof document === 'undefined') {


### PR DESCRIPTION

## Description

Values provided in `options.legend` were not applied.

## Minimal example
```ts
const container = document.getElementById("chart")!;
const chart = await ChartGPU.create(container, {
  legend: {
    show: true,
    position: "bottom",
  },
  series: [
    {
      type: "line",
      data: [
        [0, 1],
        [1, 3],
        [2, 2],
        [3, 5],
        [4, 4],
      ],
    },
  ],
});
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues



## Testing

Given the simplicity of the change, the behavior was verified through manual testing.

- [x] Tested in Chrome/Edge 113+
- [ ] Tested in Safari 18+
- [ ] Added or updated examples in `examples/` (when behavior changes)
- [ ] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested on different GPUs/platforms (if applicable)

## Documentation

I noticed that these options are not documented in `docs/api/options.md`.
I assumed they are intended to be public since they are already supported by the API, but please let me know if this behavior is not meant to be exposed yet.

- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)
- [ ] Added code comments for complex logic

## WebGPU Correctness

<!-- Important checks for WebGPU code -->

- [ ] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [ ] Render pipeline target formats match render pass attachment formats
- [ ] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)

## Browser Testing Checklist

<!-- Check the browsers you've tested in -->

- [x] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify): 

## Screenshots / Videos
With `show: false`:
<img width="811" height="412" alt="image" src="https://github.com/user-attachments/assets/04e6185c-0cf3-4e8f-be5c-155f54f3043c" />

With `position: "bottom"`:
<img width="810" height="409" alt="image" src="https://github.com/user-attachments/assets/c29e7794-cbb7-41e4-bf08-328650f3f0bb" />


## Performance Impact

Given the simplicity of the change, I doubt there will be an impact.

## Additional Notes

Although it would be preferable for the top and bottom positions to reserve the correct amount of space to avoid overlapping the plot, this can be easily mitigated by adjusting the grid margins.

---

**For Reviewers:**

- Does this PR follow the functional-first architecture patterns?
- Are WebGPU resources properly managed?
- Are examples updated and working?
- Is documentation complete and accurate?
