### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

- Bump package version from `0.3.3` to `0.3.4` for the next npm publish after the performance-audit merge (#164).

## Test plan

- [ ] Confirm `package.json` version is `0.3.4`
- [ ] Publish when ready (`npm publish` / CI release flow as usual)