### PR TITLE
chore: bump version to 0.3.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Description
Bump `@chartgpu/chartgpu` package version from `0.3.0` to `0.3.1` in `package.json` for the next patch release.[page:1]

## Type of Change
- [x] Other (version bump / release metadata only)

## Related Issues
- N/A (version-only change)

## Testing
- [x] Not required (no code or behavior changes)

## Documentation
- [x] Not required (no public API or behavior changes)

## Additional Notes
- This PR contains a single change: updating the `version` field in `package.json` from `0.3.0` to `0.3.1`.[page:1]
