### PR TITLE
Feature/multi axis y scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Multi-axis Y-scaling** - Introduced robust support for multiple independent Y-axes via `yAxes` configuration array. Allows rendering multiple datasets with distinct numerical ranges (e.g., Price vs Volume) on the same chart, mapped via `yAxisIndex` on the series configuration. Features independent tick generation, dynamic right-left layouts via `position: "right"`, and precise hit-testing alignments.
 - **Shared GPUDevice support** - Multiple `ChartGPU` instances can share a single, pre-initialized `GPUDevice` (via injected `adapter` + `device`) to reduce redundant initialization and improve dashboard ergonomics.
 - **`deviceLost` event (shared device mode)** - When using an injected/shared device, charts emit a `deviceLost` event so apps can recreate chart instances without ChartGPU destroying the shared device.
 - **Shared Pipeline Cache** - Opt-in `createPipelineCache(device)` deduplicates `GPUShaderModule`, `GPURenderPipeline`, and `GPUComputePipeline` across charts on the same device, reducing shader compilation overhead in multi-chart dashboards.

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -95,7 +95,12 @@ Notes (density mode):
 
 ## Axis Configuration
 
-- **`AxisConfig`**: configuration for `xAxis` / `yAxis`. See [`types.ts`](../../src/config/types.ts).
+- **`AxisConfig`**: configuration for `xAxis` / `yAxes`. See [`types.ts`](../../src/config/types.ts).
+- **Multiple Y-Axes**:
+  - Instead of a single `yAxis` object, ChartGPU supports an array of `yAxes` objects for independent scales (e.g. Price vs Volume).
+  - Each `yAxis` in the `yAxes` array must specify an `id: string` (default is `"primary"` for the first axis).
+  - Series map to a specific axis via `yAxisIndex` in their config.
+  - Axes can be positioned on the right using `position: "right"` (default is `"left"`).
 - **Explicit domains (override auto-bounds)**:
   - **`AxisConfig.min?: number` / `AxisConfig.max?: number`**: when set, ChartGPU uses these explicit axis bounds and does **not** auto-derive bounds from data for that axis.
   - **Precedence**: explicit `min`/`max` always override any auto-bounds behavior.

