### PR TITLE
feat(annotations): add bandX filled vertical region annotation

### DIFF
--- a/docs/api/annotations.md
+++ b/docs/api/annotations.md
@@ -24,7 +24,7 @@ Annotations are visual overlays that can be:
 - **Exported and imported** as JSON for persistence
 
 **Key capabilities:**
-- Vertical lines (lineX), horizontal lines (lineY), text notes, point markers
+- Vertical lines (lineX), horizontal lines (lineY), text notes, point markers, filled vertical bands (bandX)
 - Two coordinate systems: data-space (tracks with zoom/pan) and plot-space (pinned HUD-style)
 - Drag-to-reposition with type-specific constraints
 - Right-click context menu for creation, editing, and deletion
@@ -112,6 +112,38 @@ type AnnotationPosition =
 
 **Drag behavior:** Free 2D movement preserving original coordinate space
 
+### BandX (Filled Vertical Region)
+
+A filled, full-height vertical band spanning a data-space x-range. Useful for highlighting a regime, outage window, or any span along the x-axis.
+
+```typescript
+interface AnnotationBandX {
+  readonly type: 'bandX';
+  readonly from: number;           // Data-space x start
+  readonly to: number;             // Data-space x end
+}
+```
+
+```typescript
+{
+  type: 'bandX',
+  from: outageStart,
+  to: outageEnd,
+  layer: 'belowSeries',
+  style: { color: '#ef4444', opacity: 0.15 },
+}
+```
+
+**Use cases:** Outage windows, market regimes, weekends/holidays, highlighted ranges
+
+**Notes:**
+- `from`/`to` order doesn't matter; the band is drawn between whichever is smaller/larger.
+- Use `layer: 'belowSeries'` so the band sits behind the data.
+- `style.color`/`style.opacity` control the fill; `lineWidth`/`lineDash` are ignored (the band is a solid fill, not a stroked line).
+- `label` is not supported on `bandX` — pair it with a separate `text` annotation if you need a caption.
+
+**Drag behavior:** Not draggable via interactive authoring (declarative-only for now)
+
 ## Configuration
 
 All annotations share a common base configuration:
@@ -124,8 +156,9 @@ interface AnnotationConfigBase {
   readonly label?: AnnotationLabel;
 }
 
-type AnnotationConfig = (AnnotationLineX | AnnotationLineY | AnnotationPoint | AnnotationText) &
-  AnnotationConfigBase;
+type AnnotationConfig = (
+  AnnotationLineX | AnnotationLineY | AnnotationPoint | AnnotationText | AnnotationBandX
+) & AnnotationConfigBase;
 ```
 
 ### Style Configuration
@@ -711,7 +744,7 @@ canvas.addEventListener('contextmenu', (e) => {
 
 If you need a custom, non-standard visual element “inside the chart”, ChartGPU offers a few practical paths depending on how deep you need to go:
 
-- **Use built-in annotations (recommended)**: `lineX`, `lineY`, `point`, and `text` cover most “mark it / label it / highlight it” use cases and integrate with zoom/pan automatically (data-space) or stay pinned (plot-space). See [`ChartGPUOptions.annotations`](./options.md#annotations) and the examples above.
+- **Use built-in annotations (recommended)**: `lineX`, `lineY`, `point`, `text`, and `bandX` cover most “mark it / label it / highlight it” use cases and integrate with zoom/pan automatically (data-space) or stay pinned (plot-space). See [`ChartGPUOptions.annotations`](./options.md#annotations) and the examples above.
 - **Model it as data**: if your custom element can be represented as points/lines/bars, encode it as a normal series (often a `scatter` series for custom glyphs + labels via annotations).
 - **Overlay your own layer**: add an absolutely-positioned DOM/canvas/WebGPU overlay on top of the chart’s canvas. This gives you full rendering freedom without modifying ChartGPU, but you’ll need to handle coordinate transforms, DPR, and clipping to the plot area (use `options.grid` and listen to `'zoomRangeChange'` to re-render).
 - **Fork for true WebGPU injection**: ChartGPU does **not** currently expose a public “custom render pass” plugin hook into its internal WebGPU render pass. If you need arbitrary shaders/draw calls in the same pipeline, fork ChartGPU and add a renderer under `src/renderers/`, wiring it into `src/core/createRenderCoordinator.ts`. Start with [`docs/api/INTERNALS.md`](./INTERNALS.md#render-coordinator-internal) and the [renderer map](./INTERNALS.md#renderer-map-internal).

--- a/docs/guides/annotations-cookbook.md
+++ b/docs/guides/annotations-cookbook.md
@@ -29,6 +29,12 @@ const authoring = createAnnotationAuthoring(container, chart);
 { type: 'point', x: maxX, y: maxY, layer: 'aboveSeries', marker: { symbol: 'circle', size: 10, style: { color: '#22c55e' } }, label: { template: 'Peak: {y}', decimals: 2 } }
 ```
 
