### PR TITLE
chore: bump version to 0.3.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Description
Bump package version for `@chartgpu/chartgpu` from `0.2.9` to `0.3.0` in `package.json` to prepare for the next minor release.[page:1]

## Type of Change
- [x] Other (release metadata / version bump)[page:1]

## Related Issues
- N/A (version metadata only)

## Testing
- Not required (no runtime code changes)[page:1]

## Documentation
- [ ] Update `CHANGELOG.md` and any release notes to reference version `0.3.0` as needed.

## Additional Notes
- This PR contains a single commit and a single-line change, updating only the `version` field in `package.json`.[page:1]