--- a/examples/multi-axes/index.html
+++ b/examples/multi-axes/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi-Axes - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; padding: 0;
+      background-color: #0a0a0a;
+      color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+    .page {
+      min-height: 100%;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: 16px;
+      padding: 20px;
+      box-sizing: border-box;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    header h1 { margin: 0; font-size: 1.4rem; color: #fff; }
+    header p  { margin: 8px 0 0; color: #aaa; line-height: 1.4; }
+    .chart-shell {
+      border: 1px solid #333;
+      border-radius: 12px;
+      background: #0f0f14;
+      overflow: hidden;
+      min-height: 420px;
+      height: min(70vh, 720px);
+    }
+    .chart { width: 100%; height: 100%; }
+    .error { padding: 16px; color: #ffb4b4; white-space: pre-wrap; }
+    .back { display: inline-block; margin-top: 10px; color: #aaa; text-decoration: none; }
+    .back:hover { color: #fff; }
+    header { position: relative; }
+
+    /* Legend / info panel */
+    .info {
+      display: flex;
+      gap: 24px;
+      flex-wrap: wrap;
+      padding: 12px 0 0;
+      font-size: 0.85rem;
+      color: #aaa;
+    }
+    .legend-dot {
+      display: inline-block;
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+    .info span { white-space: nowrap; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <h1>Multi-Axis Chart</h1>
+      <p>
+        Two independent Y-axes with different scales on left and right —
+        <strong style="color:#4a9eff">Temperature (°C)</strong> on the left axis and
+        <strong style="color:#ff9f40">Humidity (%)</strong> / <strong style="color:#9b59b6">Wind speed (km/h)</strong>
+        on the right axis. Each axis is scaled independently.
+      </p>
+      <a class="back" href="../index.html">← Back to examples</a>
+    </header>
+
+    <div class="chart-shell">
+      <div id="chart" class="chart"></div>
+      <div id="error" class="error" style="display:none;"></div>
+    </div>
+
+    <div class="info">
+      <span><span class="legend-dot" style="background:#4a9eff"></span>Temperature °C (left axis, −5 → 40)</span>
+      <span><span class="legend-dot" style="background:#ff9f40"></span>Humidity % (right axis, 0 → 100)</span>
+      <span><span class="legend-dot" style="background:#9b59b6"></span>Wind speed km/h (right axis, 0 → 100)</span>
+    </div>
+  </div>
+
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/examples/multi-axes/main.ts
+++ b/examples/multi-axes/main.ts
@@ -1,0 +1,184 @@
+/**
+ * Multi-Axis Chart Example
+ *
+ * Demonstrates two independent Y-axes:
+ *   - y1 (left):  Temperature in °C  — range roughly −5 → 40
+ *   - y2 (right): Humidity % and Wind speed km/h — range 0 → 100
+ *
+ * Series are bound to their axis via the `yAxis` property.
+ */
+import { ChartGPU } from '../../src/index';
+import type { ChartGPUOptions, DataPoint } from '../../src/index';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const days = 90; // 3 months of daily readings
+
+/** Smooth pseudo-random walk within [lo, hi]. */
+function generateWalk(
+  n: number,
+  start: number,
+  lo: number,
+  hi: number,
+  step = 1.5,
+): ReadonlyArray<DataPoint> {
+  const pts: DataPoint[] = [];
+  let v = start;
+  for (let i = 0; i < n; i++) {
+    v += (Math.random() - 0.5) * step * 2;
+    v = Math.max(lo, Math.min(hi, v));
+    pts.push([i, v]);
+  }
+  return pts;
+}
+
+/** Smooth sine-modulated seasonal curve. */
+function generateSeasonal(
+  n: number,
+  baseMin: number,
+  baseMax: number,
+  noise = 1,
+): ReadonlyArray<DataPoint> {
+  const pts: DataPoint[] = [];
+  const mid = (baseMax + baseMin) / 2;
+  const amp = (baseMax - baseMin) / 2;
+  for (let i = 0; i < n; i++) {
+    const seasonal = Math.sin((i / n) * Math.PI * 2 - Math.PI / 2) * amp;
+    const jitter = (Math.random() - 0.5) * noise * 2;
+    pts.push([i, mid + seasonal + jitter]);
+  }
+  return pts;
+}
+
+// ─── data ───────────────────────────────────────────────────────────────────
+
+const temperatureData = generateSeasonal(days, 2, 34, 2);   // °C, seasonal arc
+const humidityData    = generateWalk(days, 65, 30, 95, 3);  // %, random walk
+const windData        = generateWalk(days, 20, 5, 80, 4);   // km/h, random walk
+
+// ─── chart ──────────────────────────────────────────────────────────────────
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+async function main() {
+  const container = document.getElementById('chart');
+  if (!container) throw new Error('Chart container not found');
+
+  const options: ChartGPUOptions = {
+    // Extra right margin for the right-side Y-axis labels
+    grid: { left: 70, right: 70, top: 28, bottom: 52 },
+
+    xAxis: {
+      type: 'value',
+      min: 0,
+      max: days - 1,
+      name: 'Day',
+    },
+
+    // Multi-axis configuration: two independent Y-axes
+    axes: {
+      y: [
+        {
+          id: 'y1',
+          position: 'left',
+          name: 'Temperature (°C)',
+          min: -5,
+          max: 40,
+        },
+        {
+          id: 'y2',
+          position: 'right',
+          name: 'Humidity / Wind',
+          min: 0,
+          max: 100,
+        },
+      ],
+    },
+
+    animation: { duration: 700, easing: 'cubicOut', delay: 0 },
+
+    series: [
+      {
+        type: 'line',
+        name: 'Temperature (°C)',
+        data: temperatureData,
+        color: '#4a9eff',
+        yAxis: 'y1',           // ← bound to left axis
+        lineStyle: { width: 2.5, opacity: 1 },
+        areaStyle: { opacity: 0.12 },
+      },
+      {
+        type: 'line',
+        name: 'Humidity (%)',
+        data: humidityData,
+        color: '#ff9f40',
+        yAxis: 'y2',           // ← bound to right axis
+        lineStyle: { width: 2, opacity: 1 },
+        areaStyle: { opacity: 0.08 },
+      },
+      {
+        type: 'line',
+        name: 'Wind speed (km/h)',
+        data: windData,
+        color: '#9b59b6',
+        yAxis: 'y2',           // ← also bound to right axis
+        lineStyle: { width: 2, opacity: 0.9 },
+      },
+    ],
+  };
+
+  const chart = await ChartGPU.create(container, options);
+
+  // ── resize handling ─────────────────────────────────────────────────────
+  let scheduled = false;
+  const ro = new ResizeObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      chart.resize();
+    });
+  });
+  ro.observe(container);
+  chart.resize();
+
+  // ── demonstrate setOption with updated data after 4 s ──────────────────
+  setTimeout(() => {
+    const newTemp     = generateSeasonal(days, 5, 38, 3);
+    const newHumidity = generateWalk(days, 50, 20, 98, 4);
+    const newWind     = generateWalk(days, 30, 3, 90, 5);
+
+    chart.setOption({
+      ...options,
+      series: [
+        { ...options.series![0], data: newTemp },
+        { ...options.series![1], data: newHumidity },
+        { ...options.series![2], data: newWind },
+      ],
+    });
+  }, 4000);
+
+  window.addEventListener('beforeunload', () => {
+    ro.disconnect();
+    chart.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () =>
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    }),
+  );
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/src/ChartGPU.ts
+++ b/src/ChartGPU.ts
@@ -975,7 +975,6 @@ export async function createChartGPU(
         runtimeRawDataByIndex[i] = cartesianDataToMutableColumns(raw);
         runtimeRawBoundsByIndex[i] =
           (s as unknown as { rawBounds?: Bounds | null }).rawBounds ??
-          null ??
           (computeRawBoundsFromCartesianData(raw) as Bounds | null);
       }
     }
@@ -1512,8 +1511,8 @@ export async function createChartGPU(
 
     const xMin = resolvedOptions.xAxis.min ?? cachedGlobalBounds.xMin;
     const xMax = resolvedOptions.xAxis.max ?? cachedGlobalBounds.xMax;
-    const yMin = resolvedOptions.yAxis.min ?? cachedGlobalBounds.yMin;
-    const yMax = resolvedOptions.yAxis.max ?? cachedGlobalBounds.yMax;
+    const yMin = resolvedOptions.yAxes[0]?.min ?? cachedGlobalBounds.yMin;
+    const yMax = resolvedOptions.yAxes[0]?.max ?? cachedGlobalBounds.yMax;
 
     // Make hit-testing zoom-aware (mirror coordinator percent->domain mapping).
     const baseXDomain = normalizeDomain(xMin, xMax);
@@ -2448,8 +2447,8 @@ export async function createChartGPU(
       // Compute domain and scales for hit-testing
       const xMin = resolvedOptions.xAxis.min ?? cachedGlobalBounds.xMin;
       const xMax = resolvedOptions.xAxis.max ?? cachedGlobalBounds.xMax;
-      const yMin = resolvedOptions.yAxis.min ?? cachedGlobalBounds.yMin;
-      const yMax = resolvedOptions.yAxis.max ?? cachedGlobalBounds.yMax;
+      const yMin = resolvedOptions.yAxes[0]?.min ?? cachedGlobalBounds.yMin;
+      const yMax = resolvedOptions.yAxes[0]?.max ?? cachedGlobalBounds.yMax;
 
       const baseXDomain = normalizeDomain(xMin, xMax);
       const zoomRange = coordinator?.getZoomRange() ?? null;

--- a/src/config/OptionResolver.ts
+++ b/src/config/OptionResolver.ts
@@ -97,14 +97,10 @@ export type ResolvedLineSeriesConfig = Readonly<
     readonly areaStyle?: ResolvedAreaStyleConfig;
     readonly sampling: SeriesSampling;
     readonly samplingThreshold: number;
-    /**
-     * Original (unsampled) series data.
-     *
-     * Used at runtime for zoom-aware re-sampling so we can increase detail when zoomed-in without
-     * losing outliers or permanently discarding points.
-     */
+    /** Original (unsampled) series data. */
     readonly rawData: Readonly<LineSeriesConfig["data"]>;
     readonly data: Readonly<LineSeriesConfig["data"]>;
+    readonly yAxis: string;
     /**
      * Bounds computed from the original (unsampled) data. Used for axis auto-bounds so sampling
      * cannot clip outliers.
@@ -131,6 +127,7 @@ export type ResolvedAreaSeriesConfig = Readonly<
     /** Original (unsampled) series data (see `ResolvedLineSeriesConfig.rawData`). */
     readonly rawData: Readonly<AreaSeriesConfig["data"]>;
     readonly data: Readonly<AreaSeriesConfig["data"]>;
+    readonly yAxis: string;
     /**
      * Bounds computed from the original (unsampled) data. Used for axis auto-bounds so sampling
      * cannot clip outliers.
@@ -147,6 +144,7 @@ export type ResolvedBarSeriesConfig = Readonly<
     /** Original (unsampled) series data (see `ResolvedLineSeriesConfig.rawData`). */
     readonly rawData: Readonly<BarSeriesConfig["data"]>;
     readonly data: Readonly<BarSeriesConfig["data"]>;
+    readonly yAxis: string;
     /**
      * Bounds computed from the original (unsampled) data. Used for axis auto-bounds so sampling
      * cannot clip outliers.
@@ -181,6 +179,7 @@ export type ResolvedScatterSeriesConfig = Readonly<
     /** Original (unsampled) series data (see `ResolvedLineSeriesConfig.rawData`). */
     readonly rawData: Readonly<ScatterSeriesConfig["data"]>;
     readonly data: Readonly<ScatterSeriesConfig["data"]>;
+    readonly yAxis: string;
     /**
      * Bounds computed from the original (unsampled) data. Used for axis auto-bounds so sampling
      * cannot clip outliers.
@@ -231,6 +230,7 @@ export type ResolvedCandlestickSeriesConfig = Readonly<
     /** Original (unsampled) series data. */
     readonly rawData: Readonly<CandlestickSeriesConfig["data"]>;
     readonly data: Readonly<CandlestickSeriesConfig["data"]>;
+    readonly yAxis: string;
     /**
      * Bounds computed from the original (unsampled) data. Used for axis auto-bounds so sampling
      * cannot clip outliers.
@@ -253,6 +253,7 @@ export interface ResolvedChartGPUOptions extends Omit<
   | "gridLines"
   | "xAxis"
   | "yAxis"
+  | "axes"
   | "theme"
   | "palette"
   | "series"
@@ -261,7 +262,7 @@ export interface ResolvedChartGPUOptions extends Omit<
   readonly grid: ResolvedGridConfig;
   readonly gridLines: ResolvedGridLinesConfig;
   readonly xAxis: AxisConfig;
-  readonly yAxis: AxisConfig;
+  readonly yAxes: ReadonlyArray<AxisConfig>;
   readonly autoScroll: boolean;
   readonly theme: ThemeConfig;
   readonly palette: ReadonlyArray<string>;
@@ -1010,21 +1011,45 @@ export function resolveOptions(
       }
     : { ...defaultOptions.xAxis };
 
-  const yAxis: AxisConfig = userOptions.yAxis
-    ? {
+  const yAxes: AxisConfig[] = [];
+  if (userOptions.axes?.y && userOptions.axes.y.length > 0) {
+    for (let index = 0; index < userOptions.axes.y.length; index++) {
+      const yConfig = userOptions.axes.y[index]!;
+      yAxes.push({
         ...defaultOptions.yAxis,
-        ...userOptions.yAxis,
-        // runtime safety for JS callers
-        type:
-          (userOptions.yAxis as unknown as Partial<AxisConfig>).type ??
-          defaultOptions.yAxis.type,
+        ...yConfig,
+        id: yConfig.id ?? (index === 0 ? "y" : `y${index}`),
+        position: yConfig.position ?? "left",
+        type: yConfig.type ?? defaultOptions.yAxis.type,
         autoBounds:
           normalizeAxisAutoBounds(
-            (userOptions.yAxis as unknown as { readonly autoBounds?: unknown })
+            (yConfig as unknown as { readonly autoBounds?: unknown })
               .autoBounds,
           ) ?? defaultOptions.yAxis.autoBounds,
-      }
-    : { ...defaultOptions.yAxis };
+      });
+    }
+  } else {
+    yAxes.push(
+      userOptions.yAxis
+        ? {
+            ...defaultOptions.yAxis,
+            ...userOptions.yAxis,
+            id: userOptions.yAxis.id ?? "y",
+            position: userOptions.yAxis.position ?? "left",
+            type:
+              (userOptions.yAxis as unknown as Partial<AxisConfig>).type ??
+              defaultOptions.yAxis.type,
+            autoBounds:
+              normalizeAxisAutoBounds(
+                (userOptions.yAxis as unknown as { readonly autoBounds?: unknown })
+                  .autoBounds,
+              ) ?? defaultOptions.yAxis.autoBounds,
+          }
+        : { ...defaultOptions.yAxis, id: "y", position: "left" },
+    );
+  }
+
+  const defaultYAxisId = yAxes[0]!.id ?? "y";
 
   const series: ReadonlyArray<ResolvedSeriesConfig> = (
     userOptions.series ?? []
@@ -1043,6 +1068,8 @@ export function resolveOptions(
       normalizeSamplingThreshold(
         (s as unknown as { samplingThreshold?: unknown }).samplingThreshold,
       ) ?? 5000;
+      
+    const yAxis = s.yAxis ?? defaultYAxisId;
 
     switch (s.type) {
       case "area": {
@@ -1073,6 +1100,7 @@ export function resolveOptions(
           samplingThreshold,
           rawBounds,
           connectNulls: s.connectNulls ?? false,
+          yAxis,
         };
       }
       case "line": {
@@ -1118,6 +1146,7 @@ export function resolveOptions(
           samplingThreshold,
           rawBounds,
           connectNulls: s.connectNulls ?? false,
+          yAxis,
         };
       }
       case "bar": {
@@ -1132,6 +1161,7 @@ export function resolveOptions(
           sampling,
           samplingThreshold,
           rawBounds,
+          yAxis,
         };
       }
       case "scatter": {
@@ -1168,6 +1198,7 @@ export function resolveOptions(
           sampling,
           samplingThreshold,
           rawBounds,
+          yAxis,
         };
       }
       case "pie": {
@@ -1254,6 +1285,7 @@ export function resolveOptions(
           sampling: resolvedSampling,
           samplingThreshold: resolvedSamplingThreshold,
           rawBounds,
+          yAxis,
         };
       }
       default: {
@@ -1266,7 +1298,7 @@ export function resolveOptions(
     grid,
     gridLines,
     xAxis,
-    yAxis,
+    yAxes,
     autoScroll,
     dataZoom: sanitizeDataZoom((userOptions as ChartGPUOptions).dataZoom),
     annotations: sanitizeAnnotations(

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -103,6 +103,8 @@ export interface GridConfig {
 }
 
 export interface AxisConfig {
+  readonly id?: string;
+  readonly position?: "left" | "right";
   readonly type: AxisType;
   readonly min?: number;
   readonly max?: number;
@@ -151,6 +153,7 @@ export interface AreaStyleConfig {
 
 export interface SeriesConfigBase {
   readonly name?: string;
+  readonly yAxis?: string;
   readonly data: CartesianSeriesData;
   readonly color?: string;
   /**
@@ -685,6 +688,9 @@ export interface GridLinesConfig {
 }
 
 export interface ChartGPUOptions {
+  readonly axes?: {
+    readonly y?: ReadonlyArray<AxisConfig>;
+  };
   readonly grid?: GridConfig;
   /**
    * Grid lines configuration controlling visibility, count, and appearance.

--- a/src/core/createRenderCoordinator.ts
+++ b/src/core/createRenderCoordinator.ts
@@ -33,7 +33,7 @@ import {
   computeRawBoundsFromCartesianData,
 } from "../data/cartesianData";
 import type { CartesianSeriesData } from "../config/types";
-import { renderAxisLabels } from "./renderCoordinator/render/renderAxisLabels";
+import { renderAxisLabels, renderYAxisLabels } from "./renderCoordinator/render/renderAxisLabels";
 import { renderAnnotationLabels } from "./renderCoordinator/render/renderAnnotationLabels";
 import { prepareOverlays } from "./renderCoordinator/render/renderOverlays";
 import { processAnnotations } from "./renderCoordinator/annotations/processAnnotations";
@@ -118,13 +118,21 @@ function getCanvasCssWidth(canvas: HTMLCanvasElement | null): number {
   return canvas.clientWidth;
 }
 
+/** Gets canvas CSS height - clientHeight for HTMLCanvasElement */
+function getCanvasCssHeight(canvas: HTMLCanvasElement | null): number {
+  if (!canvas) {
+    return 0;
+  }
+  return canvas.clientHeight;
+}
+
 /**
  * Gets canvas CSS size derived strictly from device-pixel dimensions and DPR.
  *
  * This is intentionally different from `getCanvasCssWidth/Height(...)`:
  * - HTMLCanvasElement: `clientWidth/clientHeight` reflect DOM layout and can diverge (rounding, zoom, async resize)
  *   from the WebGPU render target size (`canvas.width/height` in device pixels).
- * - For GPU overlays that round-trip CSS↔device pixels in-shader, we must derive CSS size from
+ * - For GPU overlays that round-trip CSSÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Âdevice pixels in-shader, we must derive CSS size from
  *   `canvas.width/height` + DPR to keep transforms consistent with the render target.
  *
  * NOTE: Use this for GPU overlay coordinate conversion only (reference lines, markers).
@@ -145,7 +153,7 @@ function getCanvasCssSizeFromDevicePixels(
 export interface RenderCoordinator {
   setOptions(resolvedOptions: ResolvedChartGPUOptions): void;
   /**
-   * Appends new points to a cartesian series’ runtime data without requiring a full `setOptions(...)`
+   * Appends new points to a cartesian seriesÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¾ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ runtime data without requiring a full `setOptions(...)`
    * resolver pass.
    *
    * Appends are coalesced and flushed once per render frame.
@@ -155,14 +163,14 @@ export interface RenderCoordinator {
     newPoints: CartesianSeriesData | ReadonlyArray<OHLCDataPoint>,
   ): void;
   /**
-   * Gets the current “interaction x” in domain units (or `null` when inactive).
+   * Gets the current ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œinteraction xÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â in domain units (or `null` when inactive).
    *
    * This is derived from pointer movement inside the plot grid and can also be driven
    * externally via `setInteractionX(...)` (e.g. chart sync).
    */
   getInteractionX(): number | null;
   /**
-   * Drives the chart’s crosshair + tooltip from a domain-space x value.
+   * Drives the chartÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¾ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢s crosshair + tooltip from a domain-space x value.
    *
    * Passing `null` clears the interaction (hides crosshair/tooltip).
    */
@@ -378,131 +386,129 @@ const extendBoundsWithOHLCDataPoints = (
   return { xMin, xMax, yMin, yMax };
 };
 
-const computeGlobalBounds = (
+const computeGlobalXBounds = (
   series: ResolvedChartGPUOptions["series"],
   runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null,
-): Bounds => {
+): { xMin: number; xMax: number } => {
   let xMin = Number.POSITIVE_INFINITY;
   let xMax = Number.NEGATIVE_INFINITY;
-  let yMin = Number.POSITIVE_INFINITY;
-  let yMax = Number.NEGATIVE_INFINITY;
 
   for (let s = 0; s < series.length; s++) {
     const seriesConfig = series[s];
-    // Pie series are non-cartesian; they don't participate in x/y bounds.
     if (seriesConfig.type === "pie") continue;
 
     const runtimeBoundsCandidate = runtimeRawBoundsByIndex?.[s] ?? null;
     if (runtimeBoundsCandidate) {
       const b = runtimeBoundsCandidate;
-      if (
-        Number.isFinite(b.xMin) &&
-        Number.isFinite(b.xMax) &&
-        Number.isFinite(b.yMin) &&
-        Number.isFinite(b.yMax)
-      ) {
+      if (Number.isFinite(b.xMin) && Number.isFinite(b.xMax)) {
         if (b.xMin < xMin) xMin = b.xMin;
         if (b.xMax > xMax) xMax = b.xMax;
-        if (b.yMin < yMin) yMin = b.yMin;
-        if (b.yMax > yMax) yMax = b.yMax;
         continue;
       }
     }
 
-    // Prefer precomputed bounds from the original (unsampled) data when available.
-    // This ensures sampling cannot affect axis auto-bounds and avoids per-render O(n) scans.
     const rawBoundsCandidate = seriesConfig.rawBounds;
     if (rawBoundsCandidate) {
       const b = rawBoundsCandidate;
-      if (
-        Number.isFinite(b.xMin) &&
-        Number.isFinite(b.xMax) &&
-        Number.isFinite(b.yMin) &&
-        Number.isFinite(b.yMax)
-      ) {
+      if (Number.isFinite(b.xMin) && Number.isFinite(b.xMax)) {
         if (b.xMin < xMin) xMin = b.xMin;
         if (b.xMax > xMax) xMax = b.xMax;
-        if (b.yMin < yMin) yMin = b.yMin;
-        if (b.yMax > yMax) yMax = b.yMax;
         continue;
       }
     }
 
-    // Candlestick series: bounds should be precomputed in OptionResolver from timestamp/low/high.
-    // If we reach here, `rawBounds` was undefined; fall back to a raw OHLC scan so axes don't break.
     if (seriesConfig.type === "candlestick") {
-      const rawOHLC = (seriesConfig.rawData ??
-        seriesConfig.data) as ReadonlyArray<OHLCDataPoint>;
+      const rawOHLC = (seriesConfig.rawData ?? seriesConfig.data) as ReadonlyArray<OHLCDataPoint>;
       for (let i = 0; i < rawOHLC.length; i++) {
         const p = rawOHLC[i]!;
-        if (isTupleOHLCDataPoint(p)) {
-          const timestamp = p[0];
-          const low = p[3];
-          const high = p[4];
-          if (
-            !Number.isFinite(timestamp) ||
-            !Number.isFinite(low) ||
-            !Number.isFinite(high)
-          )
-            continue;
-
-          const yLow = Math.min(low, high);
-          const yHigh = Math.max(low, high);
-
-          if (timestamp < xMin) xMin = timestamp;
-          if (timestamp > xMax) xMax = timestamp;
-          if (yLow < yMin) yMin = yLow;
-          if (yHigh > yMax) yMax = yHigh;
-        } else {
-          const timestamp = p.timestamp;
-          const low = p.low;
-          const high = p.high;
-          if (
-            !Number.isFinite(timestamp) ||
-            !Number.isFinite(low) ||
-            !Number.isFinite(high)
-          )
-            continue;
-
-          const yLow = Math.min(low, high);
-          const yHigh = Math.max(low, high);
-
-          if (timestamp < xMin) xMin = timestamp;
-          if (timestamp > xMax) xMax = timestamp;
-          if (yLow < yMin) yMin = yLow;
-          if (yHigh > yMax) yMax = yHigh;
-        }
+        const timestamp = isTupleOHLCDataPoint(p) ? p[0] : p.timestamp;
+        if (!Number.isFinite(timestamp)) continue;
+        if (timestamp < xMin) xMin = timestamp;
+        if (timestamp > xMax) xMax = timestamp;
       }
       continue;
     }
 
-    // Cartesian series (line, area, bar, scatter): use CartesianSeriesData accessors
     const data = seriesConfig.data as CartesianSeriesData;
     const n = getPointCount(data);
     for (let i = 0; i < n; i++) {
       const x = getX(data, i);
-      const y = getY(data, i);
-      if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+      if (!Number.isFinite(x)) continue;
       if (x < xMin) xMin = x;
       if (x > xMax) xMax = x;
+    }
+  }
+
+  if (!Number.isFinite(xMin) || !Number.isFinite(xMax)) {
+    return { xMin: 0, xMax: 1 };
+  }
+  if (xMin === xMax) xMax = xMin + 1;
+  return { xMin, xMax };
+};
+
+const computeGlobalYBoundsForAxis = (
+  series: ResolvedChartGPUOptions["series"],
+  axisId: string,
+  runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null,
+): { yMin: number; yMax: number } => {
+  let yMin = Number.POSITIVE_INFINITY;
+  let yMax = Number.NEGATIVE_INFINITY;
+
+  for (let s = 0; s < series.length; s++) {
+    const seriesConfig = series[s];
+    if (seriesConfig.type === "pie") continue;
+    if (seriesConfig.yAxis !== axisId) continue;
+
+    const runtimeBoundsCandidate = runtimeRawBoundsByIndex?.[s] ?? null;
+    if (runtimeBoundsCandidate) {
+      const b = runtimeBoundsCandidate;
+      if (Number.isFinite(b.yMin) && Number.isFinite(b.yMax)) {
+        if (b.yMin < yMin) yMin = b.yMin;
+        if (b.yMax > yMax) yMax = b.yMax;
+        continue;
+      }
+    }
+
+    const rawBoundsCandidate = seriesConfig.rawBounds;
+    if (rawBoundsCandidate) {
+      const b = rawBoundsCandidate;
+      if (Number.isFinite(b.yMin) && Number.isFinite(b.yMax)) {
+        if (b.yMin < yMin) yMin = b.yMin;
+        if (b.yMax > yMax) yMax = b.yMax;
+        continue;
+      }
+    }
+
+    if (seriesConfig.type === "candlestick") {
+      const rawOHLC = (seriesConfig.rawData ?? seriesConfig.data) as ReadonlyArray<OHLCDataPoint>;
+      for (let i = 0; i < rawOHLC.length; i++) {
+        const p = rawOHLC[i]!;
+        const low = isTupleOHLCDataPoint(p) ? p[3] : p.low;
+        const high = isTupleOHLCDataPoint(p) ? p[4] : p.high;
+        if (!Number.isFinite(low) || !Number.isFinite(high)) continue;
+        const yLow = Math.min(low, high);
+        const yHigh = Math.max(low, high);
+        if (yLow < yMin) yMin = yLow;
+        if (yHigh > yMax) yMax = yHigh;
+      }
+      continue;
+    }
+
+    const data = seriesConfig.data as CartesianSeriesData;
+    const n = getPointCount(data);
+    for (let i = 0; i < n; i++) {
+      const y = getY(data, i);
+      if (!Number.isFinite(y)) continue;
       if (y < yMin) yMin = y;
       if (y > yMax) yMax = y;
     }
   }
 
-  if (
-    !Number.isFinite(xMin) ||
-    !Number.isFinite(xMax) ||
-    !Number.isFinite(yMin) ||
-    !Number.isFinite(yMax)
-  ) {
-    return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+  if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) {
+    return { yMin: 0, yMax: 1 };
   }
-
-  if (xMin === xMax) xMax = xMin + 1;
   if (yMin === yMax) yMax = yMin + 1;
-
-  return { xMin, xMax, yMin, yMax };
+  return { yMin, yMax };
 };
 
 const normalizeDomain = (
@@ -820,12 +826,12 @@ const formatTimeTickValue = (
   if (visibleRangeMs < MS_PER_DAY) {
     return `${pad2(hh)}:${pad2(min)}`;
   }
-  // Treat the 7-day boundary as inclusive for the “1–7 days” tier.
+  // Treat the 7-day boundary as inclusive for the ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œ1ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“7 daysÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â tier.
   if (visibleRangeMs <= 7 * MS_PER_DAY) {
     return `${pad2(mm)}/${pad2(dd)} ${pad2(hh)}:${pad2(min)}`;
   }
   // Keep short calendar dates until the visible range reaches ~3 months.
-  // (This covers the 1–12 week requirement, plus the small 12w→3m gap.)
+  // (This covers the 1ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã‚Â¦ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã¢â‚¬Å“12 week requirement, plus the small 12wÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢3m gap.)
   if (visibleRangeMs < 3 * MS_PER_MONTH_APPROX) {
     return `${pad2(mm)}/${pad2(dd)}`;
   }
@@ -975,7 +981,7 @@ const computeBaseXDomain = (
   options: ResolvedChartGPUOptions,
   runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null,
 ): { readonly min: number; readonly max: number } => {
-  const bounds = computeGlobalBounds(options.series, runtimeRawBoundsByIndex);
+  const bounds = computeGlobalXBounds(options.series, runtimeRawBoundsByIndex);
   const baseMin = finiteOrUndefined(options.xAxis.min) ?? bounds.xMin;
   const baseMax = finiteOrUndefined(options.xAxis.max) ?? bounds.xMax;
   return normalizeDomain(baseMin, baseMax);
@@ -988,18 +994,18 @@ const computeBaseXDomain = (
  * Performance: O(n) where n = total points across all visible series data.
  * This is called only when renderSeries changes (zoom/pan/data updates), not per-frame.
  */
-const computeVisibleYBounds = (
+const computeVisibleYBoundsForAxis = (
   series: ResolvedChartGPUOptions["series"],
-): Bounds => {
+  axisId: string,
+): { yMin: number; yMax: number } => {
   let yMin = Number.POSITIVE_INFINITY;
   let yMax = Number.NEGATIVE_INFINITY;
 
   for (let s = 0; s < series.length; s++) {
     const seriesConfig = series[s];
-    // Pie series are non-cartesian; they don't participate in y bounds.
     if (seriesConfig.type === "pie") continue;
+    if (seriesConfig.yAxis !== axisId) continue;
 
-    // Candlestick series: scan low/high from visible data
     if (seriesConfig.type === "candlestick") {
       const visibleOHLC = seriesConfig.data as ReadonlyArray<OHLCDataPoint>;
       for (let i = 0; i < visibleOHLC.length; i++) {
@@ -1008,7 +1014,6 @@ const computeVisibleYBounds = (
         const high = isTupleOHLCDataPoint(p) ? p[4] : p.high;
         if (!Number.isFinite(low) || !Number.isFinite(high)) continue;
 
-        // Use Math.min/max to handle inverted low/high gracefully
         const yLow = Math.min(low, high);
         const yHigh = Math.max(low, high);
 
@@ -1018,7 +1023,6 @@ const computeVisibleYBounds = (
       continue;
     }
 
-    // Cartesian series (line, area, bar, scatter): scan y from visible data
     const data = seriesConfig.data as CartesianSeriesData;
     const n = getPointCount(data);
     for (let i = 0; i < n; i++) {
@@ -1029,44 +1033,38 @@ const computeVisibleYBounds = (
     }
   }
 
-  // Fallback for empty/invalid data: return safe default bounds
   if (!Number.isFinite(yMin) || !Number.isFinite(yMax)) {
-    return { xMin: 0, xMax: 1, yMin: 0, yMax: 1 };
+    return { yMin: 0, yMax: 1 };
   }
 
-  // Degenerate domain: add unit span to avoid zero-width range
   if (yMin === yMax) yMax = yMin + 1;
 
-  return { xMin: 0, xMax: 1, yMin, yMax };
+  return { yMin, yMax };
 };
 
-const computeBaseYDomain = (
+const computeBaseYDomainForAxis = (
   options: ResolvedChartGPUOptions,
+  axisId: string,
   runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null,
-  visibleBoundsOverride?: Bounds | null,
+  visibleBoundsOverride?: { yMin: number; yMax: number } | null,
 ): { readonly min: number; readonly max: number } => {
-  // Explicit min/max ALWAYS take precedence over auto-bounds
-  const explicitMin = finiteOrUndefined(options.yAxis.min);
-  const explicitMax = finiteOrUndefined(options.yAxis.max);
+  const yAxisConfig = options.yAxes.find((ax) => ax.id === axisId) || options.yAxes[0]!;
+  const explicitMin = finiteOrUndefined(yAxisConfig.min);
+  const explicitMax = finiteOrUndefined(yAxisConfig.max);
 
-  // If both min and max are explicit, use them directly (no auto-bounds needed)
   if (explicitMin !== undefined && explicitMax !== undefined) {
     return normalizeDomain(explicitMin, explicitMax);
   }
 
-  // Determine which bounds to use based on autoBounds mode
-  const autoBoundsMode = options.yAxis.autoBounds ?? "visible";
-  let bounds: Bounds;
+  const autoBoundsMode = yAxisConfig.autoBounds ?? "visible";
+  let bounds: { yMin: number; yMax: number };
 
   if (autoBoundsMode === "visible" && visibleBoundsOverride) {
-    // Use visible bounds from renderSeries (zoom-aware, computed from visible data only)
     bounds = visibleBoundsOverride;
   } else {
-    // Use global bounds from full dataset (pre-zoom behavior, computed from all raw data)
-    bounds = computeGlobalBounds(options.series, runtimeRawBoundsByIndex);
+    bounds = computeGlobalYBoundsForAxis(options.series, axisId, runtimeRawBoundsByIndex);
   }
 
-  // Merge explicit bounds with computed bounds (partial override support)
   const yMin = explicitMin ?? bounds.yMin;
   const yMax = explicitMax ?? bounds.yMax;
   return normalizeDomain(yMin, yMax);
@@ -1142,16 +1140,16 @@ const resolveUpdateAnimationConfig = (
  *
  * Coordinate transformations:
  * 1. Domain values (timestamp, open, close) from CandlestickMatch
- * 2. → xScale/yScale transform to grid-local CSS pixels
- * 3. → Add gridArea offset to get canvas-local CSS pixels
- * 4. → Add canvas offset to get container-local CSS pixels
+ * 2. ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ xScale/yScale transform to grid-local CSS pixels
+ * 3. ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ Add gridArea offset to get canvas-local CSS pixels
+ * 4. ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ Add canvas offset to get container-local CSS pixels
  *
  * Returns null if any coordinate computation fails (non-finite values).
  */
 const computeCandlestickTooltipAnchor = (
   match: { readonly point: OHLCDataPoint },
   xScale: LinearScale,
-  yScale: LinearScale,
+  yScales: Map<string, LinearScale>,
   gridArea: GridArea,
   canvas: HTMLCanvasElement,
 ): Readonly<{ x: number; y: number }> | null => {
@@ -1174,7 +1172,8 @@ const computeCandlestickTooltipAnchor = (
 
   // Transform to grid-local CSS pixels
   const xGridCss = xScale.scale(timestamp);
-  const yGridCss = yScale.scale(bodyMidY);
+  const yScale = yScales.values().next().value;
+  const yGridCss = yScale ? yScale.scale(bodyMidY) : 0;
 
   if (!Number.isFinite(xGridCss) || !Number.isFinite(yGridCss)) {
     return null;
@@ -1399,7 +1398,7 @@ export function createRenderCoordinator(
   type UpdateTransitionSnapshot = Readonly<{
     readonly xBaseDomain: { readonly min: number; readonly max: number };
     readonly xVisibleDomain: { readonly min: number; readonly max: number };
-    readonly yBaseDomain: { readonly min: number; readonly max: number };
+    readonly yBaseDomains: Map<string, { readonly min: number; readonly max: number }>;
     readonly series: ResolvedChartGPUOptions["series"];
   }>;
 
@@ -1608,11 +1607,13 @@ export function createRenderCoordinator(
       t01,
     );
     const xVisible = computeVisibleXDomain(xBase, zoomRange);
-    const yBase = lerpDomain(
-      transition.from.yBaseDomain,
-      transition.to.yBaseDomain,
-      t01,
-    );
+    const yBaseDomains = new Map<string, { readonly min: number; readonly max: number }>();
+    for (const ax of transition.from.series[0] ? currentOptions.yAxes : []) {
+        const axId = ax.id!;
+        const fromY = transition.from.yBaseDomains.get(axId) || { min: 0, max: 1 };
+        const toY = transition.to.yBaseDomains.get(axId) || { min: 0, max: 1 };
+        yBaseDomains.set(axId, lerpDomain(fromY, toY, t01));
+    }
     const series = interpolateSeriesForUpdate(
       transition.from.series,
       transition.to.series,
@@ -1622,7 +1623,7 @@ export function createRenderCoordinator(
     return {
       xBaseDomain: xBase,
       xVisibleDomain: { min: xVisible.min, max: xVisible.max },
-      yBaseDomain: yBase,
+      yBaseDomains,
       series,
     };
   };
@@ -1642,7 +1643,7 @@ export function createRenderCoordinator(
     options.series.length,
   ).fill(null);
 
-  // Baseline sampled series list derived from runtime raw data (used as the “full span” baseline).
+  // Baseline sampled series list derived from runtime raw data (used as the ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œfull spanÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â baseline).
   // Zoom-visible resampling is derived from this baseline + runtime raw as needed.
   let runtimeBaseSeries: ResolvedChartGPUOptions["series"] =
     currentOptions.series;
@@ -1653,24 +1654,26 @@ export function createRenderCoordinator(
 
   // Cache for visible y-bounds computed from renderSeries (for yAxis.autoBounds === 'visible').
   // Recomputed whenever renderSeries changes (zoom/pan/data updates).
-  let cachedVisibleYBounds: Bounds | null = null;
+  let cachedVisibleYBoundsByAxis: Map<string, { yMin: number; yMax: number }> = new Map();
 
-  const shouldComputeVisibleYBounds = (
+  const shouldComputeVisibleYBoundsForAxis = (
     opts: ResolvedChartGPUOptions,
+    axisId: string,
   ): boolean => {
-    const autoBoundsMode = opts.yAxis.autoBounds ?? "visible";
+    const yAxisConfig = opts.yAxes.find((ax) => ax.id === axisId) || opts.yAxes[0]!;
+    const autoBoundsMode = yAxisConfig.autoBounds ?? "visible";
     if (autoBoundsMode !== "visible") return false;
-    // If both bounds are explicit, auto-bounds (including visible) are never consulted.
-    const explicitMin = finiteOrUndefined(opts.yAxis.min);
-    const explicitMax = finiteOrUndefined(opts.yAxis.max);
+    const explicitMin = finiteOrUndefined(yAxisConfig.min);
+    const explicitMax = finiteOrUndefined(yAxisConfig.max);
     return !(explicitMin !== undefined && explicitMax !== undefined);
   };
 
   const recomputeCachedVisibleYBoundsIfNeeded = (): void => {
-    if (shouldComputeVisibleYBounds(currentOptions)) {
-      cachedVisibleYBounds = computeVisibleYBounds(renderSeries);
-    } else {
-      cachedVisibleYBounds = null;
+    cachedVisibleYBoundsByAxis.clear();
+    for (const ax of currentOptions.yAxes) {
+      if (shouldComputeVisibleYBoundsForAxis(currentOptions, ax.id!)) {
+        cachedVisibleYBoundsByAxis.set(ax.id!, computeVisibleYBoundsForAxis(renderSeries, ax.id!));
+      }
     }
   };
 
@@ -1759,21 +1762,18 @@ export function createRenderCoordinator(
     sampleCount: MAIN_SCENE_MSAA_SAMPLE_COUNT,
     pipelineCache,
   });
-  // Axis and crosshair renderers draw into the top overlay pass (swapchain, single-sample) — keep sampleCount: 1.
+  // Axis and crosshair renderers draw into the top overlay pass (swapchain, single-sample) ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â keep sampleCount: 1.
   const xAxisRenderer = createAxisRenderer(device, {
     targetFormat,
     pipelineCache,
   });
-  const yAxisRenderer = createAxisRenderer(device, {
-    targetFormat,
-    pipelineCache,
-  });
+  const yAxisRenderers = new Map<string, ReturnType<typeof createAxisRenderer>>();
   const crosshairRenderer = createCrosshairRenderer(device, {
     targetFormat,
     pipelineCache,
   });
   crosshairRenderer.setVisible(false);
-  // Highlight renders into the top overlay pass (swapchain, single-sample) — keep sampleCount: 1.
+  // Highlight renders into the top overlay pass (swapchain, single-sample) ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â keep sampleCount: 1.
   const highlightRenderer = createHighlightRenderer(device, {
     targetFormat,
     pipelineCache,
@@ -1852,7 +1852,7 @@ export function createRenderCoordinator(
   // Cached interaction scales from the last render (used for pointer -> domain-x mapping).
   let lastInteractionScales: {
     readonly xScale: LinearScale;
-    readonly yScale: LinearScale;
+    readonly yScales: Map<string, LinearScale>;
     readonly plotWidthCss: number;
     readonly plotHeightCss: number;
   } | null = null;
@@ -1919,7 +1919,7 @@ export function createRenderCoordinator(
       currentOptions.xAxis.min == null &&
       currentOptions.xAxis.max == null;
 
-    // Capture the pre-append visible domain so we can preserve it for “panned away” behavior.
+    // Capture the pre-append visible domain so we can preserve it for ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œpanned awayÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â behavior.
     const prevBaseXDomain = computeBaseXDomain(
       currentOptions,
       runtimeRawBoundsByIndex,
@@ -2244,11 +2244,11 @@ export function createRenderCoordinator(
     gridArea: GridArea,
     domains: {
       readonly xDomain: { readonly min: number; readonly max: number };
-      readonly yDomain: { readonly min: number; readonly max: number };
+      readonly yDomains: Map<string, { readonly min: number; readonly max: number }>;
     },
   ): {
     readonly xScale: LinearScale;
-    readonly yScale: LinearScale;
+    readonly yScales: Map<string, LinearScale>;
     readonly plotWidthCss: number;
     readonly plotHeightCss: number;
   } | null => {
@@ -2258,22 +2258,20 @@ export function createRenderCoordinator(
     const plotSize = getPlotSizeCssPx(canvas, gridArea);
     if (!plotSize) return null;
 
-    // IMPORTANT: grid-local CSS px ranges (0..plotWidth/Height), for interaction hit-testing.
     const xScale = createLinearScale()
       .domain(domains.xDomain.min, domains.xDomain.max)
       .range(0, plotSize.plotWidthCss);
-    const yScale = createLinearScale()
-      .domain(domains.yDomain.min, domains.yDomain.max)
-      .range(plotSize.plotHeightCss, 0);
+    const yScales = new Map<string, LinearScale>();
+    for (const [id, dom] of domains.yDomains) {
+      yScales.set(id, createLinearScale().domain(dom.min, dom.max).range(plotSize.plotHeightCss, 0));
+    }
 
-    const result = {
+    return {
       xScale,
-      yScale,
+      yScales,
       plotWidthCss: plotSize.plotWidthCss,
       plotHeightCss: plotSize.plotHeightCss,
     };
-
-    return result;
   };
 
   const buildTooltipParams = (
@@ -2383,18 +2381,18 @@ export function createRenderCoordinator(
       const barWidthClip = computeCandlestickBodyWidthRange(
         cs,
         cs.data,
-        interactionScales.xScale,
-        interactionScales.plotWidthCss,
-      );
-
-      const m = findCandlestick(
-        [cs],
-        gridX,
-        gridY,
-        interactionScales.xScale,
-        interactionScales.yScale,
-        barWidthClip,
-      );
+            interactionScales.xScale,
+            interactionScales.plotWidthCss,
+          );
+          
+          const m = findCandlestick(
+            [cs],
+            gridX,
+            gridY,
+            interactionScales.xScale,
+            interactionScales.yScales.get((s as any).yAxis || "y")!,
+            barWidthClip,
+          );
       if (!m) continue;
 
       const params = buildCandlestickTooltipParams(i, m.dataIndex, m.point);
@@ -2423,7 +2421,7 @@ export function createRenderCoordinator(
         "mouse",
       );
     } else if (!payload.isInGrid) {
-      // Clear interaction-x when leaving the plot area (keeps synced charts from “sticking”).
+      // Clear interaction-x when leaving the plot area (keeps synced charts from ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œstickingÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â).
       setInteractionXInternal(null, "mouse");
     }
 
@@ -2449,7 +2447,7 @@ export function createRenderCoordinator(
     eventManager.on("mouseleave", onMouseLeave);
   }
 
-  // Optional internal “inside zoom” (wheel zoom + drag pan).
+  // Optional internal ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œinside zoomÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â (wheel zoom + drag pan).
   let zoomState: ZoomState | null = null;
   let insideZoom: ReturnType<typeof createInsideZoom> | null = null;
   let unsubscribeZoom: (() => void) | null = null;
@@ -2812,7 +2810,7 @@ export function createRenderCoordinator(
     );
     const visibleX = computeVisibleXDomain(baseXDomain, zoomRange);
 
-    // Add buffer zone (±10% beyond visible range) for caching
+    // Add buffer zone (ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â±10% beyond visible range) for caching
     const bufferFactor = 0.1;
     const visibleSpan = visibleX.max - visibleX.min;
     const bufferSize = visibleSpan * bufferFactor;
@@ -3057,15 +3055,22 @@ export function createRenderCoordinator(
         runtimeRawBoundsByIndex,
       );
       const fromXVisible = computeVisibleXDomain(fromXBase, fromZoomRange);
-      const fromYBase = computeBaseYDomain(
-        currentOptions,
-        runtimeRawBoundsByIndex,
-        cachedVisibleYBounds,
-      );
+      const fromYBaseDomains = new Map<string, { min: number; max: number }>();
+      for (const ax of currentOptions.yAxes) {
+        fromYBaseDomains.set(
+          ax.id!,
+          computeBaseYDomainForAxis(
+            currentOptions,
+            ax.id!,
+            runtimeRawBoundsByIndex,
+            cachedVisibleYBoundsByAxis.get(ax.id!) ?? null,
+          ),
+        );
+      }
       return {
         xBaseDomain: fromXBase,
         xVisibleDomain: { min: fromXVisible.min, max: fromXVisible.max },
-        yBaseDomain: fromYBase,
+        yBaseDomains: fromYBaseDomains,
         series: renderSeries,
       };
     })();
@@ -3080,7 +3085,7 @@ export function createRenderCoordinator(
     currentOptions = resolvedOptions;
 
     if (likelyDataChanged) {
-      // Series data or structure changed — full reset of runtime data state.
+      // Series data or structure changed ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â full reset of runtime data state.
       runtimeBaseSeries = resolvedOptions.series;
       renderSeries = resolvedOptions.series;
       gpuSeriesKindByIndex = new Array(resolvedOptions.series.length).fill(
@@ -3094,7 +3099,7 @@ export function createRenderCoordinator(
     }
 
     // Always refresh: annotations, themes, tooltip config, etc. may have changed.
-    cachedVisibleYBounds = null;
+    cachedVisibleYBoundsByAxis.clear();
     legend?.update(resolvedOptions.series, resolvedOptions.theme);
     recomputeRuntimeBaseSeries();
     updateZoom();
@@ -3153,16 +3158,27 @@ export function createRenderCoordinator(
     const toZoomRange = zoomState?.getRange() ?? null;
     const toXBase = computeBaseXDomain(currentOptions, runtimeRawBoundsByIndex);
     const toXVisible = computeVisibleXDomain(toXBase, toZoomRange);
-    const toYBase = computeBaseYDomain(
-      currentOptions,
-      runtimeRawBoundsByIndex,
-      cachedVisibleYBounds,
-    );
+    const toYBaseDomains = new Map<string, { min: number; max: number }>();
+    for (const ax of currentOptions.yAxes) {
+      toYBaseDomains.set(
+        ax.id!,
+        computeBaseYDomainForAxis(
+          currentOptions,
+          ax.id!,
+          runtimeRawBoundsByIndex,
+          cachedVisibleYBoundsByAxis.get(ax.id!) ?? null,
+        ),
+      );
+    }
     const toSeriesForTransition = renderSeries;
 
+    // Compare primary axis domain for change detection
+    const primaryAxisId = currentOptions.yAxes[0]?.id ?? "y";
+    const fromPrimaryY = fromSnapshot.yBaseDomains.get(primaryAxisId) ?? { min: 0, max: 1 };
+    const toPrimaryY = toYBaseDomains.get(primaryAxisId) ?? { min: 0, max: 1 };
     const domainChanged =
       !isDomainEqual(fromSnapshot.xBaseDomain, toXBase) ||
-      !isDomainEqual(fromSnapshot.yBaseDomain, toYBase);
+      !isDomainEqual(fromPrimaryY, toPrimaryY);
 
     const shouldAnimateUpdate =
       hasRenderedOnce && (domainChanged || likelyDataChanged);
@@ -3179,13 +3195,13 @@ export function createRenderCoordinator(
       from: {
         xBaseDomain: fromSnapshot.xBaseDomain,
         xVisibleDomain: fromSnapshot.xVisibleDomain,
-        yBaseDomain: fromSnapshot.yBaseDomain,
+        yBaseDomains: fromSnapshot.yBaseDomains,
         series: fromSnapshot.series,
       },
       to: {
         xBaseDomain: toXBase,
         xVisibleDomain: { min: toXVisible.min, max: toXVisible.max },
-        yBaseDomain: toYBase,
+        yBaseDomains: toYBaseDomains,
         series: toSeriesForTransition,
       },
     };
@@ -3397,17 +3413,6 @@ export function createRenderCoordinator(
           updateP,
         )
       : computeBaseXDomain(currentOptions, runtimeRawBoundsByIndex);
-    const yBaseDomain = updateTransition
-      ? lerpDomain(
-          updateTransition.from.yBaseDomain,
-          updateTransition.to.yBaseDomain,
-          updateP,
-        )
-      : computeBaseYDomain(
-          currentOptions,
-          runtimeRawBoundsByIndex,
-          cachedVisibleYBounds,
-        );
     const visibleXDomain = computeVisibleXDomain(baseXDomain, zoomRange);
 
     const plotClipRect = computePlotClipRect(gridArea);
@@ -3416,9 +3421,35 @@ export function createRenderCoordinator(
     const xScale = createLinearScale()
       .domain(visibleXDomain.min, visibleXDomain.max)
       .range(plotClipRect.left, plotClipRect.right);
-    const yScale = createLinearScale()
-      .domain(yBaseDomain.min, yBaseDomain.max)
-      .range(plotClipRect.bottom, plotClipRect.top);
+
+    // Compute per-axis y domains (with transition interpolation if active)
+    const currentYScales = new Map<string, LinearScale>();
+    const currentYDomains = new Map<string, { readonly min: number; readonly max: number }>();
+    for (const ax of currentOptions.yAxes) {
+      const axisId = ax.id!;
+      let dom: { min: number; max: number };
+      if (updateTransition && updateP < 1) {
+        const fromY = updateTransition.from.yBaseDomains.get(axisId) ?? { min: 0, max: 1 };
+        const toY = updateTransition.to.yBaseDomains.get(axisId) ?? { min: 0, max: 1 };
+        dom = lerpDomain(fromY, toY, updateP);
+      } else {
+        dom = computeBaseYDomainForAxis(
+          currentOptions,
+          axisId,
+          runtimeRawBoundsByIndex,
+          cachedVisibleYBoundsByAxis.get(axisId) ?? null,
+        );
+      }
+      currentYDomains.set(axisId, dom);
+      currentYScales.set(
+        axisId,
+        createLinearScale()
+          .domain(dom.min, dom.max)
+          .range(plotClipRect.bottom, plotClipRect.top),
+      );
+    }
+    // Primary y scale (for bars, highlight, single-axis usage)
+    const yScale = currentYScales.values().next().value!;
 
     // PERFORMANCE: Cache canvas CSS dimensions (used for both GPU overlays and label processing)
     // Annotations (GPU overlays) are specified in data-space and converted to CANVAS-LOCAL CSS pixels.
@@ -3455,7 +3486,7 @@ export function createRenderCoordinator(
     const annotationResult = processAnnotations({
       annotations,
       xScale,
-      yScale,
+      yScales: currentYScales,
       plotBounds: {
         leftCss: plotLeftCss,
         rightCss: plotRightCss,
@@ -3524,7 +3555,7 @@ export function createRenderCoordinator(
 
     const interactionScales = computeInteractionScalesGridCssPx(gridArea, {
       xDomain: { min: visibleXDomain.min, max: visibleXDomain.max },
-      yDomain: yBaseDomain,
+      yDomains: currentYDomains,
     });
     lastInteractionScales = interactionScales;
 
@@ -3593,14 +3624,14 @@ export function createRenderCoordinator(
       {
         gridRenderer,
         xAxisRenderer,
-        yAxisRenderer,
+        yAxisRenderers,
         crosshairRenderer,
         highlightRenderer,
       },
       {
         currentOptions,
         xScale,
-        yScale,
+        yScales: currentYScales,
         gridArea,
         xTickCount,
         hasCartesianSeries,
@@ -3753,7 +3784,7 @@ export function createRenderCoordinator(
                   const anchor = computeCandlestickTooltipAnchor(
                     candlestickResult.match,
                     interactionScales.xScale,
-                    interactionScales.yScale,
+                    interactionScales.yScales,
                     gridArea,
                     canvas,
                   );
@@ -3798,7 +3829,7 @@ export function createRenderCoordinator(
                   const anchor = computeCandlestickTooltipAnchor(
                     candlestickResult.match,
                     interactionScales.xScale,
-                    interactionScales.yScale,
+                    interactionScales.yScales,
                     gridArea,
                     canvas,
                   );
@@ -3878,7 +3909,7 @@ export function createRenderCoordinator(
                 const anchor = computeCandlestickTooltipAnchor(
                   candlestickResult.match,
                   interactionScales.xScale,
-                  interactionScales.yScale,
+                  interactionScales.yScales,
                   gridArea,
                   canvas,
                 );
@@ -3910,7 +3941,7 @@ export function createRenderCoordinator(
               effectivePointer.gridX,
               effectivePointer.gridY,
               interactionScales.xScale,
-              interactionScales.yScale,
+              interactionScales.yScales.values().next().value!,
             );
             if (!match) {
               hideTooltip();
@@ -3967,7 +3998,7 @@ export function createRenderCoordinator(
       currentOptions,
       seriesForRender,
       xScale,
-      yScale,
+      yScales: currentYScales,
       gridArea,
       dataStore,
       appendedGpuThisFrame,
@@ -4003,7 +4034,7 @@ export function createRenderCoordinator(
 
     // Prepare annotation GPU overlays (reference lines + point markers).
     // Note: these renderers expect CANVAS-LOCAL CSS pixel coordinates; the coordinator owns
-    // data-space → canvas-space conversion and plot scissor state.
+    // data-space ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ canvas-space conversion and plot scissor state.
     if (hasCartesianSeries) {
       referenceLineRenderer.prepare(gridArea, combinedReferenceLines);
       referenceLineRendererMsaa.prepare(gridArea, combinedReferenceLines);
@@ -4105,7 +4136,7 @@ export function createRenderCoordinator(
 
     mainPass.end();
 
-    // MSAA annotation overlay pass: blit main color → MSAA target, then draw above-series annotations.
+    // MSAA annotation overlay pass: blit main color ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¾ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ MSAA target, then draw above-series annotations.
     const overlayPass = encoder.beginRenderPass({
       label: "renderCoordinator/annotationOverlayMsaaPass",
       colorAttachments: [
@@ -4160,7 +4191,9 @@ export function createRenderCoordinator(
     highlightRenderer.render(topOverlayPass);
     if (hasCartesianSeries) {
       xAxisRenderer.render(topOverlayPass);
-      yAxisRenderer.render(topOverlayPass);
+      for (const r of yAxisRenderers.values()) {
+        r.render(topOverlayPass);
+      }
     }
     crosshairRenderer.render(topOverlayPass);
 
@@ -4174,17 +4207,42 @@ export function createRenderCoordinator(
       gpuContext,
       currentOptions,
       xScale,
-      yScale,
       xTickValues,
       plotClipRect,
       visibleXRangeMs,
     });
 
+    // Generate Y-axis labels for each axis
+    const canvas2 = gpuContext.canvas as HTMLCanvasElement | null;
+    if (canvas2) {
+      const canvasCssW = getCanvasCssWidth(canvas2);
+      const canvasCssH = getCanvasCssHeight(canvas2);
+      const offX = canvas2.offsetLeft || 0;
+      const offY = canvas2.offsetTop || 0;
+      for (const yAxisConfig of currentOptions.yAxes) {
+        const axisId = yAxisConfig.id!;
+        const yScaleForAxis = currentYScales.get(axisId);
+        if (!yScaleForAxis) continue;
+        renderYAxisLabels({
+          axisLabelOverlay,
+          overlayContainer,
+          yAxisConfig,
+          yScale: yScaleForAxis,
+          plotClipRect,
+          canvasCssWidth: canvasCssW,
+          canvasCssHeight: canvasCssH,
+          offsetX: offX,
+          offsetY: offY,
+          theme: currentOptions.theme,
+        });
+      }
+    }
+
     // Generate annotation labels (DOM overlay)
     renderAnnotationLabels(annotationOverlay, overlayContainer, {
       currentOptions,
       xScale,
-      yScale,
+      yScales: currentYScales,
       canvasCssWidthForAnnotations,
       canvasCssHeightForAnnotations,
       plotLeftCss,
@@ -4243,7 +4301,8 @@ export function createRenderCoordinator(
 
     gridRenderer.dispose();
     xAxisRenderer.dispose();
-    yAxisRenderer.dispose();
+    for (const r of yAxisRenderers.values()) r.dispose();
+yAxisRenderers.clear();
     referenceLineRenderer.dispose();
     annotationMarkerRenderer.dispose();
     referenceLineRendererMsaa.dispose();
@@ -4268,7 +4327,7 @@ export function createRenderCoordinator(
     assertNotDisposed();
     const normalized = x !== null && Number.isFinite(x) ? x : null;
 
-    // External interaction should not depend on y, so we treat it as “sync” mode.
+    // External interaction should not depend on y, so we treat it as ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€šÃ‚Â¦ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦ÃƒÂ¢Ã¢â€šÂ¬Ã…â€œsyncÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Â ÃƒÂ¢Ã¢â€šÂ¬Ã¢â€žÂ¢ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã¢â‚¬Â¦Ãƒâ€šÃ‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â¬ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã†â€™ÃƒÂ¢Ã¢â€šÂ¬Ã…Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â mode.
     pointerState = {
       ...pointerState,
       source: normalized === null ? "mouse" : "sync",

--- a/src/core/renderCoordinator/annotations/__tests__/processAnnotations.test.ts
+++ b/src/core/renderCoordinator/annotations/__tests__/processAnnotations.test.ts
@@ -30,10 +30,13 @@ function createContext(
   const xScale = createLinearScale().domain(0, 100).range(-1, 1);
   const yScale = createLinearScale().domain(0, 100).range(1, -1);
 
+  const yScales = new Map<string, ReturnType<typeof createLinearScale>>();
+  yScales.set("primary", yScale);
+
   return {
     annotations,
     xScale,
-    yScale,
+    yScales,
     plotBounds: {
       leftCss: 60,
       rightCss: 20,

--- a/src/core/renderCoordinator/annotations/processAnnotations.ts
+++ b/src/core/renderCoordinator/annotations/processAnnotations.ts
@@ -57,7 +57,7 @@ export interface PlotBounds {
 export interface AnnotationContext {
   readonly annotations: ReadonlyArray<AnnotationConfig>;
   readonly xScale: LinearScale;
-  readonly yScale: LinearScale;
+  readonly yScales: Map<string, LinearScale>;
   readonly plotBounds: PlotBounds;
   readonly canvasCssWidth: number;
   readonly canvasCssHeight: number;
@@ -203,7 +203,7 @@ export function processAnnotations(
   const {
     annotations,
     xScale,
-    yScale,
+    yScales,
     plotBounds,
     canvasCssWidth,
     canvasCssHeight,
@@ -211,6 +211,10 @@ export function processAnnotations(
     offsetX = 0,
     offsetY = 0,
   } = context;
+
+  // Use the primary y-axis scale (first entry) for annotation positioning.
+  // Future work: support per-annotation yAxis binding.
+  const yScale = yScales.values().next().value ?? xScale;
 
   const {
     leftCss: plotLeftCss,

--- a/src/core/renderCoordinator/axis/axisLabelHelpers.ts
+++ b/src/core/renderCoordinator/axis/axisLabelHelpers.ts
@@ -74,6 +74,20 @@ export function getYAxisLabelX(
 }
 
 /**
+ * Calculates the X position for right y-axis labels.
+ *
+ * @param plotRightCss - Right edge of plot area in CSS pixels
+ * @param tickLengthCssPx - Length of tick marks
+ * @returns X position in CSS pixels (canvas-local)
+ */
+export function getRightYAxisLabelX(
+  plotRightCss: number,
+  tickLengthCssPx: number,
+): number {
+  return plotRightCss + tickLengthCssPx + LABEL_PADDING_CSS_PX;
+}
+
+/**
  * Calculates the Y position for the x-axis title.
  *
  * The title is centered vertically between the tick labels and the bottom edge
@@ -123,6 +137,25 @@ export function getYAxisTitleX(
 ): number {
   const yTickLabelLeft = yLabelX - maxTickLabelWidth;
   return yTickLabelLeft - LABEL_PADDING_CSS_PX - titleFontSize * 0.5;
+}
+
+/**
+ * Calculates the X position for the right y-axis title.
+ *
+ * The title is positioned to the right of the tick labels, accounting for their width.
+ *
+ * @param yLabelX - X position of right y-axis tick labels
+ * @param maxTickLabelWidth - Maximum width of tick labels in CSS pixels
+ * @param titleFontSize - Font size for axis title
+ * @returns X position for y-axis title in CSS pixels
+ */
+export function getRightYAxisTitleX(
+  yLabelX: number,
+  maxTickLabelWidth: number,
+  titleFontSize: number,
+): number {
+  const yTickLabelRight = yLabelX + maxTickLabelWidth;
+  return yTickLabelRight + LABEL_PADDING_CSS_PX + titleFontSize * 0.5;
 }
 
 /**

--- a/src/core/renderCoordinator/axis/computeAxisTicks.ts
+++ b/src/core/renderCoordinator/axis/computeAxisTicks.ts
@@ -79,7 +79,7 @@ export function computeMaxFractionDigitsFromStep(
  */
 export function createTickFormatter(tickStep: number): Intl.NumberFormat {
   const maximumFractionDigits = computeMaxFractionDigitsFromStep(tickStep);
-  return new Intl.NumberFormat(undefined, { maximumFractionDigits });
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits });
 }
 
 /**

--- a/src/core/renderCoordinator/render/__tests__/renderAxisLabels.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/renderAxisLabels.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   renderAxisLabels,
+  renderYAxisLabels,
   type AxisLabelRenderContext,
+  type YAxisLabelRenderContext,
 } from "../renderAxisLabels";
 
 /**
@@ -67,7 +69,7 @@ function createMinimalContext(
     currentOptions: {
       series: [{ type: "line", data: [], color: "#fff", visible: true }],
       xAxis: { type: "value" },
-      yAxis: { type: "value" },
+      yAxes: [{ id: "primary", type: "value" }],
       theme: {
         fontSize: 12,
         textColor: "#ffffff",
@@ -83,10 +85,10 @@ function createMinimalContext(
       scale: (v: number) => -1 + (v / 100) * 2, // maps 0-100 to -1..+1
       invert: (c: number) => ((c + 1) / 2) * 100,
     } as any,
-    yScale: {
+    yScales: new Map([["primary", {
       scale: (v: number) => -1 + (v / 100) * 2,
       invert: (c: number) => ((c + 1) / 2) * 100,
-    } as any,
+    } as any]]),
     xTickValues: [0, 25, 50, 75, 100],
     plotClipRect: { left: -0.85, right: 0.95, top: 0.8, bottom: -0.8 },
     visibleXRangeMs: 0,
@@ -169,14 +171,28 @@ describe("renderAxisLabels", () => {
       const context = createMinimalContext({
         currentOptions: {
           ...createMinimalContext().currentOptions,
-          yAxis: {
+          yAxes: [{
+            id: "primary",
             type: "value" as const,
             tickFormatter: (v: number) => `${(v * 100).toFixed(0)}%`,
-          },
+          }],
         } as any,
       });
 
-      renderAxisLabels(overlay as any, container, context);
+      const yCtx: YAxisLabelRenderContext = {
+        axisLabelOverlay: overlay as any,
+        overlayContainer: container,
+        yAxisConfig: context.currentOptions.yAxes[0],
+        yScale: context.yScales.values().next().value!,
+        plotClipRect: context.plotClipRect,
+        canvasCssWidth: context.gpuContext.canvas.clientWidth,
+        canvasCssHeight: context.gpuContext.canvas.clientHeight,
+        offsetX: 0,
+        offsetY: 0,
+        theme: context.currentOptions.theme,
+      };
+
+      renderYAxisLabels(yCtx);
 
       const yLabels = labels.filter((l) => l.text.endsWith("%"));
       expect(yLabels.length).toBeGreaterThan(0);
@@ -189,22 +205,32 @@ describe("renderAxisLabels", () => {
       const context = createMinimalContext({
         currentOptions: {
           ...createMinimalContext().currentOptions,
-          yAxis: {
+          yAxes: [{
+            id: "primary",
             type: "value" as const,
             tickFormatter: () => null,
-          },
+          }],
         } as any,
       });
 
-      renderAxisLabels(overlay as any, container, context);
+      const yCtx: YAxisLabelRenderContext = {
+        axisLabelOverlay: overlay as any,
+        overlayContainer: container,
+        yAxisConfig: context.currentOptions.yAxes[0],
+        yScale: context.yScales.values().next().value!,
+        plotClipRect: context.plotClipRect,
+        canvasCssWidth: context.gpuContext.canvas.clientWidth,
+        canvasCssHeight: context.gpuContext.canvas.clientHeight,
+        offsetX: 0,
+        offsetY: 0,
+        theme: context.currentOptions.theme,
+      };
+
+      renderYAxisLabels(yCtx);
 
       // No y-axis labels should be rendered (all suppressed)
-      // x-axis labels still render (5 ticks), plus no y-axis labels
       const allLabels = labels.map((l) => l.text);
-      // Y-labels would normally be 5 ticks of values 0-100 range
-      // With null formatter, none should appear
-      // Only x-axis labels should be present
-      expect(allLabels.length).toBe(5); // only x-axis labels
+      expect(allLabels.length).toBe(0); // only Y-labels tested here
     });
   });
 });

--- a/src/core/renderCoordinator/render/renderAnnotationLabels.ts
+++ b/src/core/renderCoordinator/render/renderAnnotationLabels.ts
@@ -21,7 +21,7 @@ import { assertUnreachable } from "../utils/dataPointUtils";
 export interface AnnotationLabelRenderContext {
   currentOptions: ResolvedChartGPUOptions;
   xScale: LinearScale;
-  yScale: LinearScale;
+  yScales: Map<string, LinearScale>;
   canvasCssWidthForAnnotations: number;
   canvasCssHeightForAnnotations: number;
   plotLeftCss: number;
@@ -124,7 +124,7 @@ export function renderAnnotationLabels(
   const {
     currentOptions,
     xScale,
-    yScale,
+    yScales,
     canvasCssWidthForAnnotations,
     canvasCssHeightForAnnotations,
     plotLeftCss,
@@ -133,6 +133,9 @@ export function renderAnnotationLabels(
     plotHeightCss,
     canvas,
   } = context;
+
+  // Use primary y-axis scale for annotation positioning
+  const yScale = yScales.values().next().value ?? xScale;
 
   const hasCartesianSeries = currentOptions.series.some(
     (s) => s.type !== "pie",

--- a/src/core/renderCoordinator/render/renderAxisLabels.ts
+++ b/src/core/renderCoordinator/render/renderAxisLabels.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ResolvedChartGPUOptions } from "../../../config/OptionResolver";
+import type { AxisConfig } from "../../../config/types";
 import type { LinearScale } from "../../../utils/scales";
 import type {
   TextOverlay,
@@ -19,26 +20,39 @@ import { formatTimeTickValue } from "../utils/timeAxisUtils";
 import { formatTickValue, createTickFormatter } from "../axis/computeAxisTicks";
 import { finiteOrUndefined } from "../utils/dataPointUtils";
 import { getAxisTitleFontSize } from "../../../utils/axisLabelStyling";
+import {
+  getRightYAxisLabelX,
+  getYAxisLabelX,
+  getRightYAxisTitleX,
+  getYAxisTitleX,
+} from "../axis/axisLabelHelpers";
 
 const DEFAULT_TICK_LENGTH_CSS_PX = 6;
 const LABEL_PADDING_CSS_PX = 4;
 const DEFAULT_TICK_COUNT = 5;
 
+/** Context for rendering X-axis labels and titles. */
 export interface AxisLabelRenderContext {
-  gpuContext: {
-    canvas: HTMLCanvasElement | null;
-  };
-  currentOptions: ResolvedChartGPUOptions;
-  xScale: LinearScale;
-  yScale: LinearScale;
-  xTickValues: ReadonlyArray<number>;
-  plotClipRect: {
-    left: number;
-    right: number;
-    top: number;
-    bottom: number;
-  };
-  visibleXRangeMs: number;
+  readonly gpuContext: { readonly canvas: HTMLCanvasElement | null };
+  readonly currentOptions: ResolvedChartGPUOptions;
+  readonly xScale: LinearScale;
+  readonly xTickValues: readonly number[];
+  readonly plotClipRect: { left: number; right: number; top: number; bottom: number };
+  readonly visibleXRangeMs: number;
+}
+
+/** Context for rendering a single Y-axis's tick labels and title. */
+export interface YAxisLabelRenderContext {
+  readonly axisLabelOverlay: TextOverlay | null;
+  readonly overlayContainer: HTMLElement | null;
+  readonly yAxisConfig: AxisConfig;
+  readonly yScale: LinearScale;
+  readonly plotClipRect: { left: number; right: number; top: number; bottom: number };
+  readonly canvasCssWidth: number;
+  readonly canvasCssHeight: number;
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly theme: ResolvedChartGPUOptions["theme"];
 }
 
 function clipXToCanvasCssPx(xClip: number, canvasCssWidth: number): number {
@@ -61,14 +75,8 @@ function styleAxisLabelSpan(
 }
 
 /**
- * Renders axis labels and titles to the text overlay.
- *
- * Generates X and Y axis tick labels with appropriate formatting,
- * and renders axis titles if configured.
- *
- * @param axisLabelOverlay - Text overlay for rendering labels
- * @param overlayContainer - DOM container for overlay positioning
- * @param context - Rendering context with scales, options, and layout
+ * Renders X-axis tick labels, titles and clears the overlay for re-use.
+ * Y-axis labels are handled separately by renderYAxisLabels().
  */
 export function renderAxisLabels(
   axisLabelOverlay: TextOverlay | null,
@@ -79,7 +87,6 @@ export function renderAxisLabels(
     gpuContext,
     currentOptions,
     xScale,
-    yScale,
     xTickValues,
     plotClipRect,
     visibleXRangeMs,
@@ -95,24 +102,18 @@ export function renderAxisLabels(
   const canvas = gpuContext.canvas;
   if (!canvas) return;
 
-  // Get canvas dimensions
   const canvasCssWidth = getCanvasCssWidth(canvas as HTMLCanvasElement);
   const canvasCssHeight = getCanvasCssHeight(canvas as HTMLCanvasElement);
   if (canvasCssWidth <= 0 || canvasCssHeight <= 0) return;
 
-  // Calculate offsets (only for HTMLCanvasElement with DOM)
   const offsetX = (canvas as HTMLCanvasElement).offsetLeft || 0;
   const offsetY = (canvas as HTMLCanvasElement).offsetTop || 0;
 
   const plotLeftCss = clipXToCanvasCssPx(plotClipRect.left, canvasCssWidth);
   const plotRightCss = clipXToCanvasCssPx(plotClipRect.right, canvasCssWidth);
-  const plotTopCss = clipYToCanvasCssPx(plotClipRect.top, canvasCssHeight);
-  const plotBottomCss = clipYToCanvasCssPx(
-    plotClipRect.bottom,
-    canvasCssHeight,
-  );
+  const plotBottomCss = clipYToCanvasCssPx(plotClipRect.bottom, canvasCssHeight);
 
-  // Clear axis label overlay
+  // Clear axis label overlay (Y-axis labels will be re-added by renderYAxisLabels)
   axisLabelOverlay.clear();
 
   // X-axis tick labels
@@ -172,48 +173,6 @@ export function renderAxisLabels(
     styleAxisLabelSpan(span, false, currentOptions.theme);
   }
 
-  // Y-axis tick labels
-  const yTickCount = DEFAULT_TICK_COUNT;
-  const yTickLengthCssPx =
-    currentOptions.yAxis.tickLength ?? DEFAULT_TICK_LENGTH_CSS_PX;
-  const yDomainMin =
-    finiteOrUndefined(currentOptions.yAxis.min) ??
-    yScale.invert(plotClipRect.bottom);
-  const yDomainMax =
-    finiteOrUndefined(currentOptions.yAxis.max) ??
-    yScale.invert(plotClipRect.top);
-  const yTickStep =
-    yTickCount <= 1 ? 0 : (yDomainMax - yDomainMin) / (yTickCount - 1);
-  const yFormatter = createTickFormatter(yTickStep);
-  const yLabelX = plotLeftCss - yTickLengthCssPx - LABEL_PADDING_CSS_PX;
-  const ySpans: HTMLSpanElement[] = [];
-
-  const yTickFormatter = currentOptions.yAxis.tickFormatter;
-  for (let i = 0; i < yTickCount; i++) {
-    const t = yTickCount <= 1 ? 0.5 : i / (yTickCount - 1);
-    const v = yDomainMin + t * (yDomainMax - yDomainMin);
-    const yClip = yScale.scale(v);
-    const yCss = clipYToCanvasCssPx(yClip, canvasCssHeight);
-
-    const label = yTickFormatter
-      ? yTickFormatter(v)
-      : formatTickValue(yFormatter, v);
-    if (label == null) continue;
-
-    const span = axisLabelOverlay.addLabel(
-      label,
-      offsetX + yLabelX,
-      offsetY + yCss,
-      {
-        fontSize: currentOptions.theme.fontSize,
-        color: currentOptions.theme.textColor,
-        anchor: "end",
-      },
-    );
-    styleAxisLabelSpan(span, false, currentOptions.theme);
-    ySpans.push(span);
-  }
-
   // X-axis title
   const axisNameFontSize = getAxisTitleFontSize(currentOptions.theme.fontSize);
   const xAxisName = currentOptions.xAxis.name?.trim() ?? "";
@@ -240,11 +199,83 @@ export function renderAxisLabels(
     );
     styleAxisLabelSpan(span, true, currentOptions.theme);
   }
+}
+
+/**
+ * Renders tick labels and a title for a single Y-axis into the shared overlay.
+ * Called once per Y-axis after renderAxisLabels() has cleared the overlay.
+ */
+export function renderYAxisLabels(ctx: YAxisLabelRenderContext): void {
+  const {
+    axisLabelOverlay,
+    overlayContainer,
+    yAxisConfig,
+    yScale,
+    plotClipRect,
+    canvasCssWidth,
+    canvasCssHeight,
+    offsetX,
+    offsetY,
+    theme,
+  } = ctx;
+  if (!axisLabelOverlay || !overlayContainer) return;
+  if (canvasCssWidth <= 0 || canvasCssHeight <= 0) return;
+
+  const plotLeftCss = clipXToCanvasCssPx(plotClipRect.left, canvasCssWidth);
+  const plotRightCss = clipXToCanvasCssPx(plotClipRect.right, canvasCssWidth);
+  const plotTopCss = clipYToCanvasCssPx(plotClipRect.top, canvasCssHeight);
+  const plotBottomCss = clipYToCanvasCssPx(plotClipRect.bottom, canvasCssHeight);
+
+  const isRight = yAxisConfig.position === "right";
+  const yTickLengthCssPx = yAxisConfig.tickLength ?? DEFAULT_TICK_LENGTH_CSS_PX;
+
+  const yTickCount = (yAxisConfig as any).tickCount ?? DEFAULT_TICK_COUNT;
+  const yDomainMin =
+    finiteOrUndefined(yAxisConfig.min) ??
+    yScale.invert(plotClipRect.bottom);
+  const yDomainMax =
+    finiteOrUndefined(yAxisConfig.max) ??
+    yScale.invert(plotClipRect.top);
+  const yTickStep =
+    yTickCount <= 1 ? 0 : (yDomainMax - yDomainMin) / (yTickCount - 1);
+  const yFormatter = createTickFormatter(yTickStep);
+
+  const yLabelX = isRight
+    ? getRightYAxisLabelX(plotRightCss, yTickLengthCssPx)
+    : getYAxisLabelX(plotLeftCss, yTickLengthCssPx);
+
+  const ySpans: HTMLSpanElement[] = [];
+  const yTickFormatter = yAxisConfig.tickFormatter;
+
+  for (let i = 0; i < yTickCount; i++) {
+    const t = yTickCount <= 1 ? 0.5 : i / (yTickCount - 1);
+    const v = yDomainMin + t * (yDomainMax - yDomainMin);
+    const yClip = yScale.scale(v);
+    const yCss = clipYToCanvasCssPx(yClip, canvasCssHeight);
+
+    const label = yTickFormatter
+      ? yTickFormatter(v)
+      : formatTickValue(yFormatter, v);
+    if (label == null) continue;
+
+    const span = axisLabelOverlay.addLabel(
+      label,
+      offsetX + yLabelX,
+      offsetY + yCss,
+      {
+        fontSize: theme.fontSize,
+        color: theme.textColor,
+        anchor: isRight ? "start" : "end",
+      },
+    );
+    styleAxisLabelSpan(span, false, theme);
+    ySpans.push(span);
+  }
 
   // Y-axis title
-  const yAxisName = currentOptions.yAxis.name?.trim() ?? "";
+  const axisNameFontSize = getAxisTitleFontSize(theme.fontSize);
+  const yAxisName = yAxisConfig.name?.trim() ?? "";
   if (yAxisName.length > 0) {
-    // Measure actual rendered label widths from DOM
     const maxTickLabelWidth =
       ySpans.length === 0
         ? 0
@@ -254,9 +285,10 @@ export function renderAxisLabels(
           );
 
     const yCenter = (plotTopCss + plotBottomCss) / 2;
-    const yTickLabelLeft = yLabelX - maxTickLabelWidth;
-    const yTitleX =
-      yTickLabelLeft - LABEL_PADDING_CSS_PX - axisNameFontSize * 0.5;
+
+    const yTitleX = isRight
+      ? getRightYAxisTitleX(yLabelX, maxTickLabelWidth, axisNameFontSize)
+      : getYAxisTitleX(yLabelX, maxTickLabelWidth, axisNameFontSize);
 
     const span = axisLabelOverlay.addLabel(
       yAxisName,
@@ -264,11 +296,11 @@ export function renderAxisLabels(
       offsetY + yCenter,
       {
         fontSize: axisNameFontSize,
-        color: currentOptions.theme.textColor,
+        color: theme.textColor,
         anchor: "middle",
-        rotation: -90,
+        rotation: isRight ? 90 : -90,
       },
     );
-    styleAxisLabelSpan(span, true, currentOptions.theme);
+    styleAxisLabelSpan(span, true, theme);
   }
 }

--- a/src/core/renderCoordinator/render/renderOverlays.ts
+++ b/src/core/renderCoordinator/render/renderOverlays.ts
@@ -31,7 +31,7 @@ const DEFAULT_HIGHLIGHT_SIZE_CSS_PX = 4;
 export interface OverlayRenderers {
   gridRenderer: GridRenderer;
   xAxisRenderer: AxisRenderer;
-  yAxisRenderer: AxisRenderer;
+  yAxisRenderers: Map<string, AxisRenderer>;
   crosshairRenderer: CrosshairRenderer;
   highlightRenderer: HighlightRenderer;
 }
@@ -39,7 +39,7 @@ export interface OverlayRenderers {
 export interface OverlayPrepareContext {
   currentOptions: ResolvedChartGPUOptions;
   xScale: LinearScale;
-  yScale: LinearScale;
+  yScales: Map<string, LinearScale>;
   gridArea: GridArea;
   xTickCount: number;
   hasCartesianSeries: boolean;
@@ -54,7 +54,7 @@ export interface OverlayPrepareContext {
   };
   interactionScales: {
     xScale: LinearScale;
-    yScale: LinearScale;
+    yScales: Map<string, LinearScale>;
   } | null;
   seriesForRender: ReadonlyArray<any>;
   withAlpha: (color: string, alpha: number) => string;
@@ -81,7 +81,7 @@ export function prepareOverlays(
   const {
     currentOptions,
     xScale,
-    yScale,
+    yScales,
     gridArea,
     xTickCount,
     hasCartesianSeries,
@@ -90,6 +90,7 @@ export function prepareOverlays(
     seriesForRender,
     withAlpha,
   } = context;
+
 
   // Grid preparation - always prepare so hidden grids don't render stale geometry.
   const gridLinesConfig = currentOptions.gridLines;
@@ -145,15 +146,21 @@ export function prepareOverlays(
       currentOptions.theme.axisTickColor,
       xTickCount,
     );
-    renderers.yAxisRenderer.prepare(
-      currentOptions.yAxis,
-      yScale,
-      "y",
-      gridArea,
-      currentOptions.theme.axisLineColor,
-      currentOptions.theme.axisTickColor,
-      DEFAULT_TICK_COUNT,
-    );
+    for (const yAxisConfig of currentOptions.yAxes) {
+      const axisId = yAxisConfig.id!;
+      const yAxisRenderer = renderers.yAxisRenderers.get(axisId);
+      if (!yAxisRenderer) continue;
+      const axisYScale = yScales.get(axisId) ?? yScales.values().next().value!;
+      yAxisRenderer.prepare(
+        yAxisConfig,
+        axisYScale,
+        "y",
+        gridArea,
+        currentOptions.theme.axisLineColor,
+        currentOptions.theme.axisTickColor,
+        (yAxisConfig as any).tickCount ?? DEFAULT_TICK_COUNT,
+      );
+    }
   }
 
   // Crosshair preparation (when pointer is in grid)
@@ -189,13 +196,17 @@ export function prepareOverlays(
         effectivePointer.gridX,
         effectivePointer.gridY,
         interactionScales.xScale,
-        interactionScales.yScale,
+        interactionScales.yScales.values().next().value!,
       );
 
       if (match) {
         const { x, y } = getPointXY(match.point);
         const xGridCss = interactionScales.xScale.scale(x);
-        const yGridCss = interactionScales.yScale.scale(y);
+        const matchedSeriesCfg = seriesForRender[match.seriesIndex] as any;
+        const matchedAxisId = matchedSeriesCfg?.yAxis || "y";
+        const matchedYScale = interactionScales.yScales.get(matchedAxisId)
+          ?? interactionScales.yScales.values().next().value!;
+        const yGridCss = matchedYScale.scale(y);
 
         if (Number.isFinite(xGridCss) && Number.isFinite(yGridCss)) {
           const centerCssX = gridArea.left + xGridCss;
@@ -257,7 +268,9 @@ export function renderOverlays(
   renderers.highlightRenderer.render(topOverlayPass);
   if (hasCartesianSeries) {
     renderers.xAxisRenderer.render(topOverlayPass);
-    renderers.yAxisRenderer.render(topOverlayPass);
+    for (const r of renderers.yAxisRenderers.values()) {
+      r.render(topOverlayPass);
+    }
   }
   renderers.crosshairRenderer.render(topOverlayPass);
 }

--- a/src/core/renderCoordinator/render/renderSeries.ts
+++ b/src/core/renderCoordinator/render/renderSeries.ts
@@ -54,7 +54,7 @@ export interface SeriesPrepareContext {
   currentOptions: ResolvedChartGPUOptions;
   seriesForRender: ReadonlyArray<ResolvedSeriesConfig>;
   xScale: LinearScale;
-  yScale: LinearScale;
+  yScales: Map<string, LinearScale>;
   gridArea: GridArea;
   dataStore: DataStore;
   appendedGpuThisFrame: Set<number>;
@@ -126,7 +126,7 @@ export function prepareSeries(
     currentOptions,
     seriesForRender,
     xScale,
-    yScale,
+    yScales,
     gridArea,
     dataStore,
     appendedGpuThisFrame,
@@ -139,8 +139,14 @@ export function prepareSeries(
     maxRadiusCss,
   } = context;
 
+  // Helper: get the y-scale for a series by its yAxis binding
+  const getYScale = (s: ResolvedSeriesConfig): LinearScale => {
+    const axisId = (s as any).yAxis || "y";
+    return yScales.get(axisId) ?? yScales.values().next().value!;
+  };
+
   const defaultBaseline =
-    currentOptions.yAxis.min ?? currentOptions.yAxis.min ?? 0;
+    currentOptions.yAxes[0]?.min ?? 0;
   const barSeriesConfigs: ResolvedBarSeriesConfig[] = [];
 
   const introP = introPhase === "running" ? clamp01(introProgress01) : 1;
@@ -160,7 +166,7 @@ export function prepareSeries(
           s,
           areaData,
           xScale,
-          yScale,
+          getYScale(s),
           baseline,
         );
         break;
@@ -198,7 +204,7 @@ export function prepareSeries(
           lineSeriesForRenderer,
           buffer,
           xScale,
-          yScale,
+          getYScale(s),
           xOffset,
           gridArea.devicePixelRatio,
           gridArea.canvasWidth,
@@ -231,13 +237,14 @@ export function prepareSeries(
             sampling: s.sampling,
             samplingThreshold: s.samplingThreshold,
             connectNulls: s.connectNulls,
+            yAxis: (s as any).yAxis ?? "y",
           };
 
           renderers.areaRenderers[i].prepare(
             areaLike,
             areaLike.data,
             xScale,
-            yScale,
+            getYScale(s),
             defaultBaseline,
           );
         }
@@ -274,7 +281,7 @@ export function prepareSeries(
             visible.start,
             visible.end,
             xScale,
-            yScale,
+            getYScale(s),
             gridArea,
             s.rawBounds,
           );
@@ -289,7 +296,7 @@ export function prepareSeries(
             animated,
             s.data,
             xScale,
-            yScale,
+            getYScale(s),
             gridArea,
           );
         }
@@ -317,7 +324,7 @@ export function prepareSeries(
           s,
           s.data,
           xScale,
-          yScale,
+          getYScale(s),
           gridArea,
           currentOptions.theme.backgroundColor,
         );

--- a/src/core/renderCoordinator/utils/axisUtils.ts
+++ b/src/core/renderCoordinator/utils/axisUtils.ts
@@ -9,7 +9,7 @@
  * @module axisUtils
  */
 
-import type { GPUContextLike } from "../types";
+import type { GPUContextLike } from "../../createRenderCoordinator";
 import type { ResolvedChartGPUOptions } from "../../../config/OptionResolver";
 import type { GridArea } from "../../../renderers/createGridRenderer";
 import { parseCssColorToRgba01 } from "../../../utils/colors";

--- a/src/renderers/createAxisRenderer.ts
+++ b/src/renderers/createAxisRenderer.ts
@@ -214,15 +214,18 @@ const generateAxisVertices = (
       vertices[idx++] = y1;
     }
   } else {
-    // Baseline along left edge of plot rect.
-    vertices[idx++] = plotLeftClip;
+    const isRight = axisConfig.position === "right";
+    const baselineX = isRight ? plotRightClip : plotLeftClip;
+
+    // Baseline along edge of plot rect.
+    vertices[idx++] = baselineX;
     vertices[idx++] = plotBottomClip;
-    vertices[idx++] = plotLeftClip;
+    vertices[idx++] = baselineX;
     vertices[idx++] = plotTopClip;
 
-    // Ticks extend left (outside plot).
-    const x0 = plotLeftClip;
-    const x1 = x0 - tickDeltaClipX;
+    // Ticks extend outward (outside plot).
+    const x0 = baselineX;
+    const x1 = isRight ? x0 + tickDeltaClipX : x0 - tickDeltaClipX;
 
     for (let i = 0; i < tickCount; i++) {
       const t = tickCount === 1 ? 0.5 : i / (tickCount - 1);


### PR DESCRIPTION
## Description

Implements multiple independent Y-axes for ChartGPU (closes #157).

Charts can now declare an `axes.y` array with any number of Y-axes, each
with its own domain, position (`left` / `right`), label, and tick
configuration. Individual series are bound to a specific axis via the
`yAxis` string property. All existing single-axis charts continue to work
unchanged — the resolver automatically promotes the legacy `yAxis` config
to `yAxes[0]`.

**Example usage:**

```ts
ChartGPU.create(container, {
  grid: { left: 70, right: 70, top: 24, bottom: 52 },
  xAxis: { type: 'value' },
  axes: {
    y: [
      { id: 'y1', position: 'left',  name: 'Temperature (°C)', min: -5,  max: 40  },
      { id: 'y2', position: 'right', name: 'Humidity (%)',      min: 0,   max: 100 },
    ],
  },
  series: [
    { type: 'line', data: tempData,     yAxis: 'y1' },
    { type: 'line', data: humidityData, yAxis: 'y2' },
  ],
});
```

**Architecture changes:**
- `yScale` / `yAxisRenderer` singletons replaced by `Map<string, LinearScale>` and `Map<string, AxisRenderer>` throughout the render coordinator
- Per-frame domain computation is now per-axis; animated transitions interpolate domains across all axes simultaneously
- `renderAxisLabels` split into X-only rendering + a new `renderYAxisLabels` called once per axis
- Interaction hit-testing and tooltip anchoring resolve the correct scale via the series `yAxis` binding
- `createAxisRenderer` extended to render baseline and ticks on the right side

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Related Issues

Closes #157

## Testing

- [x] Tested in Chrome/Edge 113+
- [x] Added or updated examples in `examples/` — new `examples/multi-axes/` demonstrates left + right axes with three series and an animated `setOption()` update after 4 s
- [x] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested in Safari 18+
- [ ] Tested on different GPUs/platforms (if applicable)

## Documentation

- [x] Added code comments for complex logic (coordinator domain loop, per-axis scale resolution)
- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)

## WebGPU Correctness

No new GPU resources are allocated by this change. The feature operates
entirely at the scale / layout layer above the GPU renderers.

- [x] GPU resources are properly cleaned up (no new buffers or pipelines added)

## Browser Testing Checklist

- [x] Chrome 113+
- [x] Edge 113+
- [ ] Safari 18+

## Screenshots / Videos

Live example running at `examples/multi-axes/` — temperature vs.
humidity/wind with independent left and right Y-axes.

<img width="1108" height="787" alt="image" src="https://github.com/user-attachments/assets/5e0a022b-70f3-409a-beb7-a567897aed20" />


## Performance Impact

Negligible. Per-frame cost is one extra `Map` iteration over the number of
configured Y-axes (typically 2–4). No additional GPU draw calls are issued.

## Additional Notes

- The `yAxis` top-level option on `ChartGPUOptions` is still accepted and
  silently promoted to `axes.y[0]` by the resolver, so no existing charts
  need to be updated.
- Series without a `yAxis` binding default to the first axis (`axes.y[0]`).
- Right-axis tick labels and title are positioned symmetrically to the left
  axis using new `getRightYAxisLabelX` / `getRightYAxisTitleX` helpers.
- Per-annotation axis binding is out of scope for this PR; annotations
  currently use the primary (first) axis as before.

---

**For Reviewers:**

- Does this PR follow the functional-first architecture patterns? ✅ All new logic is pure functions; no classes introduced.
- Are WebGPU resources properly managed? ✅ No new GPU resources.
- Are examples updated and working? ✅ `examples/multi-axes/` added.
- Is documentation complete and accurate? ⚠️ `docs/` and `CHANGELOG.md` not yet updated — happy to add in a follow-up or here if preferred.
