### PR TITLE
Version Bump to 0.2.9 -- Chart Legend Options Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Description
Bump `@chartgpu/chartgpu` package version from `0.2.8` to `0.2.9` in `package.json` to prepare for the next release.[page:1]

## Type of Change
- [x] Other (version bump for release)[page:1]

## Related Issues
- N/A (version-only update)

## Testing
- [ ] Tested in Chrome/Edge 113+
- [ ] Tested in Safari 18+
- [ ] Added or updated examples in `examples/` (when behavior changes)
- [ ] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested on different GPUs/platforms (if applicable)

## Documentation
- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)
- [ ] Added code comments for complex logic

## WebGPU Correctness
- [ ] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [ ] Render pipeline target formats match render pass attachment formats
- [ ] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)

## Browser Testing Checklist
- [ ] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify):

## Screenshots / Videos
- Not applicable for this change.

## Performance Impact
- None; version-only change.

## Additional Notes
- Single commit: `version bump` updating `package.json` from `0.2.8` to `0.2.9`.[page:1]