+### Highlighted region (outage window, regime)
+```ts
+{ type: 'bandX', from: outageStart, to: outageEnd, layer: 'belowSeries', style: { color: '#ef4444', opacity: 0.15 } }
+```
+`from`/`to` order doesn't matter. No `label` support — pair with a `text` annotation for a caption.
+
 ### Plot-space HUD (watermark, status)
 ```ts
 { type: 'text', position: { space: 'plot', x: 0.95, y: 0.05 }, text: 'LIVE', layer: 'aboveSeries', style: { color: '#22c55e' } }

--- a/examples/annotation-authoring/README.md
+++ b/examples/annotation-authoring/README.md
@@ -85,6 +85,12 @@ The demo includes example annotations demonstrating all features:
    - Position: data-space at minimum point
    - Tracks with pan/zoom
 
+6. **Regime Band** (red fill) + caption
+   - Type: `bandX`
+   - `from`/`to`: data-space x-range
+   - No label support on `bandX` — paired with a separate `text` annotation for the "regime" caption
+   - Layer: below series
+
 ## Usage
 
 ### Programmatic API

--- a/examples/annotation-authoring/main.ts
+++ b/examples/annotation-authoring/main.ts
@@ -113,6 +113,14 @@ async function main(): Promise<void> {
 
   const referenceY = Math.round((maxY * 0.35 + minY * 0.65) * 1000) / 1000;
 
+  // BandX span: a fixed-width window of x-indices, highlighting a "regime" of the series.
+  const bandFromIndex = Math.floor(data.length * 0.15);
+  const bandToIndex = Math.floor(data.length * 0.3);
+  const bandFromPoint = data[bandFromIndex]!;
+  const bandToPoint = data[bandToIndex]!;
+  const bandFromX = isTuplePoint(bandFromPoint) ? bandFromPoint[0] : bandFromPoint.x;
+  const bandToX = isTuplePoint(bandToPoint) ? bandToPoint[0] : bandToPoint.x;
+
   const options: ChartGPUOptions = {
     grid: { left: 70, right: 24, top: 24, bottom: 44 },
     xAxis: { type: 'time', name: 'Time (ms)' },
@@ -131,6 +139,25 @@ async function main(): Promise<void> {
       },
     ],
     annotations: [
+      // Filled vertical band (type: 'bandX') highlighting a regime. No label support on
+      // bandX itself — pair with a separate 'text' annotation for a caption (see below).
+      {
+        id: 'regime-band',
+        type: 'bandX',
+        from: bandFromX,
+        to: bandToX,
+        layer: 'belowSeries',
+        style: { color: '#ef4444', opacity: 0.12 },
+      },
+      {
+        id: 'regime-caption',
+        type: 'text',
+        layer: 'aboveSeries',
+        position: { space: 'data', x: bandFromX, y: 0.95 },
+        text: 'regime',
+        style: { color: '#ef4444', opacity: 0.9 },
+      },
+
       // Horizontal reference line (type: 'lineY') with dashed style + template label + decimals.
       {
         id: 'ref-y',

--- a/src/config/OptionResolver.ts
+++ b/src/config/OptionResolver.ts
@@ -380,7 +380,8 @@ const sanitizeAnnotations = (
       type !== "lineX" &&
       type !== "lineY" &&
       type !== "point" &&
-      type !== "text"
+      type !== "text" &&
+      type !== "bandX"
     )
       continue;
 
@@ -469,6 +470,22 @@ const sanitizeAnnotations = (
             return Object.keys(next).length > 0 ? next : undefined;
           })()
         : undefined;
+
+    if (type === "bandX") {
+      const from = sanitizeFiniteNumber(record.from);
+      const to = sanitizeFiniteNumber(record.to);
+      if (from == null || to == null) continue;
+      const base: AnnotationConfig = {
+        type: "bandX",
+        from,
+        to,
+        ...(id ? { id } : {}),
+        ...(layer ? { layer } : {}),
+        ...(style ? { style } : {}),
+      };
+      out.push(base);
+      continue;
+    }
 
     if (type === "lineX") {
       const x = sanitizeFiniteNumber(record.x);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -612,6 +612,14 @@ export interface AnnotationText {
   readonly text: string;
 }
 
+export interface AnnotationBandX {
+  readonly type: "bandX";
+  /** Data-space x start of the filled vertical region. */
+  readonly from: number;
+  /** Data-space x end of the filled vertical region. */
+  readonly to: number;
+}
+
 export interface AnnotationConfigBase {
   /**
    * Optional stable identifier for updates/diffing in userland.
@@ -628,6 +636,7 @@ export type AnnotationConfig = (
   | AnnotationLineY
   | AnnotationPoint
   | AnnotationText
+  | AnnotationBandX
 ) &
   AnnotationConfigBase;
 

--- a/src/core/renderCoordinator/annotations/processAnnotations.ts
+++ b/src/core/renderCoordinator/annotations/processAnnotations.ts
@@ -322,9 +322,30 @@ export function processAnnotations(
         // Text annotations are handled via DOM overlays (labels), not GPU
         break;
       }
+      case "bandX": {
+        // Filled full-height vertical region between two x-domain values, drawn
+        // by reusing the vertical reference-line quad: center it and set its
+        // width to the pixel span. Meant for `belowSeries` regime highlights.
+        const x0 = clipXToCanvasCssPx(xScale.scale(a.from), canvasCssWidth);
+        const x1 = clipXToCanvasCssPx(xScale.scale(a.to), canvasCssWidth);
+        if (!Number.isFinite(x0) || !Number.isFinite(x1)) break;
+        const width = Math.abs(x1 - x0);
+        if (!(width > 0)) break;
+        targetLines.push({
+          axis: "vertical",
+          positionCssPx: (x0 + x1) / 2,
+          lineWidth: width,
+          lineDash: undefined,
+          rgba,
+        });
+        break;
+      }
       default:
         assertUnreachable(a);
     }
+
+    // bandX carries no label and isn't part of the label switch below.
+    if (a.type === "bandX") continue;
 
     // Process annotation label (DOM overlay)
     const labelCfg = a.label;

--- a/src/core/renderCoordinator/render/renderAnnotationLabels.ts
+++ b/src/core/renderCoordinator/render/renderAnnotationLabels.ts
@@ -174,6 +174,8 @@ export function renderAnnotationLabels(
     const labelCfg = a.label;
     const wantsLabel = labelCfg != null || a.type === "text";
     if (!wantsLabel) continue;
+    // bandX regions carry no label — narrow it out of the label switch below.
+    if (a.type === "bandX") continue;
 
     // Compute anchor point (canvas-local CSS px)
     let anchorXCss: number | null = null;


### PR DESCRIPTION
Introduce a new declarative-only `bandX` annotation type for highlighting a data-space x-range (outage windows, regimes, etc.) with a filled band, reusing the existing vertical line rendering path.

- Add `AnnotationBandX` type and wire it into `AnnotationConfig`
- Sanitize/validate `bandX` in `OptionResolver`
- Render bandX as a wide vertical quad in `processAnnotations`
- Skip label handling for bandX (no label support) in both `processAnnotations` and `renderAnnotationLabels`
- Document `bandX` in API docs, cookbook, and update the annotation-authoring example with a regime band + caption

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues

<!-- Link to any related issues, e.g., "Fixes #123" or "Closes #456" -->

## Testing

<!-- Describe the testing you've performed -->

- [ ] Tested in Chrome/Edge 113+
- [ ] Tested in Safari 18+
- [ ] Added or updated examples in `examples/` (when behavior changes)
- [ ] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested on different GPUs/platforms (if applicable)

## Documentation

<!-- Documentation updates for public-facing changes -->

- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)
- [ ] Added code comments for complex logic

## WebGPU Correctness

<!-- Important checks for WebGPU code -->

- [x] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
- [x] Uniform buffer sizes are properly aligned (typically 16 bytes)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [x] Render pipeline target formats match render pass attachment formats
- [x] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)

## Browser Testing Checklist

<!-- Check the browsers you've tested in -->

- [x] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify): 

## Screenshots / Videos
<img width="1369" height="994" alt="Screenshot 2026-07-07 at 9 42 58 PM" src="https://github.com/user-attachments/assets/3d27f4b0-5cc8-41fa-a5fa-f95153c1862b" />


## Performance Impact

<!-- If this change affects performance, describe the impact and any measurements -->

## Additional Notes

<!-- Any additional information, context, or concerns -->

---

**For Reviewers:**

- Does this PR follow the functional-first architecture patterns?
- Are WebGPU resources properly managed?
- Are examples updated and working?
- Is documentation complete and accurate?
