### PR TITLE
fix: time-axis affine, area streaming, and full-width append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GPU line decimation** - Compute-shader sampling (`lttb` / `min` / `max`, null-gap-free lines) keeps raw points resident in `DataStore` and swaps the line/area bind buffer to the decimation output each frame.
 - **Dense hairline draw policy** - High displayed-point-count line series (and multi-series segment budgets) switch draw-only to 1 device-px `line-list` outside main MSAA overdraw.
 - **Submit batcher** - Multi-chart dashboards sharing one `GPUDevice` coalesce `queue.submit` on a microtask after `renderFrame()` encode.
-- **Sticky auto-range domains** - Grow-by style headroom on auto axes reduces domain thrash under streaming append.
+- **Sticky auto-range domains** - Y uses ~10% growBy headroom under streaming amplitude noise; X tracks data max tightly (headroom 0) so unbounded `appendData` stays full-width.
+- **Device storage-cap streaming** - Unbounded `appendData` that would exceed `maxStorageBufferBindingSize` (often ~16.7M points / 128 MiB) auto-windows like `maxPoints` instead of silently desyncing domain past GPU-resident data.
 - **Multi-Chart Dashboard Cookbook** - Added comprehensive guide at `docs/guides/multichart-dashboard-cookbook.md` covering shared device, pipeline cache, external render mode, and chart synchronization patterns.
 - **Streaming Dashboard example** - Added 5-chart APM-style dashboard with correlated metric streaming, programmatic annotations, dark theme support, and shared device + pipeline cache.
 - **Acceptance: auto-scroll + zoom sync** - Added an acceptance example that covers auto-scroll behavior with zoom synchronization.

--- a/docs/api/chart.md
+++ b/docs/api/chart.md
@@ -69,6 +69,7 @@ See [ChartGPU.ts](../../src/ChartGPU.ts) for the full interface and lifecycle be
     - Otherwise **fixed-capacity ring**: fill up to `maxPoints`, then overwrite oldest slots (GPU modular writes — O(append), no full retained-window rewrite). Peak retained length / GPU reservation = **`maxPoints`**.
     - Prefer over sliding-window full `setOption` for high-rate streaming (fixed-capacity ring; not sticky series construction state).
     - When both `maxPoints` is set and `tooltip.show === false`, ChartGPU’s hit-test columnar store is not updated on append (dual-store relief); coordinator/GPU still apply the ring.
+  - **Device storage cap (unbounded append):** series buffers are storage-bound. When growth would exceed `min(maxBufferSize, maxStorageBufferBindingSize)` (often **128 MiB ≈ 16.7M** xy points on Chrome/Metal), ChartGPU **auto-windows** to that point budget (same ring policy as `maxPoints`) so the x-domain stays in sync with GPU-resident data. Without this, the axis could keep expanding while the series stopped short of the right edge. Pass an explicit `{ maxPoints }` when you want a smaller sliding window.
   - Types: [`src/config/types.ts`](../../src/config/types.ts)
 - `resize()`, `dispose()`
 - `on(...)`, `off(...)`: events (see [interaction.md](interaction.md))

--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -118,8 +118,10 @@ Notes (density mode):
   - **Precedence**: explicit `min`/`max` always override any auto-bounds behavior.
   - **One-sided explicit**: if only `min` or only `max` is set, the other end is still data-derived; sticky auto-domain headroom (below) is **disabled** whenever either end is explicit so growBy padding never extends past a locked edge.
 - **Sticky auto-domain headroom (streaming / multi-chart)**:
-  - When **both** ends of an axis are auto (no explicit `min`/`max`), ChartGPU uses a sticky domain: **first establish matches the data extrema exactly** (static column/mountain charts fill the plot), then ~**10% growBy headroom** is added only when data **breaches** that domain (streaming compression amortization). If the data **min slides upward** (FIFO/`maxPoints` drop-oldest), sticky **follows** the new min instead of freezing the historical origin. Sticky X is off entirely when `autoScroll: true`.
-  - Purpose: high-rate `appendData` (series compression, multi-chart line slots) would otherwise force grid/axis prepare + label rebuild every frame as the domain creeps by a few points.
+  - When **both** ends of an axis are auto (no explicit `min`/`max`), ChartGPU uses a sticky domain: **first establish matches the data extrema exactly** (static column/mountain charts fill the plot).
+  - **Y**: ~**10% growBy headroom** is added only when data **breaches** that domain (amortizes overlay rebuild under amplitude noise).
+  - **X**: headroom is **0** so unbounded `appendData` tracks data max tightly and the series stays **full plot width**. Non-zero X pad previously left an empty right gutter that filled then re-expanded on every breach (visible as a grow/reset loop in examples like ultimate-benchmark streaming).
+  - If the data **min slides upward** (FIFO/`maxPoints` drop-oldest), sticky **follows** the new min instead of freezing the historical origin. Sticky X is off entirely when `autoScroll: true`.
   - Cleared on `setOption` (including axes-only rewrites) and when any end becomes explicit.
   - Does **not** change sampling contracts (`lttb` stays `lttb`).
 - **Y-axis auto-bounds during x-zoom (new default)**:

--- a/src/ChartGPU.ts
+++ b/src/ChartGPU.ts
@@ -2768,8 +2768,7 @@ export async function createChartGPU(
       // Use shared device/adapter if provided in context parameter.
       // Optional devicePixelRatio overrides window.devicePixelRatio (multi-chart 1×).
       const dprOpt = options.devicePixelRatio;
-      const dprOverride =
-        typeof dprOpt === 'number' && Number.isFinite(dprOpt) && dprOpt > 0 ? dprOpt : undefined;
+      const dprOverride = typeof dprOpt === 'number' && Number.isFinite(dprOpt) && dprOpt > 0 ? dprOpt : undefined;
       const gpuContextOptions = context
         ? {
             device: context.device,

--- a/src/components/createTextOverlay.ts
+++ b/src/components/createTextOverlay.ts
@@ -52,9 +52,7 @@ export function createTextOverlay(container: HTMLElement, options?: TextOverlayO
 
   const clip = options?.clip ?? false;
   const fixedDpr =
-    options?.devicePixelRatio != null &&
-    Number.isFinite(options.devicePixelRatio) &&
-    options.devicePixelRatio > 0
+    options?.devicePixelRatio != null && Number.isFinite(options.devicePixelRatio) && options.devicePixelRatio > 0
       ? options.devicePixelRatio
       : null;
 
@@ -87,8 +85,7 @@ export function createTextOverlay(container: HTMLElement, options?: TextOverlayO
 
   const ctx = canvas.getContext('2d');
   let disposed = false;
-  let dpr =
-    fixedDpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+  let dpr = fixedDpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
 
   type PendingLabel = {
     text: string;
@@ -113,8 +110,7 @@ export function createTextOverlay(container: HTMLElement, options?: TextOverlayO
     if (!ctx) return;
     const cssW = container.clientWidth || 0;
     const cssH = container.clientHeight || 0;
-    dpr =
-      fixedDpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+    dpr = fixedDpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
     const bw = Math.max(1, Math.round(cssW * dpr));
     const bh = Math.max(1, Math.round(cssH * dpr));
     if (canvas.width !== bw || canvas.height !== bh) {
@@ -133,8 +129,7 @@ export function createTextOverlay(container: HTMLElement, options?: TextOverlayO
     for (let i = 0; i < pending.length; i++) {
       const lab = pending[i]!;
       ctx.save();
-      const weightPrefix =
-        lab.fontWeight !== undefined && lab.fontWeight !== '' ? `${lab.fontWeight} ` : '';
+      const weightPrefix = lab.fontWeight !== undefined && lab.fontWeight !== '' ? `${lab.fontWeight} ` : '';
       ctx.font = `${weightPrefix}${lab.fontSize}px ${lab.fontFamily}`;
       ctx.fillStyle = lab.color;
       ctx.textBaseline = 'middle';

--- a/src/config/OptionResolver.ts
+++ b/src/config/OptionResolver.ts
@@ -1214,390 +1214,385 @@ export function resolveOptions(
   const series: ReadonlyArray<ResolvedSeriesConfig> = canReuseEntireSeriesArray
     ? previousSeries!
     : (userOptions.series ?? []).map((s, i) => {
-    const explicitColor = normalizeOptionalColor(s.color);
-    const inheritedColor = theme.colorPalette[i % theme.colorPalette.length];
-    const color = explicitColor ?? inheritedColor;
-    const prevResolved = previousSeries?.[i];
+        const explicitColor = normalizeOptionalColor(s.color);
+        const inheritedColor = theme.colorPalette[i % theme.colorPalette.length];
+        const color = explicitColor ?? inheritedColor;
+        const prevResolved = previousSeries?.[i];
 
-    // Ensure visible defaults to true (converts undefined to true, preserves explicit false)
-    const visible = s.visible !== false;
+        // Ensure visible defaults to true (converts undefined to true, preserves explicit false)
+        const visible = s.visible !== false;
 
-    const sampling: SeriesSampling = normalizeSampling((s as unknown as { sampling?: unknown }).sampling) ?? 'lttb';
-    const samplingThreshold: number =
-      normalizeSamplingThreshold((s as unknown as { samplingThreshold?: unknown }).samplingThreshold) ?? 5000;
+        const sampling: SeriesSampling = normalizeSampling((s as unknown as { sampling?: unknown }).sampling) ?? 'lttb';
+        const samplingThreshold: number =
+          normalizeSamplingThreshold((s as unknown as { samplingThreshold?: unknown }).samplingThreshold) ?? 5000;
 
-    const yAxis = s.yAxis ?? defaultYAxisId;
+        const yAxis = s.yAxis ?? defaultYAxisId;
 
-    switch (s.type) {
-      case 'area': {
-        // Resolve effective fill color with precedence: areaStyle.color → series.color → palette
-        const areaStyleColor = normalizeOptionalColor(s.areaStyle?.color);
-        const effectiveColor = areaStyleColor ?? explicitColor ?? inheritedColor;
+        switch (s.type) {
+          case 'area': {
+            // Resolve effective fill color with precedence: areaStyle.color → series.color → palette
+            const areaStyleColor = normalizeOptionalColor(s.areaStyle?.color);
+            const effectiveColor = areaStyleColor ?? explicitColor ?? inheritedColor;
 
-        const areaStyle: ResolvedAreaStyleConfig = {
-          opacity: s.areaStyle?.opacity ?? defaultAreaStyle.opacity,
-          color: effectiveColor,
-        };
+            const areaStyle: ResolvedAreaStyleConfig = {
+              opacity: s.areaStyle?.opacity ?? defaultAreaStyle.opacity,
+              color: effectiveColor,
+            };
 
-        const connectNulls = s.connectNulls ?? false;
-        const contentHash = resolveSeriesContentHash(prevResolved, 'area', s.data, () =>
-          cheapCartesianContentStamp(s.data)
-        );
-        const reuseSample = canReuseResolvedSeriesSample(
-          prevResolved,
-          'area',
-          s.data,
-          sampling,
-          samplingThreshold,
-          connectNulls,
-          contentHash
-        );
-        const prevArea = reuseSample
-          ? (prevResolved as ResolvedAreaSeriesConfig & {
-              contentHash?: number;
-              rawBoundsMode?: RawBoundsMode;
-            })
-          : null;
-        const { bounds: rawBounds, mode: rawBoundsMode } = resolveCartesianBounds(prevArea, s.data, reuseSample);
-        // Bypass sampling when data contains null gap markers to preserve gap structure.
-        // sampling:'none' already returns data as-is — skip O(n) hasNullGaps.
-        const sampledAreaData = prevArea
-          ? prevArea.data
-          : sampling === 'none' || hasNullGaps(s.data)
-            ? s.data
-            : sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
-        return {
-          ...s,
-          visible,
-          rawData: s.data,
-          data: sampledAreaData,
-          color: effectiveColor,
-          areaStyle,
-          sampling,
-          samplingThreshold,
-          rawBounds,
-          rawBoundsMode,
-          connectNulls,
-          yAxis,
-          contentHash,
-        };
-      }
-      case 'line': {
-        // Resolve effective stroke color with precedence: lineStyle.color → series.color → palette
-        const lineStyleColor = normalizeOptionalColor(s.lineStyle?.color);
-        const effectiveStrokeColor = lineStyleColor ?? explicitColor ?? inheritedColor;
-
-        const lineStyle: ResolvedLineStyleConfig = {
-          width: s.lineStyle?.width ?? defaultLineStyle.width,
-          opacity: s.lineStyle?.opacity ?? defaultLineStyle.opacity,
-          color: effectiveStrokeColor,
-        };
-
-        // Avoid leaking the unresolved (user) areaStyle shape via object spread.
-        const { areaStyle: _userAreaStyle, ...rest } = s;
-        const connectNulls = s.connectNulls ?? false;
-        const contentHash = resolveSeriesContentHash(prevResolved, 'line', s.data, () =>
-          cheapCartesianContentStamp(s.data)
-        );
-        const reuseSample = canReuseResolvedSeriesSample(
-          prevResolved,
-          'line',
-          s.data,
-          sampling,
-          samplingThreshold,
-          connectNulls,
-          contentHash
-        );
-        const prevLine = reuseSample
-          ? (prevResolved as ResolvedLineSeriesConfig & {
-              contentHash?: number;
-              rawBoundsMode?: RawBoundsMode;
-            })
-          : null;
-        const { bounds: rawBounds, mode: rawBoundsMode } = resolveCartesianBounds(prevLine, s.data, reuseSample);
-        // Bypass sampling when data contains null gap markers to preserve gap structure.
-        // sampling:'none' already returns data as-is — skip O(n) hasNullGaps.
-        const sampledData = prevLine
-          ? prevLine.data
-          : sampling === 'none' || hasNullGaps(s.data)
-            ? s.data
-            : sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
-
-        return {
-          ...rest,
-          visible,
-          rawData: s.data,
-          data: sampledData,
-          color: effectiveStrokeColor,
-          lineStyle,
-          ...(s.areaStyle
-            ? {
-                areaStyle: {
-                  opacity: s.areaStyle.opacity ?? defaultAreaStyle.opacity,
-                  // Fill color precedence: areaStyle.color → resolved stroke color
-                  color: normalizeOptionalColor(s.areaStyle.color) ?? effectiveStrokeColor,
-                },
-              }
-            : {}),
-          sampling,
-          samplingThreshold,
-          rawBounds,
-          rawBoundsMode,
-          connectNulls,
-          yAxis,
-          contentHash,
-        };
-      }
-      case 'bar': {
-        const contentHash = resolveSeriesContentHash(prevResolved, 'bar', s.data, () =>
-          cheapCartesianContentStamp(s.data)
-        );
-        const reuseSample = canReuseResolvedSeriesSample(
-          prevResolved,
-          'bar',
-          s.data,
-          sampling,
-          samplingThreshold,
-          undefined,
-          contentHash
-        );
-        const prevBar = reuseSample
-          ? (prevResolved as ResolvedBarSeriesConfig & {
-              contentHash?: number;
-              rawBoundsMode?: RawBoundsMode;
-            })
-          : null;
-        const { bounds: rawBounds, mode: rawBoundsMode } = resolveCartesianBounds(prevBar, s.data, reuseSample);
-        return {
-          ...s,
-          visible,
-          rawData: s.data,
-          data: prevBar ? prevBar.data : sampleSeriesDataPoints(s.data, sampling, samplingThreshold),
-          color,
-          sampling,
-          samplingThreshold,
-          rawBounds,
-          rawBoundsMode,
-          yAxis,
-          contentHash,
-        };
-      }
-      case 'scatter': {
-        const contentHash = resolveSeriesContentHash(prevResolved, 'scatter', s.data, () =>
-          cheapCartesianContentStamp(s.data)
-        );
-        const reuseSample = canReuseResolvedSeriesSample(
-          prevResolved,
-          'scatter',
-          s.data,
-          sampling,
-          samplingThreshold,
-          undefined,
-          contentHash
-        );
-        const prevScatterResolved =
-          prevResolved?.type === 'scatter' ? (prevResolved as ResolvedScatterSeriesConfig) : null;
-        const prevScatter = reuseSample
-          ? (prevResolved as ResolvedScatterSeriesConfig & {
-              contentHash?: number;
-              rawBoundsMode?: RawBoundsMode;
-            })
-          : null;
-        const rawPointCount = getPointCount(s.data);
-        // Sticky index-sorted proof: prior frame fully proved x=i at this N.
-        const stickyIndexSorted =
-          prevScatterResolved?.indexSortedProven === true &&
-          prevScatterResolved.indexSortedPointCount === rawPointCount;
-
-        // Equal-N y-only + index-sorted under **LTTB** (group 4): re-bind y at
-        // prior sample x indices in O(k) instead of full O(N) LTTB. Requires
-        // matching sampling + threshold (same gate as canReuseResolvedSeriesSample).
-        // min/max/average always re-sample (bucket extrema depend on y).
-        // Brownian xy (group 2) fails classifyEqualNYOnlyRewrite → full path.
-        // Classify before bounds so sticky/full proof is shared (one O(n) max cold).
-        let sampledData: CartesianSeriesData;
-        /** True when this frame still has a valid index-sorted proof (sticky or cold). */
-        let indexSortedThisFrame = false;
-        if (prevScatter) {
-          sampledData = prevScatter.data;
-          // Identity-reuse: keep prior sticky proof when present.
-          indexSortedThisFrame = stickyIndexSorted;
-        } else if (
-          sampling === 'lttb' &&
-          prevScatterResolved &&
-          prevScatterResolved.sampling === 'lttb' &&
-          prevScatterResolved.samplingThreshold === samplingThreshold
-        ) {
-          const yOnlyKind = classifyEqualNYOnlyRewrite(
-            prevScatterResolved.rawData as CartesianSeriesData,
-            s.data,
-            { prevIndexSortedProven: stickyIndexSorted }
-          );
-          if (yOnlyKind === 'indexSorted') {
-            indexSortedThisFrame = true;
-            const remapped = remapIndexSortedSampleY(
-              prevScatterResolved.data as CartesianSeriesData,
-              s.data
+            const connectNulls = s.connectNulls ?? false;
+            const contentHash = resolveSeriesContentHash(prevResolved, 'area', s.data, () =>
+              cheapCartesianContentStamp(s.data)
             );
-            sampledData = remapped ?? sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
-          } else {
-            // Clears sticky for this frame (Brownian / equalX) — do not trustIndexSorted.
-            sampledData = sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+            const reuseSample = canReuseResolvedSeriesSample(
+              prevResolved,
+              'area',
+              s.data,
+              sampling,
+              samplingThreshold,
+              connectNulls,
+              contentHash
+            );
+            const prevArea = reuseSample
+              ? (prevResolved as ResolvedAreaSeriesConfig & {
+                  contentHash?: number;
+                  rawBoundsMode?: RawBoundsMode;
+                })
+              : null;
+            const { bounds: rawBounds, mode: rawBoundsMode } = resolveCartesianBounds(prevArea, s.data, reuseSample);
+            // Bypass sampling when data contains null gap markers to preserve gap structure.
+            // sampling:'none' already returns data as-is — skip O(n) hasNullGaps.
+            const sampledAreaData = prevArea
+              ? prevArea.data
+              : sampling === 'none' || hasNullGaps(s.data)
+                ? s.data
+                : sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+            return {
+              ...s,
+              visible,
+              rawData: s.data,
+              data: sampledAreaData,
+              color: effectiveColor,
+              areaStyle,
+              sampling,
+              samplingThreshold,
+              rawBounds,
+              rawBoundsMode,
+              connectNulls,
+              yAxis,
+              contentHash,
+            };
           }
-        } else if (stickyIndexSorted && sampleLooksIndexSortedX(s.data)) {
-          // Non-LTTB equal-N stream (e.g. sampling:'none'): keep sticky for bounds O(1).
-          indexSortedThisFrame = true;
-          sampledData = sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
-        } else {
-          sampledData = sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
-          // Cold first frame (no sticky / no LTTB remap prev): one full O(n) proof so
-          // subsequent equal-N frames can sticky-skip. Cheap sample reject first.
-          if (sampleLooksIndexSortedX(s.data) && isIndexSortedX(s.data)) {
-            indexSortedThisFrame = true;
+          case 'line': {
+            // Resolve effective stroke color with precedence: lineStyle.color → series.color → palette
+            const lineStyleColor = normalizeOptionalColor(s.lineStyle?.color);
+            const effectiveStrokeColor = lineStyleColor ?? explicitColor ?? inheritedColor;
+
+            const lineStyle: ResolvedLineStyleConfig = {
+              width: s.lineStyle?.width ?? defaultLineStyle.width,
+              opacity: s.lineStyle?.opacity ?? defaultLineStyle.opacity,
+              color: effectiveStrokeColor,
+            };
+
+            // Avoid leaking the unresolved (user) areaStyle shape via object spread.
+            const { areaStyle: _userAreaStyle, ...rest } = s;
+            const connectNulls = s.connectNulls ?? false;
+            const contentHash = resolveSeriesContentHash(prevResolved, 'line', s.data, () =>
+              cheapCartesianContentStamp(s.data)
+            );
+            const reuseSample = canReuseResolvedSeriesSample(
+              prevResolved,
+              'line',
+              s.data,
+              sampling,
+              samplingThreshold,
+              connectNulls,
+              contentHash
+            );
+            const prevLine = reuseSample
+              ? (prevResolved as ResolvedLineSeriesConfig & {
+                  contentHash?: number;
+                  rawBoundsMode?: RawBoundsMode;
+                })
+              : null;
+            const { bounds: rawBounds, mode: rawBoundsMode } = resolveCartesianBounds(prevLine, s.data, reuseSample);
+            // Bypass sampling when data contains null gap markers to preserve gap structure.
+            // sampling:'none' already returns data as-is — skip O(n) hasNullGaps.
+            const sampledData = prevLine
+              ? prevLine.data
+              : sampling === 'none' || hasNullGaps(s.data)
+                ? s.data
+                : sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+
+            return {
+              ...rest,
+              visible,
+              rawData: s.data,
+              data: sampledData,
+              color: effectiveStrokeColor,
+              lineStyle,
+              ...(s.areaStyle
+                ? {
+                    areaStyle: {
+                      opacity: s.areaStyle.opacity ?? defaultAreaStyle.opacity,
+                      // Fill color precedence: areaStyle.color → resolved stroke color
+                      color: normalizeOptionalColor(s.areaStyle.color) ?? effectiveStrokeColor,
+                    },
+                  }
+                : {}),
+              sampling,
+              samplingThreshold,
+              rawBounds,
+              rawBoundsMode,
+              connectNulls,
+              yAxis,
+              contentHash,
+            };
+          }
+          case 'bar': {
+            const contentHash = resolveSeriesContentHash(prevResolved, 'bar', s.data, () =>
+              cheapCartesianContentStamp(s.data)
+            );
+            const reuseSample = canReuseResolvedSeriesSample(
+              prevResolved,
+              'bar',
+              s.data,
+              sampling,
+              samplingThreshold,
+              undefined,
+              contentHash
+            );
+            const prevBar = reuseSample
+              ? (prevResolved as ResolvedBarSeriesConfig & {
+                  contentHash?: number;
+                  rawBoundsMode?: RawBoundsMode;
+                })
+              : null;
+            const { bounds: rawBounds, mode: rawBoundsMode } = resolveCartesianBounds(prevBar, s.data, reuseSample);
+            return {
+              ...s,
+              visible,
+              rawData: s.data,
+              data: prevBar ? prevBar.data : sampleSeriesDataPoints(s.data, sampling, samplingThreshold),
+              color,
+              sampling,
+              samplingThreshold,
+              rawBounds,
+              rawBoundsMode,
+              yAxis,
+              contentHash,
+            };
+          }
+          case 'scatter': {
+            const contentHash = resolveSeriesContentHash(prevResolved, 'scatter', s.data, () =>
+              cheapCartesianContentStamp(s.data)
+            );
+            const reuseSample = canReuseResolvedSeriesSample(
+              prevResolved,
+              'scatter',
+              s.data,
+              sampling,
+              samplingThreshold,
+              undefined,
+              contentHash
+            );
+            const prevScatterResolved =
+              prevResolved?.type === 'scatter' ? (prevResolved as ResolvedScatterSeriesConfig) : null;
+            const prevScatter = reuseSample
+              ? (prevResolved as ResolvedScatterSeriesConfig & {
+                  contentHash?: number;
+                  rawBoundsMode?: RawBoundsMode;
+                })
+              : null;
+            const rawPointCount = getPointCount(s.data);
+            // Sticky index-sorted proof: prior frame fully proved x=i at this N.
+            const stickyIndexSorted =
+              prevScatterResolved?.indexSortedProven === true &&
+              prevScatterResolved.indexSortedPointCount === rawPointCount;
+
+            // Equal-N y-only + index-sorted under **LTTB** (group 4): re-bind y at
+            // prior sample x indices in O(k) instead of full O(N) LTTB. Requires
+            // matching sampling + threshold (same gate as canReuseResolvedSeriesSample).
+            // min/max/average always re-sample (bucket extrema depend on y).
+            // Brownian xy (group 2) fails classifyEqualNYOnlyRewrite → full path.
+            // Classify before bounds so sticky/full proof is shared (one O(n) max cold).
+            let sampledData: CartesianSeriesData;
+            /** True when this frame still has a valid index-sorted proof (sticky or cold). */
+            let indexSortedThisFrame = false;
+            if (prevScatter) {
+              sampledData = prevScatter.data;
+              // Identity-reuse: keep prior sticky proof when present.
+              indexSortedThisFrame = stickyIndexSorted;
+            } else if (
+              sampling === 'lttb' &&
+              prevScatterResolved &&
+              prevScatterResolved.sampling === 'lttb' &&
+              prevScatterResolved.samplingThreshold === samplingThreshold
+            ) {
+              const yOnlyKind = classifyEqualNYOnlyRewrite(prevScatterResolved.rawData as CartesianSeriesData, s.data, {
+                prevIndexSortedProven: stickyIndexSorted,
+              });
+              if (yOnlyKind === 'indexSorted') {
+                indexSortedThisFrame = true;
+                const remapped = remapIndexSortedSampleY(prevScatterResolved.data as CartesianSeriesData, s.data);
+                sampledData = remapped ?? sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+              } else {
+                // Clears sticky for this frame (Brownian / equalX) — do not trustIndexSorted.
+                sampledData = sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+              }
+            } else if (stickyIndexSorted && sampleLooksIndexSortedX(s.data)) {
+              // Non-LTTB equal-N stream (e.g. sampling:'none'): keep sticky for bounds O(1).
+              indexSortedThisFrame = true;
+              sampledData = sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+            } else {
+              sampledData = sampleSeriesDataPoints(s.data, sampling, samplingThreshold);
+              // Cold first frame (no sticky / no LTTB remap prev): one full O(n) proof so
+              // subsequent equal-N frames can sticky-skip. Cheap sample reject first.
+              if (sampleLooksIndexSortedX(s.data) && isIndexSortedX(s.data)) {
+                indexSortedThisFrame = true;
+              }
+            }
+
+            const {
+              bounds: rawBounds,
+              mode: rawBoundsMode,
+              indexSortedHit,
+            } = resolveCartesianBounds(prevScatter, s.data, reuseSample, {
+              // Only trust when this frame re-validated sticky or cold-proved — never
+              // after classify rejected (Brownian).
+              trustIndexSorted: indexSortedThisFrame,
+            });
+
+            const indexSortedProven = Boolean(indexSortedThisFrame || indexSortedHit);
+            const mode =
+              normalizeScatterMode((s as unknown as { readonly mode?: unknown }).mode) ?? scatterDefaults.mode;
+            const binSize =
+              normalizeDensityBinSize((s as unknown as { readonly binSize?: unknown }).binSize) ??
+              scatterDefaults.binSize;
+            const densityColormap =
+              normalizeDensityColormap((s as unknown as { readonly densityColormap?: unknown }).densityColormap) ??
+              scatterDefaults.densityColormap;
+            const densityNormalization =
+              normalizeDensityNormalization(
+                (s as unknown as { readonly densityNormalization?: unknown }).densityNormalization
+              ) ?? scatterDefaults.densityNormalization;
+
+            return {
+              ...s,
+              visible,
+              rawData: s.data,
+              data: sampledData,
+              color,
+              mode,
+              binSize,
+              densityColormap,
+              densityNormalization,
+              sampling,
+              samplingThreshold,
+              rawBounds,
+              rawBoundsMode,
+              yAxis,
+              contentHash,
+              ...(indexSortedProven ? { indexSortedProven: true as const, indexSortedPointCount: rawPointCount } : {}),
+            };
+          }
+          case 'pie': {
+            // Pie series intentionally do NOT support sampling at runtime.
+            // For JS callers, strip any extra sampling keys so they don't leak through the resolver.
+            const {
+              sampling: _sampling,
+              samplingThreshold: _samplingThreshold,
+              ...rest
+            } = s as PieSeriesConfig & {
+              readonly sampling?: unknown;
+              readonly samplingThreshold?: unknown;
+            };
+
+            const resolvedData: ReadonlyArray<ResolvedPieDataItem> = (s.data ?? []).map((item, itemIndex) => {
+              const itemColor = normalizeOptionalColor(item?.color);
+              const fallback = theme.colorPalette[(i + itemIndex) % theme.colorPalette.length];
+              // Ensure visible defaults to true (converts undefined to true, preserves explicit false)
+              const itemVisible = item?.visible !== false;
+              return {
+                ...item,
+                color: itemColor ?? fallback,
+                visible: itemVisible,
+              };
+            });
+
+            return { ...rest, visible, color, data: resolvedData };
+          }
+          case 'candlestick': {
+            warnCandlestickNotImplemented();
+
+            const resolvedSampling: 'none' | 'ohlc' =
+              normalizeCandlestickSampling((s as unknown as { sampling?: unknown }).sampling) ??
+              candlestickDefaults.sampling;
+
+            const resolvedSamplingThreshold: number =
+              normalizeSamplingThreshold((s as unknown as { samplingThreshold?: unknown }).samplingThreshold) ??
+              candlestickDefaults.samplingThreshold;
+
+            const resolvedItemStyle: ResolvedCandlestickItemStyleConfig = {
+              upColor: normalizeOptionalColor(s.itemStyle?.upColor) ?? candlestickDefaults.itemStyle.upColor,
+              downColor: normalizeOptionalColor(s.itemStyle?.downColor) ?? candlestickDefaults.itemStyle.downColor,
+              upBorderColor:
+                normalizeOptionalColor(s.itemStyle?.upBorderColor) ?? candlestickDefaults.itemStyle.upBorderColor,
+              downBorderColor:
+                normalizeOptionalColor(s.itemStyle?.downBorderColor) ?? candlestickDefaults.itemStyle.downBorderColor,
+              borderWidth:
+                typeof s.itemStyle?.borderWidth === 'number' && Number.isFinite(s.itemStyle.borderWidth)
+                  ? s.itemStyle.borderWidth
+                  : candlestickDefaults.itemStyle.borderWidth,
+            };
+
+            const contentHash = resolveSeriesContentHash(prevResolved, 'candlestick', s.data, () =>
+              cheapOHLCContentStamp(s.data)
+            );
+            const reuseCandle = canReuseResolvedSeriesSample(
+              prevResolved,
+              'candlestick',
+              s.data,
+              resolvedSampling,
+              resolvedSamplingThreshold,
+              undefined,
+              contentHash
+            );
+            const prevCandle = reuseCandle
+              ? (prevResolved as ResolvedCandlestickSeriesConfig & {
+                  contentHash?: number;
+                })
+              : null;
+            const rawBounds = prevCandle?.rawBounds ?? computeRawBoundsFromOHLC(s.data);
+
+            const sampledData = prevCandle
+              ? prevCandle.data
+              : resolvedSampling === 'ohlc' && s.data.length > resolvedSamplingThreshold
+                ? ohlcSample(s.data, resolvedSamplingThreshold)
+                : s.data;
+
+            return {
+              ...s,
+              visible,
+              rawData: s.data,
+              data: sampledData,
+              color,
+              style: s.style ?? candlestickDefaults.style,
+              itemStyle: resolvedItemStyle,
+              barWidth: s.barWidth ?? candlestickDefaults.barWidth,
+              barMinWidth: s.barMinWidth ?? candlestickDefaults.barMinWidth,
+              barMaxWidth: s.barMaxWidth ?? candlestickDefaults.barMaxWidth,
+              sampling: resolvedSampling,
+              samplingThreshold: resolvedSamplingThreshold,
+              rawBounds,
+              yAxis,
+              contentHash,
+            };
+          }
+          default: {
+            return assertUnreachable(s);
           }
         }
-
-        const {
-          bounds: rawBounds,
-          mode: rawBoundsMode,
-          indexSortedHit,
-        } = resolveCartesianBounds(prevScatter, s.data, reuseSample, {
-          // Only trust when this frame re-validated sticky or cold-proved — never
-          // after classify rejected (Brownian).
-          trustIndexSorted: indexSortedThisFrame,
-        });
-
-        const indexSortedProven = Boolean(indexSortedThisFrame || indexSortedHit);
-        const mode = normalizeScatterMode((s as unknown as { readonly mode?: unknown }).mode) ?? scatterDefaults.mode;
-        const binSize =
-          normalizeDensityBinSize((s as unknown as { readonly binSize?: unknown }).binSize) ?? scatterDefaults.binSize;
-        const densityColormap =
-          normalizeDensityColormap((s as unknown as { readonly densityColormap?: unknown }).densityColormap) ??
-          scatterDefaults.densityColormap;
-        const densityNormalization =
-          normalizeDensityNormalization(
-            (s as unknown as { readonly densityNormalization?: unknown }).densityNormalization
-          ) ?? scatterDefaults.densityNormalization;
-
-        return {
-          ...s,
-          visible,
-          rawData: s.data,
-          data: sampledData,
-          color,
-          mode,
-          binSize,
-          densityColormap,
-          densityNormalization,
-          sampling,
-          samplingThreshold,
-          rawBounds,
-          rawBoundsMode,
-          yAxis,
-          contentHash,
-          ...(indexSortedProven
-            ? { indexSortedProven: true as const, indexSortedPointCount: rawPointCount }
-            : {}),
-        };
-      }
-      case 'pie': {
-        // Pie series intentionally do NOT support sampling at runtime.
-        // For JS callers, strip any extra sampling keys so they don't leak through the resolver.
-        const {
-          sampling: _sampling,
-          samplingThreshold: _samplingThreshold,
-          ...rest
-        } = s as PieSeriesConfig & {
-          readonly sampling?: unknown;
-          readonly samplingThreshold?: unknown;
-        };
-
-        const resolvedData: ReadonlyArray<ResolvedPieDataItem> = (s.data ?? []).map((item, itemIndex) => {
-          const itemColor = normalizeOptionalColor(item?.color);
-          const fallback = theme.colorPalette[(i + itemIndex) % theme.colorPalette.length];
-          // Ensure visible defaults to true (converts undefined to true, preserves explicit false)
-          const itemVisible = item?.visible !== false;
-          return {
-            ...item,
-            color: itemColor ?? fallback,
-            visible: itemVisible,
-          };
-        });
-
-        return { ...rest, visible, color, data: resolvedData };
-      }
-      case 'candlestick': {
-        warnCandlestickNotImplemented();
-
-        const resolvedSampling: 'none' | 'ohlc' =
-          normalizeCandlestickSampling((s as unknown as { sampling?: unknown }).sampling) ??
-          candlestickDefaults.sampling;
-
-        const resolvedSamplingThreshold: number =
-          normalizeSamplingThreshold((s as unknown as { samplingThreshold?: unknown }).samplingThreshold) ??
-          candlestickDefaults.samplingThreshold;
-
-        const resolvedItemStyle: ResolvedCandlestickItemStyleConfig = {
-          upColor: normalizeOptionalColor(s.itemStyle?.upColor) ?? candlestickDefaults.itemStyle.upColor,
-          downColor: normalizeOptionalColor(s.itemStyle?.downColor) ?? candlestickDefaults.itemStyle.downColor,
-          upBorderColor:
-            normalizeOptionalColor(s.itemStyle?.upBorderColor) ?? candlestickDefaults.itemStyle.upBorderColor,
-          downBorderColor:
-            normalizeOptionalColor(s.itemStyle?.downBorderColor) ?? candlestickDefaults.itemStyle.downBorderColor,
-          borderWidth:
-            typeof s.itemStyle?.borderWidth === 'number' && Number.isFinite(s.itemStyle.borderWidth)
-              ? s.itemStyle.borderWidth
-              : candlestickDefaults.itemStyle.borderWidth,
-        };
-
-        const contentHash = resolveSeriesContentHash(prevResolved, 'candlestick', s.data, () =>
-          cheapOHLCContentStamp(s.data)
-        );
-        const reuseCandle = canReuseResolvedSeriesSample(
-          prevResolved,
-          'candlestick',
-          s.data,
-          resolvedSampling,
-          resolvedSamplingThreshold,
-          undefined,
-          contentHash
-        );
-        const prevCandle = reuseCandle
-          ? (prevResolved as ResolvedCandlestickSeriesConfig & {
-              contentHash?: number;
-            })
-          : null;
-        const rawBounds = prevCandle?.rawBounds ?? computeRawBoundsFromOHLC(s.data);
-
-        const sampledData = prevCandle
-          ? prevCandle.data
-          : resolvedSampling === 'ohlc' && s.data.length > resolvedSamplingThreshold
-            ? ohlcSample(s.data, resolvedSamplingThreshold)
-            : s.data;
-
-        return {
-          ...s,
-          visible,
-          rawData: s.data,
-          data: sampledData,
-          color,
-          style: s.style ?? candlestickDefaults.style,
-          itemStyle: resolvedItemStyle,
-          barWidth: s.barWidth ?? candlestickDefaults.barWidth,
-          barMinWidth: s.barMinWidth ?? candlestickDefaults.barMinWidth,
-          barMaxWidth: s.barMaxWidth ?? candlestickDefaults.barMaxWidth,
-          sampling: resolvedSampling,
-          samplingThreshold: resolvedSamplingThreshold,
-          rawBounds,
-          yAxis,
-          contentHash,
-        };
-      }
-      default: {
-        return assertUnreachable(s);
-      }
-    }
-  });
+      });
 
   return {
     grid,

--- a/src/core/renderCoordinator/__tests__/moduleHonesty.test.ts
+++ b/src/core/renderCoordinator/__tests__/moduleHonesty.test.ts
@@ -81,9 +81,7 @@ function collectExports(files: string[]): ExportEntry[] {
         out.push({ name, file: resolve(file) });
       }
     }
-    for (const m of text.matchAll(
-      /^export\s+(?:async\s+)?(?:function|const|class|type|interface|enum)\s+(\w+)/gm
-    )) {
+    for (const m of text.matchAll(/^export\s+(?:async\s+)?(?:function|const|class|type|interface|enum)\s+(\w+)/gm)) {
       out.push({ name: m[1]!, file: resolve(file) });
     }
   }
@@ -129,11 +127,7 @@ function moduleReexports(
 }
 
 /** True if any production file imports something from this module path. */
-function moduleHasProductionImporter(
-  modulePath: string,
-  allProdSrc: string[],
-  shellPath: string
-): boolean {
+function moduleHasProductionImporter(modulePath: string, allProdSrc: string[], shellPath: string): boolean {
   if (modulePath === shellPath) return true;
   const stem = modulePath.replace(/\.ts$/, '');
   for (const file of allProdSrc) {
@@ -212,7 +206,10 @@ describe('renderCoordinator module honesty', () => {
             break;
           }
           // Import from a barrel that re-exports us only if that barrel is live.
-          if (moduleReexports(resolved, name, file, reexports) && moduleHasProductionImporter(resolved, allProdSrc, shell)) {
+          if (
+            moduleReexports(resolved, name, file, reexports) &&
+            moduleHasProductionImporter(resolved, allProdSrc, shell)
+          ) {
             hasConsumer = true;
             break;
           }

--- a/src/core/renderCoordinator/animation/animationHelpers.ts
+++ b/src/core/renderCoordinator/animation/animationHelpers.ts
@@ -148,7 +148,9 @@ function hasDrawableMarks(series: AnySeriesConfig): boolean {
       return getPointCount(series.data as CartesianSeriesData) > 0;
     }
     case 'candlestick': {
-      return Array.isArray(series.data) ? series.data.length > 0 : getPointCount(series.data as CartesianSeriesData) > 0;
+      return Array.isArray(series.data)
+        ? series.data.length > 0
+        : getPointCount(series.data as CartesianSeriesData) > 0;
     }
     default: {
       return false;

--- a/src/core/renderCoordinator/axis/__tests__/axisLabelHelpers.test.ts
+++ b/src/core/renderCoordinator/axis/__tests__/axisLabelHelpers.test.ts
@@ -1,11 +1,5 @@
-
 import { describe, it, expect } from 'vitest';
-import {
-  getYAxisLabelX,
-  getRightYAxisLabelX,
-  getYAxisTitleX,
-  getRightYAxisTitleX,
-} from '../axisLabelHelpers';
+import { getYAxisLabelX, getRightYAxisLabelX, getYAxisTitleX, getRightYAxisTitleX } from '../axisLabelHelpers';
 
 describe('axisLabelHelpers (production exports)', () => {
   it('computes left/right label X', () => {

--- a/src/core/renderCoordinator/axis/__tests__/computeAxisTicks.test.ts
+++ b/src/core/renderCoordinator/axis/__tests__/computeAxisTicks.test.ts
@@ -4,11 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-  generateLinearTicks,
-  createTickFormatter,
-  formatTickValue,
-} from '../computeAxisTicks';
+import { generateLinearTicks, createTickFormatter, formatTickValue } from '../computeAxisTicks';
 
 describe('generateLinearTicks', () => {
   it('generates single tick at midpoint', () => {

--- a/src/core/renderCoordinator/axis/axisLabelHelpers.ts
+++ b/src/core/renderCoordinator/axis/axisLabelHelpers.ts
@@ -3,7 +3,6 @@
  * @module axisLabelHelpers
  */
 
-
 const LABEL_PADDING_CSS_PX = 4;
 
 export function getYAxisLabelX(plotLeftCss: number, tickLengthCssPx: number): number {

--- a/src/core/renderCoordinator/axis/computeAxisTicks.ts
+++ b/src/core/renderCoordinator/axis/computeAxisTicks.ts
@@ -43,10 +43,7 @@ export function generateLinearTicks(domainMin: number, domainMax: number, tickCo
  * @param cap - Maximum number of decimal places to consider (default: 8)
  * @returns Number of decimal places (0 to cap)
  */
-function computeMaxFractionDigitsFromStep(
-  tickStep: number,
-  cap: number = DEFAULT_MAX_TICK_FRACTION_DIGITS
-): number {
+function computeMaxFractionDigitsFromStep(tickStep: number, cap: number = DEFAULT_MAX_TICK_FRACTION_DIGITS): number {
   const stepAbs = Math.abs(tickStep);
   if (!Number.isFinite(stepAbs) || stepAbs === 0) return 0;
 

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -64,6 +64,7 @@ import { enqueueDeviceSubmit, flushDeviceSubmit } from '../gpu/submitBatcher';
 import {
   applyStickyAutoDomain,
   DEFAULT_STICKY_DOMAIN_HEADROOM,
+  DEFAULT_STICKY_X_DOMAIN_HEADROOM,
   resolveStickyOrDataDomain,
   shouldApplyStickyAutoDomain,
   shouldSkipStickyAutoXDomain,
@@ -968,11 +969,11 @@ export function createRenderCoordinator(
   let cachedVisibleYBoundsByAxis: Map<string, { yMin: number; yMax: number }> = new Map();
 
   /**
-   * Sticky auto-range domains (multi-chart / series compression).
-   * Expanding data every frame otherwise forces grid+axis prepare + label rebuild
-   * every append. Hold ~10% headroom and only expand when data breaches the sticky
-   * domain — grow-by style amortization without changing the
-   * sampling contract. Cleared on full setOption / explicit axis domains.
+   * Sticky auto-range domains.
+   * Y: ~10% growBy headroom amortizes overlay rebuild under amplitude noise.
+   * X: headroom 0 so unbounded appendData stays full-width (non-zero pad caused
+   * the ultimate-benchmark empty-right grow/reset loop). Cleared on full
+   * setOption / explicit axis domains / autoScroll.
    */
   let stickyAutoXDomain: { min: number; max: number } | null = null;
   const stickyAutoYDomainByAxis = new Map<string, { min: number; max: number }>();
@@ -980,7 +981,7 @@ export function createRenderCoordinator(
   /**
    * Base X domain used for zoom→visible window, sampling, and slice.
    * Must match paint's sticky / autoScroll / explicit-end gates so decimation
-   * windows agree with GPU scales when sticky headroom is active.
+   * windows agree with GPU scales when sticky is active.
    *
    * - `mode: 'read'`: use existing sticky if active; do not mutate sticky state.
    * - `mode: 'paint'`: applyStickyAutoDomain / clear sticky when skipped or mid-transition.
@@ -1011,7 +1012,8 @@ export function createRenderCoordinator(
         stickyAutoXDomain = null;
         return dataXDomain;
       }
-      const next = applyStickyAutoDomain(dataXDomain, stickyAutoXDomain, DEFAULT_STICKY_DOMAIN_HEADROOM);
+      // X headroom must be 0 — see DEFAULT_STICKY_X_DOMAIN_HEADROOM.
+      const next = applyStickyAutoDomain(dataXDomain, stickyAutoXDomain, DEFAULT_STICKY_X_DOMAIN_HEADROOM);
       stickyAutoXDomain = next;
       return next;
     }

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -4,26 +4,14 @@ import type {
   ResolvedPieSeriesConfig,
   ResolvedSeriesConfig,
 } from '../../config/OptionResolver';
-import type {
-  AnnotationConfig,
-  DataPoint,
-  OHLCDataPoint,
-} from '../../config/types';
+import type { AnnotationConfig, DataPoint, OHLCDataPoint } from '../../config/types';
 import { GPUContext, isHTMLCanvasElement as isHTMLCanvasElementGPU } from '../GPUContext';
 import { createDataStore } from '../../data/createDataStore';
 import { isGpuDecimationEligible } from '../../data/gpuDecimationEligibility';
 import { canRangedAppendLine, type DataStoreBufferKind } from './data/canRangedAppendLine';
-import {
-  buildRuntimeBaseSeries,
-  buildSetOptionsReuseSeries,
-  resolveZoomedSeriesEntry,
-} from './data/seriesPipeline';
+import { buildRuntimeBaseSeries, buildSetOptionsReuseSeries, resolveZoomedSeriesEntry } from './data/seriesPipeline';
 import { createAppendFlush, type AppendFlushDeps } from './data/appendFlush';
-import {
-  sliceVisibleRangeByX,
-  sliceVisibleRangeByOHLC,
-  isTupleOHLCDataPoint,
-} from './data/computeVisibleSlice';
+import { sliceVisibleRangeByX, sliceVisibleRangeByOHLC, isTupleOHLCDataPoint } from './data/computeVisibleSlice';
 import {
   getPointCount,
   getX,
@@ -70,10 +58,7 @@ import {
 import { createAxisRenderer } from '../../renderers/createAxisRenderer';
 import { createGridRenderer } from '../../renderers/createGridRenderer';
 import type { GridArea } from '../../renderers/createGridRenderer';
-import {
-  createRendererPool,
-  ensureRendererPoolsForSeries,
-} from './renderers/rendererPool';
+import { createRendererPool, ensureRendererPoolsForSeries } from './renderers/rendererPool';
 import { createTextureManager } from './gpu/textureManager';
 import { enqueueDeviceSubmit, flushDeviceSubmit } from '../gpu/submitBatcher';
 import {
@@ -83,10 +68,7 @@ import {
   shouldApplyStickyAutoDomain,
   shouldSkipStickyAutoXDomain,
 } from './zoom/stickyAutoDomain';
-import {
-  isFullSpanZoomRange as isFullSpanZoomRangeHelper,
-  scanCartesianVisibleYBounds,
-} from './zoom/visibleYBounds';
+import { isFullSpanZoomRange as isFullSpanZoomRangeHelper, scanCartesianVisibleYBounds } from './zoom/visibleYBounds';
 import { createCrosshairRenderer } from '../../renderers/createCrosshairRenderer';
 import { createHighlightRenderer } from '../../renderers/createHighlightRenderer';
 import { createReferenceLineRenderer } from '../../renderers/createReferenceLineRenderer';
@@ -119,16 +101,8 @@ import type { EasingFunction } from '../../utils/easing';
 import type { ZoomChangeSourceKind } from '../../ChartGPU';
 
 // Canonical pure helpers (one-way cutover — do not re-define below)
-import {
-  getCanvasCssWidth,
-  getCanvasCssHeight,
-  getCanvasCssSizeFromDevicePixels,
-} from './utils/canvasUtils';
-import {
-  finiteOrNull,
-  finiteOrUndefined,
-  getPointXY,
-} from './utils/dataPointUtils';
+import { getCanvasCssWidth, getCanvasCssHeight, getCanvasCssSizeFromDevicePixels } from './utils/canvasUtils';
+import { finiteOrNull, finiteOrUndefined, getPointXY } from './utils/dataPointUtils';
 /* dataPointUtils cutover */
 import {
   computeGridArea,
@@ -139,10 +113,7 @@ import {
   clipXToCanvasCssPx,
   clipYToCanvasCssPx,
 } from './utils/axisUtils';
-import {
-  extendBoundsWithOHLCDataPoints,
-  normalizeDomain,
-} from './utils/boundsComputation';
+import { extendBoundsWithOHLCDataPoints, normalizeDomain } from './utils/boundsComputation';
 import {
   DEFAULT_TICK_COUNT as TIME_DEFAULT_TICK_COUNT,
   resolvePieCenterPlotCss,
@@ -164,10 +135,7 @@ import {
 } from './animation/animationHelpers';
 import { computeCandlestickTooltipAnchorFromMatch } from './ui/tooltipLegendHelpers';
 const computeCandlestickTooltipAnchor = computeCandlestickTooltipAnchorFromMatch;
-import {
-  MAIN_SCENE_MSAA_SAMPLE_COUNT,
-  ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT,
-} from './gpu/textureManager';
+import { MAIN_SCENE_MSAA_SAMPLE_COUNT, ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT } from './gpu/textureManager';
 import {
   createPointerState,
   updatePointerFromMouse,
@@ -187,7 +155,6 @@ import {
   isOHLCDataPoint,
 } from './ui/tooltipLegendHelpers';
 
-
 export interface GPUContextLike {
   readonly device: GPUDevice | null;
   readonly canvas: HTMLCanvasElement | null;
@@ -201,7 +168,6 @@ export interface GPUContextLike {
 const isHTMLCanvasElement = isHTMLCanvasElementGPU;
 
 /** Gets canvas CSS width - clientWidth for HTMLCanvasElement */
-
 
 export interface RenderCoordinator {
   setOptions(resolvedOptions: ResolvedChartGPUOptions): void;
@@ -303,8 +269,7 @@ const LABEL_SIG_FNV_PRIME = 0x01000193;
 const labelSigF64 = new Float64Array(1);
 const labelSigU32 = new Uint32Array(labelSigF64.buffer);
 
-const mixLabelSigUint = (h: number, v: number): number =>
-  Math.imul(h ^ (v >>> 0), LABEL_SIG_FNV_PRIME) >>> 0;
+const mixLabelSigUint = (h: number, v: number): number => Math.imul(h ^ (v >>> 0), LABEL_SIG_FNV_PRIME) >>> 0;
 
 const mixLabelSigFloat = (h: number, f: number): number => {
   labelSigF64[0] = f;
@@ -313,16 +278,9 @@ const mixLabelSigFloat = (h: number, f: number): number => {
   return next;
 };
 
-
-
-
-
 // Story 5.17: CPU-side update interpolation can be expensive for very large series.
 // We still animate domains for large series, but skip per-point y interpolation past this cap.
 const MAX_ANIMATED_POINTS_PER_SERIES = 20_000;
-
-
-
 
 /**
  * Brand for coordinator-owned MutableXYColumns. User-supplied `{ x, y }` arrays
@@ -410,7 +368,6 @@ const extendBoundsWithCartesianData = (bounds: Bounds | null, data: CartesianSer
 
   return { xMin, xMax, yMin, yMax };
 };
-
 
 const computeGlobalXBounds = (
   series: ResolvedChartGPUOptions['series'],
@@ -536,16 +493,6 @@ const computeGlobalYBoundsForAxis = (
   if (yMin === yMax) yMax = yMin + 1;
   return { yMin, yMax };
 };
-
-
-
-
-
-
-
-
-
-
 
 const computeBaseXDomain = (
   options: ResolvedChartGPUOptions,
@@ -681,8 +628,6 @@ const computeVisibleXDomain = (
 
 // Intro phase machine lives in animationHelpers.computeNextIntroPhase (string-literal states).
 type IntroPhase = 'pending' | 'running' | 'done';
-
-
 
 /**
  * Computes container-local CSS pixel anchor coordinates for a candlestick tooltip.
@@ -1048,8 +993,7 @@ export function createRenderCoordinator(
       updateTransitionActive?: boolean;
     }
   ): { min: number; max: number } {
-    const dataXDomain =
-      opts?.dataXDomain ?? computeBaseXDomain(currentOptions, runtimeRawBoundsByIndex);
+    const dataXDomain = opts?.dataXDomain ?? computeBaseXDomain(currentOptions, runtimeRawBoundsByIndex);
 
     if (opts?.updateTransitionActive) {
       if (mode === 'paint') {
@@ -1060,22 +1004,14 @@ export function createRenderCoordinator(
 
     const xExplicitMin = finiteOrUndefined(currentOptions.xAxis.min);
     const xExplicitMax = finiteOrUndefined(currentOptions.xAxis.max);
-    const skipSticky = shouldSkipStickyAutoXDomain(
-      currentOptions.autoScroll,
-      xExplicitMin,
-      xExplicitMax
-    );
+    const skipSticky = shouldSkipStickyAutoXDomain(currentOptions.autoScroll, xExplicitMin, xExplicitMax);
 
     if (mode === 'paint') {
       if (skipSticky) {
         stickyAutoXDomain = null;
         return dataXDomain;
       }
-      const next = applyStickyAutoDomain(
-        dataXDomain,
-        stickyAutoXDomain,
-        DEFAULT_STICKY_DOMAIN_HEADROOM
-      );
+      const next = applyStickyAutoDomain(dataXDomain, stickyAutoXDomain, DEFAULT_STICKY_DOMAIN_HEADROOM);
       stickyAutoXDomain = next;
       return next;
     }
@@ -1101,8 +1037,7 @@ export function createRenderCoordinator(
     // otherwise be an O(N) y-extrema walk.
     const zoomRange = zoomState?.getRange() ?? null;
     const fullSpan = isFullSpanZoomRangeHelper(zoomRange);
-    const seriesForAxis =
-      runtimeBaseSeries.length > 0 ? runtimeBaseSeries : currentOptions.series;
+    const seriesForAxis = runtimeBaseSeries.length > 0 ? runtimeBaseSeries : currentOptions.series;
 
     // Zoomed: filter Y extrema to the visible X window (GPU-decimation series
     // keep full raw on the series; unfiltered scan would use off-window peaks).
@@ -1122,10 +1057,7 @@ export function createRenderCoordinator(
           computeGlobalYBoundsForAxis(seriesForAxis, ax.id!, runtimeRawBoundsByIndex)
         );
       } else {
-        cachedVisibleYBoundsByAxis.set(
-          ax.id!,
-          computeVisibleYBoundsForAxis(renderSeries, ax.id!, xWindow)
-        );
+        cachedVisibleYBoundsByAxis.set(ax.id!, computeVisibleYBoundsForAxis(renderSeries, ax.id!, xWindow));
       }
     }
   };
@@ -1242,11 +1174,9 @@ export function createRenderCoordinator(
 
   // MSAA: default 4× (portable WebGPU max). `antialias: false` → sampleCount 1
   // for multi-chart dashboards / streaming grids (legal values are only 1|4).
-  const msaaSampleCount: 1 | 4 =
-    currentOptions.antialias === false ? 1 : MAIN_SCENE_MSAA_SAMPLE_COUNT;
+  const msaaSampleCount: 1 | 4 = currentOptions.antialias === false ? 1 : MAIN_SCENE_MSAA_SAMPLE_COUNT;
   // Overlay pass (axes/crosshair/highlight/above-series annotations) shares the same rule.
-  const overlayMsaaSampleCount: 1 | 4 =
-    currentOptions.antialias === false ? 1 : ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT;
+  const overlayMsaaSampleCount: 1 | 4 = currentOptions.antialias === false ? 1 : ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT;
 
   const gridRenderer = createGridRenderer(device, {
     targetFormat,
@@ -1364,53 +1294,68 @@ export function createRenderCoordinator(
   };
 
   // Append flush ownership: data/appendFlush.ts
-  const flushPendingAppends = createAppendFlush(() => ({
-      pendingAppendByIndex,
-      appendedGpuThisFrame,
-      zoomState,
-      currentOptions,
-      dataStore,
-      runtimeRawDataByIndex,
-      runtimeRawBoundsByIndex,
-      gpuSeriesKindByIndex,
-      lastSetSeriesCache,
-      filterGapsCache,
-      lastSampledData,
-      warnedSamplingDefeatsFastPath,
-      recomputeRuntimeBaseSeries,
-      recomputeCachedVisibleYBoundsIfNeeded,
-      ensureMutableRuntimeColumns,
-      isOwnedMutableColumns,
-      brandOwnedColumns,
-      computeBaseXDomain,
-      computeVisibleXDomain,
-      isFullSpanZoomRange,
-      computeEffectiveZoomSpanConstraints,
-      extendBoundsWithCartesianData,
-      extendBoundsWithOHLCDataPoints,
-      canRangedAppendLine,
-      isGpuDecimationEligible,
-      normalizeMaxPoints,
-      planMaxPointsWindow,
-      getPointCount,
-      getX,
-      getY,
-      getSize,
-      createRingXYColumns,
-      appendIntoRingXY,
-      dropPrefixXY,
-      createStagingRingView,
-      isRingXYColumns,
-      isStagingRingView,
-      demoteStagingViewAfterRebindFailure,
-      computeRawBoundsFromCartesianData,
-    get runtimeBaseSeries() { return runtimeBaseSeries; },
-    set runtimeBaseSeries(v) { runtimeBaseSeries = v; },
-    get renderSeries() { return renderSeries; },
-    set renderSeries(v) { renderSeries = v; },
-    get pendingZoomSourceKind() { return pendingZoomSourceKind; },
-      set pendingZoomSourceKind(v) { pendingZoomSourceKind = v; },
-  } as AppendFlushDeps));
+  const flushPendingAppends = createAppendFlush(
+    () =>
+      ({
+        pendingAppendByIndex,
+        appendedGpuThisFrame,
+        zoomState,
+        currentOptions,
+        dataStore,
+        runtimeRawDataByIndex,
+        runtimeRawBoundsByIndex,
+        gpuSeriesKindByIndex,
+        lastSetSeriesCache,
+        filterGapsCache,
+        lastSampledData,
+        warnedSamplingDefeatsFastPath,
+        recomputeRuntimeBaseSeries,
+        recomputeCachedVisibleYBoundsIfNeeded,
+        ensureMutableRuntimeColumns,
+        isOwnedMutableColumns,
+        brandOwnedColumns,
+        computeBaseXDomain,
+        computeVisibleXDomain,
+        isFullSpanZoomRange,
+        computeEffectiveZoomSpanConstraints,
+        extendBoundsWithCartesianData,
+        extendBoundsWithOHLCDataPoints,
+        canRangedAppendLine,
+        isGpuDecimationEligible,
+        normalizeMaxPoints,
+        planMaxPointsWindow,
+        getPointCount,
+        getX,
+        getY,
+        getSize,
+        createRingXYColumns,
+        appendIntoRingXY,
+        dropPrefixXY,
+        createStagingRingView,
+        isRingXYColumns,
+        isStagingRingView,
+        demoteStagingViewAfterRebindFailure,
+        computeRawBoundsFromCartesianData,
+        get runtimeBaseSeries() {
+          return runtimeBaseSeries;
+        },
+        set runtimeBaseSeries(v) {
+          runtimeBaseSeries = v;
+        },
+        get renderSeries() {
+          return renderSeries;
+        },
+        set renderSeries(v) {
+          renderSeries = v;
+        },
+        get pendingZoomSourceKind() {
+          return pendingZoomSourceKind;
+        },
+        set pendingZoomSourceKind(v) {
+          pendingZoomSourceKind = v;
+        },
+      }) as AppendFlushDeps
+  );
 
   const executeFlush = (options?: { readonly requestRenderAfter?: boolean }): void => {
     if (disposed) return;
@@ -1685,13 +1630,7 @@ export function createRenderCoordinator(
   };
 
   const onMouseMove = (payload: ChartGPUEventPayload): void => {
-    pointerState = updatePointerFromMouse(
-      payload.x,
-      payload.y,
-      payload.gridX,
-      payload.gridY,
-      payload.isInGrid
-    );
+    pointerState = updatePointerFromMouse(payload.x, payload.y, payload.gridX, payload.gridY, payload.isInGrid);
 
     // If we're over the plot and we have recent interaction scales, update interaction-x in domain units.
     // (Best-effort; render() refreshes scales and overlays.)
@@ -1981,11 +1920,7 @@ export function createRenderCoordinator(
   };
 
   const recomputeRuntimeBaseSeries = (): void => {
-    runtimeBaseSeries = buildRuntimeBaseSeries(
-      currentOptions.series,
-      runtimeRawDataByIndex,
-      runtimeRawBoundsByIndex
-    );
+    runtimeBaseSeries = buildRuntimeBaseSeries(currentOptions.series, runtimeRawDataByIndex, runtimeRawBoundsByIndex);
   };
 
   function sliceRenderSeriesToVisibleRange(): void {
@@ -2085,7 +2020,13 @@ export function createRenderCoordinator(
       }
 
       // Candlestick + cartesian: single pure zoomed resolver (seriesPipeline).
-      if (s.type === 'candlestick' || s.type === 'line' || s.type === 'area' || s.type === 'bar' || s.type === 'scatter') {
+      if (
+        s.type === 'candlestick' ||
+        s.type === 'line' ||
+        s.type === 'area' ||
+        s.type === 'bar' ||
+        s.type === 'scatter'
+      ) {
         const result = resolveZoomedSeriesEntry({
           series: s,
           rawSlot: runtimeRawDataByIndex[i],
@@ -2148,7 +2089,6 @@ export function createRenderCoordinator(
     updateTransition = null;
     resetUpdateInterpolationCaches();
   };
-
 
   const setOptions: RenderCoordinator['setOptions'] = (resolvedOptions) => {
     assertNotDisposed();
@@ -2528,23 +2468,12 @@ export function createRenderCoordinator(
     if (introPhase !== 'done') {
       const introCfg = resolveIntroAnimationConfig(currentOptions.animation);
 
-      const hasDrawableSeriesMarks = hasAnyDrawableMarks(
-        seriesForIntro as ReadonlyArray<AnySeriesConfig>
-      );
+      const hasDrawableSeriesMarks = hasAnyDrawableMarks(seriesForIntro as ReadonlyArray<AnySeriesConfig>);
 
-      const nextIntro = computeNextIntroPhase(
-        introPhase,
-        hasDrawableSeriesMarks,
-        !!introCfg,
-        false
-      );
+      const nextIntro = computeNextIntroPhase(introPhase, hasDrawableSeriesMarks, !!introCfg, false);
       if (nextIntro === 'running' && introPhase === 'pending' && introCfg) {
         const totalMs = introCfg.delayMs + introCfg.durationMs;
-        const easingWithDelay = createEasingWithDelay(
-          introCfg.delayMs,
-          introCfg.durationMs,
-          introCfg.easing
-        );
+        const easingWithDelay = createEasingWithDelay(introCfg.delayMs, introCfg.durationMs, introCfg.easing);
 
         introProgress01 = 0;
         introPhase = 'running';
@@ -2775,8 +2704,7 @@ export function createRenderCoordinator(
     const interactionScalesForHelpers = interactionScales
       ? {
           xScale: interactionScales.xScale,
-          yScale:
-            interactionScales.yScales.values().next().value ?? interactionScales.xScale,
+          yScale: interactionScales.yScales.values().next().value ?? interactionScales.xScale,
           plotWidthCss: interactionScales.plotWidthCss,
           plotHeightCss: interactionScales.plotHeightCss,
         }
@@ -2788,8 +2716,14 @@ export function createRenderCoordinator(
       {
         left: gridArea.left,
         top: gridArea.top,
-        width: Math.max(0, gridArea.canvasWidth / Math.max(1e-6, gridArea.devicePixelRatio || 1) - gridArea.left - gridArea.right),
-        height: Math.max(0, gridArea.canvasHeight / Math.max(1e-6, gridArea.devicePixelRatio || 1) - gridArea.top - gridArea.bottom),
+        width: Math.max(
+          0,
+          gridArea.canvasWidth / Math.max(1e-6, gridArea.devicePixelRatio || 1) - gridArea.left - gridArea.right
+        ),
+        height: Math.max(
+          0,
+          gridArea.canvasHeight / Math.max(1e-6, gridArea.devicePixelRatio || 1) - gridArea.top - gridArea.bottom
+        ),
       }
     );
 
@@ -2886,10 +2820,7 @@ export function createRenderCoordinator(
               const content = formatter
                 ? (formatter as (p: ReadonlyArray<TooltipParams>) => string)(paramsArray)
                 : formatTooltipAxis(paramsArray);
-              if (
-                content &&
-                (shouldUpdateTooltip(tooltipCache, content, containerX, containerY))
-              ) {
+              if (content && shouldUpdateTooltip(tooltipCache, content, containerX, containerY)) {
                 updateTooltipCache(tooltipCache, content, containerX, containerY);
                 showTooltipInternal(containerX, containerY, content, paramsArray);
               } else if (!content) {
@@ -2901,10 +2832,7 @@ export function createRenderCoordinator(
               const content = formatter
                 ? (formatter as (p: TooltipParams) => string)(params)
                 : formatTooltipItem(params);
-              if (
-                content &&
-                (shouldUpdateTooltip(tooltipCache, content, containerX, containerY))
-              ) {
+              if (content && shouldUpdateTooltip(tooltipCache, content, containerX, containerY)) {
                 updateTooltipCache(tooltipCache, content, containerX, containerY);
                 showTooltipInternal(containerX, containerY, content, params);
               } else if (!content) {
@@ -2935,10 +2863,7 @@ export function createRenderCoordinator(
               const content = formatter
                 ? (formatter as (p: ReadonlyArray<TooltipParams>) => string)([params])
                 : formatTooltipItem(params);
-              if (
-                content &&
-                (shouldUpdateTooltip(tooltipCache, content, containerX, containerY))
-              ) {
+              if (content && shouldUpdateTooltip(tooltipCache, content, containerX, containerY)) {
                 updateTooltipCache(tooltipCache, content, containerX, containerY);
                 showTooltipInternal(containerX, containerY, content, [params]);
               } else if (!content) {
@@ -2974,7 +2899,7 @@ export function createRenderCoordinator(
                     const tooltipY = anchor?.y ?? containerY;
                     if (shouldUpdateTooltip(tooltipCache, content, tooltipX, tooltipY)) {
                       updateTooltipCache(tooltipCache, content, tooltipX, tooltipY);
-                showTooltipInternal(tooltipX, tooltipY, content, paramsArray);
+                      showTooltipInternal(tooltipX, tooltipY, content, paramsArray);
                     }
                   } else {
                     hideTooltip();
@@ -3007,7 +2932,7 @@ export function createRenderCoordinator(
                   }
                   if (shouldUpdateTooltip(tooltipCache, content, tooltipX, tooltipY)) {
                     updateTooltipCache(tooltipCache, content, tooltipX, tooltipY);
-                showTooltipInternal(tooltipX, tooltipY, content, paramsArray);
+                    showTooltipInternal(tooltipX, tooltipY, content, paramsArray);
                   }
                 } else {
                   hideTooltip();
@@ -3037,10 +2962,7 @@ export function createRenderCoordinator(
               const content = formatter
                 ? (formatter as (p: TooltipParams) => string)(params)
                 : formatTooltipItem(params);
-              if (
-                content &&
-                (shouldUpdateTooltip(tooltipCache, content, containerX, containerY))
-              ) {
+              if (content && shouldUpdateTooltip(tooltipCache, content, containerX, containerY)) {
                 updateTooltipCache(tooltipCache, content, containerX, containerY);
                 showTooltipInternal(containerX, containerY, content, params);
               } else if (!content) {
@@ -3072,7 +2994,7 @@ export function createRenderCoordinator(
                   const tooltipY = anchor?.y ?? containerY;
                   if (shouldUpdateTooltip(tooltipCache, content, tooltipX, tooltipY)) {
                     updateTooltipCache(tooltipCache, content, tooltipX, tooltipY);
-                showTooltipInternal(tooltipX, tooltipY, content, candlestickResult.params);
+                    showTooltipInternal(tooltipX, tooltipY, content, candlestickResult.params);
                   }
                 } else {
                   hideTooltip();
@@ -3089,12 +3011,9 @@ export function createRenderCoordinator(
                 const content = formatter
                   ? (formatter as (p: TooltipParams) => string)(params)
                   : formatTooltipItem(params);
-                if (
-                  content &&
-                  (shouldUpdateTooltip(tooltipCache, content, containerX, containerY))
-                ) {
+                if (content && shouldUpdateTooltip(tooltipCache, content, containerX, containerY)) {
                   updateTooltipCache(tooltipCache, content, containerX, containerY);
-                showTooltipInternal(containerX, containerY, content, params);
+                  showTooltipInternal(containerX, containerY, content, params);
                 } else if (!content) {
                   hideTooltip();
                 }
@@ -3149,8 +3068,7 @@ export function createRenderCoordinator(
 
     // Prepare bar renderer with animated scale if intro is running
     const introP = introPhase === 'running' ? clamp01(introProgress01) : 1;
-    const yScaleForBars =
-      introP < 1 ? createAnimatedBarYScale(yScale, plotClipRect, introP) : yScale;
+    const yScaleForBars = introP < 1 ? createAnimatedBarYScale(yScale, plotClipRect, introP) : yScale;
     poolState.barRenderer.prepare(visibleBarSeriesConfigs, xScale, yScaleForBars, gridArea);
 
     // Prepare annotation GPU overlays for main vs overlay pipelines (both 4× MSAA).
@@ -3205,12 +3123,7 @@ export function createRenderCoordinator(
       msaaSampleCount,
       hasDenseHairline: hasDenseHairlineLines(poolState, seriesPreparation),
     });
-    const {
-      useDirectSwapchainResolve,
-      useSwapchainAsMainView,
-      needResolveAndOverlay,
-      needMainColor,
-    } = framePlan;
+    const { useDirectSwapchainResolve, useSwapchainAsMainView, needResolveAndOverlay, needMainColor } = framePlan;
     // passOrder drives which optional passes run (dense hairline / overlay).
     const runDenseHairlinePass = framePlanIncludesDenseHairline(framePlan);
     const runAnnotationOverlayPass = framePlanIncludesAnnotationOverlay(framePlan);
@@ -3233,9 +3146,7 @@ export function createRenderCoordinator(
     encodeFrameComputePasses(poolState, seriesForRender, encoder);
 
     const mainPass = encoder.beginRenderPass({
-      label: useDirectSwapchainResolve
-        ? 'renderCoordinator/mainPassDirect'
-        : 'renderCoordinator/mainPass',
+      label: useDirectSwapchainResolve ? 'renderCoordinator/mainPassDirect' : 'renderCoordinator/mainPass',
       colorAttachments: [
         useSwapchainAsMainView
           ? {
@@ -3246,9 +3157,7 @@ export function createRenderCoordinator(
             }
           : {
               view: texState.mainColorView!, // MSAA (4×) main color
-              resolveTarget: useDirectSwapchainResolve
-                ? swapchainView
-                : texState.mainResolveView!, // intermediate resolve for hairline/overlay path
+              resolveTarget: useDirectSwapchainResolve ? swapchainView : texState.mainResolveView!, // intermediate resolve for hairline/overlay path
               clearValue,
               loadOp: 'clear',
               storeOp: 'discard', // MSAA content discarded after resolve

--- a/src/core/renderCoordinator/data/__tests__/appendFlush.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/appendFlush.test.ts
@@ -5,7 +5,10 @@ import { demoteStagingViewAfterRebindFailure } from '../stagingThinPath';
 import { createStagingRingView } from '../../../../data/cartesianData';
 
 function baseDeps(overrides: Partial<AppendFlushDeps> = {}): AppendFlushDeps {
-  const pendingAppendByIndex = new Map<number, AppendFlushDeps['pendingAppendByIndex'] extends Map<number, infer V> ? V : never>();
+  const pendingAppendByIndex = new Map<
+    number,
+    AppendFlushDeps['pendingAppendByIndex'] extends Map<number, infer V> ? V : never
+  >();
   const lastSetSeriesCache = new Map<number, { data: unknown; xOffset: number }>();
   const deps: AppendFlushDeps = {
     pendingAppendByIndex: pendingAppendByIndex as AppendFlushDeps['pendingAppendByIndex'],

--- a/src/core/renderCoordinator/data/__tests__/canRangedAppendLine.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/canRangedAppendLine.test.ts
@@ -80,13 +80,49 @@ describe('canRangedAppendLine', () => {
     ).toBe(false);
   });
 
-  it('rejects non-line series', () => {
+  it('rejects non-line non-area series', () => {
     expect(
       canRangedAppendLine({
         seriesType: 'scatter',
         sampling: 'none',
         kind: 'fullRawLine',
         rawData: raw,
+      })
+    ).toBe(false);
+  });
+
+  it('allows pure area with sampling none (streaming full-raw resident)', () => {
+    expect(
+      canRangedAppendLine({
+        seriesType: 'area',
+        sampling: 'none',
+        kind: 'fullRawLine',
+        rawData: raw,
+        series: { type: 'area', sampling: 'none' } as Pick<ResolvedSeriesConfig, 'type' | 'sampling'>,
+      })
+    ).toBe(true);
+  });
+
+  it('unlocks cold unknown + area + sampling none', () => {
+    expect(
+      canRangedAppendLine({
+        seriesType: 'area',
+        sampling: 'none',
+        kind: 'unknown',
+        rawData: raw,
+        series: { type: 'area', sampling: 'none' } as Pick<ResolvedSeriesConfig, 'type' | 'sampling'>,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects pure area with lttb when kind is unknown (no GPU decimation for area)', () => {
+    expect(
+      canRangedAppendLine({
+        seriesType: 'area',
+        sampling: 'lttb',
+        kind: 'unknown',
+        rawData: raw,
+        series: { type: 'area', sampling: 'lttb' } as Pick<ResolvedSeriesConfig, 'type' | 'sampling'>,
       })
     ).toBe(false);
   });

--- a/src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts
@@ -137,7 +137,6 @@ describe('computeVisibleSlice', () => {
     });
   });
 
-  
   describe('sliceVisibleRangeByX', () => {
     it('slices monotonic tuple data using binary search', () => {
       const data: DataPoint[] = [

--- a/src/core/renderCoordinator/data/__tests__/samplingDirty.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/samplingDirty.test.ts
@@ -24,9 +24,7 @@ function fixtureHash(data: ReadonlyArray<DataPoint>, salt = 0): number {
 
 function lineSeries(data: ReadonlyArray<DataPoint>, extra: Record<string, unknown> = {}): ResolvedSeriesConfig {
   const contentHash =
-    typeof extra.contentHash === 'number'
-      ? (extra.contentHash as number)
-      : fixtureHash(data as DataPoint[]);
+    typeof extra.contentHash === 'number' ? (extra.contentHash as number) : fixtureHash(data as DataPoint[]);
   return {
     type: 'line',
     name: 's',
@@ -99,8 +97,6 @@ describe('samplingDirty predicates (P1-7)', () => {
     const second = resolveOptions({ series: [{ type: 'line', data, sampling: 'none' }] }, { previousResolved: first });
     expect(didSeriesDataLikelyChange(first.series, second.series)).toBe(false);
   });
-
-
 
   it('shouldRecomputeBaselineSampling is false for presentation-only', () => {
     const data: DataPoint[] = [
@@ -191,7 +187,6 @@ describe('samplingDirty predicates (P1-7)', () => {
     expect((patched[0] as { contentHash?: number }).contentHash).toBe(h);
   });
 });
-
 
 describe('OptionResolver sample reuse (P1-7)', () => {
   it('reuses previous sampled data when raw ref, content, and sampling are unchanged', () => {
@@ -430,6 +425,4 @@ describe('OptionResolver sample reuse (P1-7)', () => {
     // Eligibility-sensitive: sampling dirty flags treat areaStyle presence as config change.
     expect(shouldRecomputeBaselineSampling(without.series, withFill.series)).toBe(true);
   });
-
-
 });

--- a/src/core/renderCoordinator/data/__tests__/seriesPipeline.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/seriesPipeline.test.ts
@@ -3,11 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-  buildRuntimeBaseSeries,
-  buildSetOptionsReuseSeries,
-  resolveZoomedSeriesEntry,
-} from '../seriesPipeline';
+import { buildRuntimeBaseSeries, buildSetOptionsReuseSeries, resolveZoomedSeriesEntry } from '../seriesPipeline';
 import type { ResolvedSeriesConfig } from '../../../../config/OptionResolver';
 
 const raw100 = {

--- a/src/core/renderCoordinator/data/appendFlush.ts
+++ b/src/core/renderCoordinator/data/appendFlush.ts
@@ -237,9 +237,20 @@ function flushPendingAppendsImplInner(d: any): boolean {
             // Shared d.planMaxPointsWindow policy keeps GPU length in sync with columns below.
             d.dataStore.appendSeries(seriesIndex, cartesianData, appendGpuOptions);
             d.appendedGpuThisFrame.add(seriesIndex);
-          } catch {
-            // If the DataStore has not been initialized for this index (or any other error occurs),
-            // fall back to the normal full upload path later in render().
+          } catch (err) {
+            // Do NOT fall through to dual-pack + bounds extension: that grew the
+            // CPU/domain past the GPU-resident buffer when append threw at the
+            // storage-binding hard cap (empty-right gutter at ~16.7M pts / 128 MiB).
+            // Unbounded oversize is auto-windowed in DataStore; remaining failures
+            // skip this batch so domain stays tied to GPU data.
+            if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+              console.warn(
+                `[ChartGPU] appendData() GPU append failed for series ${seriesIndex}; ` +
+                  `skipping batch to keep domain in sync with GPU-resident data.`,
+                err
+              );
+            }
+            continue;
           }
         } else if (
           (s.type === 'line' || s.type === 'area') &&

--- a/src/core/renderCoordinator/data/appendFlush.ts
+++ b/src/core/renderCoordinator/data/appendFlush.ts
@@ -238,19 +238,25 @@ function flushPendingAppendsImplInner(d: any): boolean {
             d.dataStore.appendSeries(seriesIndex, cartesianData, appendGpuOptions);
             d.appendedGpuThisFrame.add(seriesIndex);
           } catch (err) {
-            // Do NOT fall through to dual-pack + bounds extension: that grew the
-            // CPU/domain past the GPU-resident buffer when append threw at the
-            // storage-binding hard cap (empty-right gutter at ~16.7M pts / 128 MiB).
-            // Unbounded oversize is auto-windowed in DataStore; remaining failures
-            // skip this batch so domain stays tied to GPU data.
-            if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-              console.warn(
-                `[ChartGPU] appendData() GPU append failed for series ${seriesIndex}; ` +
-                  `skipping batch to keep domain in sync with GPU-resident data.`,
-                err
-              );
+            // Cold path: DataStore has no series yet ("Call setSeries first") — fall
+            // through to dual-pack + full upload on prepare. Device capacity errors
+            // must NOT fall through: that grew CPU/domain past GPU-resident data
+            // (empty-right gutter at ~16.7M pts / 128 MiB). Unbounded oversize is
+            // normally auto-windowed in DataStore; if a hard-cap throw still escapes,
+            // skip the batch so domain stays tied to GPU data.
+            const msg = err instanceof Error ? err.message : String(err);
+            const isDeviceCapacity = /maxStorageBufferBindingSize|maxBufferSize|required buffer size/i.test(msg);
+            if (isDeviceCapacity) {
+              if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+                console.warn(
+                  `[ChartGPU] appendData() hit device buffer limit for series ${seriesIndex}; ` +
+                    `skipping batch to keep domain in sync with GPU-resident data.`,
+                  err
+                );
+              }
+              continue;
             }
-            continue;
+            // Recoverable (cold series / other): dual-pack below + setSeries later.
           }
         } else if (
           (s.type === 'line' || s.type === 'area') &&

--- a/src/core/renderCoordinator/data/appendFlush.ts
+++ b/src/core/renderCoordinator/data/appendFlush.ts
@@ -115,325 +115,196 @@ function flushPendingAppendsImpl(d: AppendFlushDeps): boolean {
 
 /** @internal Ring/staging mutation loop — entry point is {@link flushPendingAppendsImpl}. */
 function flushPendingAppendsImplInner(d: any): boolean {
-    if (d.pendingAppendByIndex.size === 0) return false;
+  if (d.pendingAppendByIndex.size === 0) return false;
 
-    d.appendedGpuThisFrame.clear();
+  d.appendedGpuThisFrame.clear();
 
-    const zoomRangeBefore = d.zoomState?.getRange() ?? null;
-    const canAutoScroll =
-      d.currentOptions.autoScroll === true &&
-      d.zoomState != null &&
-      d.currentOptions.xAxis.min == null &&
-      d.currentOptions.xAxis.max == null;
+  const zoomRangeBefore = d.zoomState?.getRange() ?? null;
+  const canAutoScroll =
+    d.currentOptions.autoScroll === true &&
+    d.zoomState != null &&
+    d.currentOptions.xAxis.min == null &&
+    d.currentOptions.xAxis.max == null;
 
-    // Capture pre-append visible domain so we can preserve it for "panned away" behavior.
-    const prevBaseXDomain = d.computeBaseXDomain(d.currentOptions, d.runtimeRawBoundsByIndex);
-    const prevVisibleXDomain = zoomRangeBefore ? d.computeVisibleXDomain(prevBaseXDomain, zoomRangeBefore) : null;
+  // Capture pre-append visible domain so we can preserve it for "panned away" behavior.
+  const prevBaseXDomain = d.computeBaseXDomain(d.currentOptions, d.runtimeRawBoundsByIndex);
+  const prevVisibleXDomain = zoomRangeBefore ? d.computeVisibleXDomain(prevBaseXDomain, zoomRangeBefore) : null;
 
-    let didAppendAny = false;
+  let didAppendAny = false;
 
-    for (const [seriesIndex, batches] of d.pendingAppendByIndex) {
-      if (batches.length === 0) continue;
-      const s = d.currentOptions.series[seriesIndex];
-      if (!s || s.type === 'pie') continue;
-      didAppendAny = true;
+  for (const [seriesIndex, batches] of d.pendingAppendByIndex) {
+    if (batches.length === 0) continue;
+    const s = d.currentOptions.series[seriesIndex];
+    if (!s || s.type === 'pie') continue;
+    didAppendAny = true;
 
-      if (s.type === 'candlestick') {
-        // Handle candlestick OHLC data.
-        let raw = d.runtimeRawDataByIndex[seriesIndex] as OHLCDataPoint[] | null;
-        if (!raw) {
-          const seed = (s.rawData ?? s.data) as ReadonlyArray<OHLCDataPoint>;
-          raw = seed.length === 0 ? [] : seed.slice();
-          d.runtimeRawDataByIndex[seriesIndex] = raw;
-          d.runtimeRawBoundsByIndex[seriesIndex] = s.rawBounds ?? null;
+    if (s.type === 'candlestick') {
+      // Handle candlestick OHLC data.
+      let raw = d.runtimeRawDataByIndex[seriesIndex] as OHLCDataPoint[] | null;
+      if (!raw) {
+        const seed = (s.rawData ?? s.data) as ReadonlyArray<OHLCDataPoint>;
+        raw = seed.length === 0 ? [] : seed.slice();
+        d.runtimeRawDataByIndex[seriesIndex] = raw;
+        d.runtimeRawBoundsByIndex[seriesIndex] = s.rawBounds ?? null;
+      }
+
+      let didWindow = false;
+      for (const batch of batches) {
+        const ohlcPoints = batch.points as ReadonlyArray<OHLCDataPoint>;
+        const maxPoints = d.normalizeMaxPoints(batch.maxPoints);
+        const prevLen = raw.length;
+        const plan = d.planMaxPointsWindow(prevLen, ohlcPoints.length, maxPoints);
+        if (plan.dropPrevCount > 0) {
+          raw.splice(0, plan.dropPrevCount);
+          didWindow = true;
         }
-
-        let didWindow = false;
-        for (const batch of batches) {
-          const ohlcPoints = batch.points as ReadonlyArray<OHLCDataPoint>;
-          const maxPoints = d.normalizeMaxPoints(batch.maxPoints);
-          const prevLen = raw.length;
-          const plan = d.planMaxPointsWindow(prevLen, ohlcPoints.length, maxPoints);
-          if (plan.dropPrevCount > 0) {
-            raw.splice(0, plan.dropPrevCount);
-            didWindow = true;
-          }
-          if (plan.keepNewCount > 0) {
-            const start = plan.newSrcOffset;
-            const end = start + plan.keepNewCount;
-            for (let i = start; i < end; i++) {
-              raw.push(ohlcPoints[i]!);
-            }
-          }
-          if (!plan.didWindow) {
-            d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithOHLCDataPoints(
-              d.runtimeRawBoundsByIndex[seriesIndex],
-              ohlcPoints
-            );
-          } else {
-            didWindow = true;
+        if (plan.keepNewCount > 0) {
+          const start = plan.newSrcOffset;
+          const end = start + plan.keepNewCount;
+          for (let i = start; i < end; i++) {
+            raw.push(ohlcPoints[i]!);
           }
         }
-        if (didWindow) {
-          // Windowing can invalidate prior y/x extrema — full rescan.
-          d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithOHLCDataPoints(null, raw);
+        if (!plan.didWindow) {
+          d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithOHLCDataPoints(
+            d.runtimeRawBoundsByIndex[seriesIndex],
+            ohlcPoints
+          );
+        } else {
+          didWindow = true;
         }
-      } else {
-        // Handle other cartesian series (line, area, bar, scatter).
-        // Optional fast-path: append just the new points when the DataStore buffer
-        // holds full raw line data (sampling='none' any zoom, or GPU decimation raw).
-        const kind = d.gpuSeriesKindByIndex[seriesIndex] ?? 'unknown';
-        const existingRuntime = d.runtimeRawDataByIndex[seriesIndex] as CartesianSeriesData | null;
-        const rawForAppend = existingRuntime ?? ((s.rawData ?? s.data) as CartesianSeriesData);
-        const canUseFastPath = d.canRangedAppendLine({
-          seriesType: s.type,
-          sampling: (s as { sampling?: string }).sampling as any,
-          kind,
-          rawData: rawForAppend,
-          series: s as any,
-        });
+      }
+      if (didWindow) {
+        // Windowing can invalidate prior y/x extrema — full rescan.
+        d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithOHLCDataPoints(null, raw);
+      }
+    } else {
+      // Handle other cartesian series (line, area, bar, scatter).
+      // Optional fast-path: append just the new points when the DataStore buffer
+      // holds full raw line data (sampling='none' any zoom, or GPU decimation raw).
+      const kind = d.gpuSeriesKindByIndex[seriesIndex] ?? 'unknown';
+      const existingRuntime = d.runtimeRawDataByIndex[seriesIndex] as CartesianSeriesData | null;
+      const rawForAppend = existingRuntime ?? ((s.rawData ?? s.data) as CartesianSeriesData);
+      const canUseFastPath = d.canRangedAppendLine({
+        seriesType: s.type,
+        sampling: (s as { sampling?: string }).sampling as any,
+        kind,
+        rawData: rawForAppend,
+        series: s as any,
+      });
 
-        // Thin path = GPU append fast path: bind coordinator raw to DataStore
-        // staging (zero-copy) instead of dual-packing into any /
-        // growing any every frame.
-        const useStagingThinPath = canUseFastPath;
+      // Thin path = GPU append fast path: bind coordinator raw to DataStore
+      // staging (zero-copy) instead of dual-packing into any /
+      // growing any every frame.
+      const useStagingThinPath = canUseFastPath;
 
-        // setOption rewrite may store a raw DataPoint[] ref — promote before mutate
-        // (unless thin path will replace the slot with a staging view).
-        let raw: any = null;
-        if (!useStagingThinPath) {
-          raw = d.ensureMutableRuntimeColumns(seriesIndex, s);
-        } else if (d.isStagingRingView(existingRuntime)) {
-          raw = existingRuntime;
-        } else if (d.isRingXYColumns(existingRuntime)) {
-          raw = existingRuntime;
+      // setOption rewrite may store a raw DataPoint[] ref — promote before mutate
+      // (unless thin path will replace the slot with a staging view).
+      let raw: any = null;
+      if (!useStagingThinPath) {
+        raw = d.ensureMutableRuntimeColumns(seriesIndex, s);
+      } else if (d.isStagingRingView(existingRuntime)) {
+        raw = existingRuntime;
+      } else if (d.isRingXYColumns(existingRuntime)) {
+        raw = existingRuntime;
+      }
+
+      let didWindow = false;
+      for (const batch of batches) {
+        const cartesianData = batch.points as CartesianSeriesData;
+        const maxPoints = d.normalizeMaxPoints(batch.maxPoints);
+        const appendGpuOptions = maxPoints != null ? ({ maxPoints } as const) : undefined;
+
+        // prevLen for d.planMaxPointsWindow: staging view / ring / linear / DataStore.
+        let prevLen = 0;
+        if (d.isStagingRingView(raw)) {
+          prevLen = raw.count;
+        } else if (d.isRingXYColumns(raw)) {
+          prevLen = raw.count;
+        } else if (raw != null && d.isOwnedMutableColumns(raw)) {
+          prevLen = (raw as any).x.length;
+        } else {
+          try {
+            prevLen = d.dataStore.getSeriesPointCount(seriesIndex);
+          } catch {
+            prevLen = existingRuntime ? d.getPointCount(existingRuntime) : 0;
+          }
         }
 
-        let didWindow = false;
-        for (const batch of batches) {
-          const cartesianData = batch.points as CartesianSeriesData;
-          const maxPoints = d.normalizeMaxPoints(batch.maxPoints);
-          const appendGpuOptions = maxPoints != null ? ({ maxPoints } as const) : undefined;
-
-          // prevLen for d.planMaxPointsWindow: staging view / ring / linear / DataStore.
-          let prevLen = 0;
-          if (d.isStagingRingView(raw)) {
-            prevLen = raw.count;
-          } else if (d.isRingXYColumns(raw)) {
-            prevLen = raw.count;
-          } else if (raw != null && d.isOwnedMutableColumns(raw)) {
-            prevLen = (raw as any).x.length;
-          } else {
-            try {
-              prevLen = d.dataStore.getSeriesPointCount(seriesIndex);
-            } catch {
-              prevLen = existingRuntime ? d.getPointCount(existingRuntime) : 0;
-            }
+        if (canUseFastPath) {
+          try {
+            // Pass CartesianSeriesData directly to DataStore (avoids per-point allocations).
+            // Shared d.planMaxPointsWindow policy keeps GPU length in sync with columns below.
+            d.dataStore.appendSeries(seriesIndex, cartesianData, appendGpuOptions);
+            d.appendedGpuThisFrame.add(seriesIndex);
+          } catch {
+            // If the DataStore has not been initialized for this index (or any other error occurs),
+            // fall back to the normal full upload path later in render().
           }
+        } else if (
+          (s.type === 'line' || s.type === 'area') &&
+          s.sampling !== 'none' &&
+          !canUseFastPath &&
+          !d.warnedSamplingDefeatsFastPath.has(seriesIndex)
+        ) {
+          // Warn users that sampling defeats the incremental append optimization.
+          // Pure area is never GPU-decimation eligible — only recommend sampling='none'.
+          d.warnedSamplingDefeatsFastPath.add(seriesIndex);
+          const advice =
+            s.type === 'area'
+              ? `For optimal streaming performance, use sampling='none'. `
+              : `For optimal streaming performance, use sampling='none' or rely on GPU decimation for lttb/min/max. `;
+          console.warn(
+            `[ChartGPU] appendData() on series ${seriesIndex} with sampling='${s.sampling}' causes full buffer re-upload every frame. ` +
+              advice +
+              `See docs/internal/INCREMENTAL_APPEND_OPTIMIZATION.md for details.`
+          );
+        }
 
-          if (canUseFastPath) {
-            try {
-              // Pass CartesianSeriesData directly to DataStore (avoids per-point allocations).
-              // Shared d.planMaxPointsWindow policy keeps GPU length in sync with columns below.
-              d.dataStore.appendSeries(seriesIndex, cartesianData, appendGpuOptions);
-              d.appendedGpuThisFrame.add(seriesIndex);
-            } catch {
-              // If the DataStore has not been initialized for this index (or any other error occurs),
-              // fall back to the normal full upload path later in render().
-            }
-          } else if (
-            s.type === 'line' &&
-            s.sampling !== 'none' &&
-            !canUseFastPath &&
-            !d.warnedSamplingDefeatsFastPath.has(seriesIndex)
-          ) {
-            // Warn users that sampling defeats the incremental append optimization
-            d.warnedSamplingDefeatsFastPath.add(seriesIndex);
-            console.warn(
-              `[ChartGPU] appendData() on series ${seriesIndex} with sampling='${s.sampling}' causes full buffer re-upload every frame. ` +
-                `For optimal streaming performance, use sampling='none' or rely on GPU decimation for lttb/min/max. ` +
-                `See docs/internal/INCREMENTAL_APPEND_OPTIMIZATION.md for details.`
-            );
-          }
-
-          // Thin path: after GPU modular/ranged append, point coordinator raw at
-          // staging (no RingXY / MutableXY dual-pack). Bounds from O(1) endpoints
-          // + new-batch y. FIFO (maxPoints) and unbounded pure growth both qualify.
-          if (useStagingThinPath && d.appendedGpuThisFrame.has(seriesIndex)) {
-            const n = d.getPointCount(cartesianData);
-            const plan = d.planMaxPointsWindow(prevLen, n, maxPoints);
-            try {
-              const layout = d.dataStore.getSeriesRingLayout(seriesIndex);
-              const staging = d.dataStore.getSeriesStagingBuffer(seriesIndex);
-              const count = d.dataStore.getSeriesPointCount(seriesIndex);
-              const xOffset = d.dataStore.getSeriesXOffset(seriesIndex);
-              const prevView = d.isStagingRingView(raw) ? raw : null;
-              raw = d.createStagingRingView(staging, layout.start, layout.capacity, count, xOffset, prevView);
-              d.runtimeRawDataByIndex[seriesIndex] = raw;
-
-              // O(1) x endpoints from any (staging is mirrored) +
-              // O(append) y scan of the new batch. Never shrinks y on drop —
-              // same conservative product policy as any path.
-              const x0 = d.getX(raw as unknown as CartesianSeriesData, 0);
-              const x1 = d.getX(raw as unknown as CartesianSeriesData, Math.max(0, count - 1));
-              const prevB = d.runtimeRawBoundsByIndex[seriesIndex];
-              let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
-              let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
-              const end = plan.newSrcOffset + plan.keepNewCount;
-              // FIFO / compression suite: shared Float64 y columns — scan column
-              // directly (avoid d.getY dispatch × large append batches / frame).
-              const yCol =
-                typeof cartesianData === 'object' &&
-                cartesianData !== null &&
-                !Array.isArray(cartesianData) &&
-                !d.isStagingRingView(cartesianData) &&
-                !d.isRingXYColumns(cartesianData) &&
-                'y' in cartesianData
-                  ? (cartesianData as { y: ArrayLike<number> }).y
-                  : null;
-              if (yCol != null) {
-                for (let i = plan.newSrcOffset; i < end; i++) {
-                  const y = yCol[i] as number;
-                  if (Number.isFinite(y)) {
-                    if (y < yMin) yMin = y;
-                    if (y > yMax) yMax = y;
-                  }
-                }
-              } else {
-                for (let i = plan.newSrcOffset; i < end; i++) {
-                  const y = d.getY(cartesianData, i);
-                  if (Number.isFinite(y)) {
-                    if (y < yMin) yMin = y;
-                    if (y > yMax) yMax = y;
-                  }
-                }
-              }
-              if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
-                let xMin = x0;
-                let xMax = x1;
-                if (xMin === xMax) xMax = xMin + 1;
-                if (yMin === yMax) yMax = yMin + 1;
-                d.runtimeRawBoundsByIndex[seriesIndex] = {
-                  xMin,
-                  xMax,
-                  yMin,
-                  yMax,
-                };
-              } else if (plan.didWindow) {
-                didWindow = true;
-              }
-            } catch {
-              // DataStore not ready or rebind failed after append — demote any
-              // stale any so fallthrough dual-pack can re-sync.
-              raw = d.demoteStagingViewAfterRebindFailure(raw);
-            }
-            if (d.isStagingRingView(raw)) {
-              continue;
-            }
-          }
-
-          // Full column path (thin path ineligible / rebind failed).
-          if (raw == null || d.isStagingRingView(raw)) {
-            raw = d.ensureMutableRuntimeColumns(seriesIndex, s);
-          }
-
-          // Update runtime columnar storage with the same window policy as DataStore.
+        // Thin path: after GPU modular/ranged append, point coordinator raw at
+        // staging (no RingXY / MutableXY dual-pack). Bounds from O(1) endpoints
+        // + new-batch y. FIFO (maxPoints) and unbounded pure growth both qualify.
+        if (useStagingThinPath && d.appendedGpuThisFrame.has(seriesIndex)) {
           const n = d.getPointCount(cartesianData);
-          let plan = d.planMaxPointsWindow(prevLen, n, maxPoints);
+          const plan = d.planMaxPointsWindow(prevLen, n, maxPoints);
+          try {
+            const layout = d.dataStore.getSeriesRingLayout(seriesIndex);
+            const staging = d.dataStore.getSeriesStagingBuffer(seriesIndex);
+            const count = d.dataStore.getSeriesPointCount(seriesIndex);
+            const xOffset = d.dataStore.getSeriesXOffset(seriesIndex);
+            const prevView = d.isStagingRingView(raw) ? raw : null;
+            raw = d.createStagingRingView(staging, layout.start, layout.capacity, count, xOffset, prevView);
+            d.runtimeRawDataByIndex[seriesIndex] = raw;
 
-          // Leave-ring or capacity mismatch: demote RingXY → chronological linear
-          // so we match DataStore rebuild (linearize + ringStart=0).
-          if (d.isRingXYColumns(raw)) {
-            const capMismatch = plan.isRing && plan.ringCapacity > 0 && raw.capacity !== plan.ringCapacity;
-            if (!plan.isRing || capMismatch) {
-              const demoted = d.brandOwnedColumns({
-                x: [] as number[],
-                y: [] as number[],
-              });
-              const count = raw.count;
-              for (let i = 0; i < count; i++) {
-                demoted.x.push(d.getX(raw as unknown as CartesianSeriesData, i));
-                demoted.y.push(d.getY(raw as unknown as CartesianSeriesData, i));
-              }
-              raw = demoted;
-              d.runtimeRawDataByIndex[seriesIndex] = demoted;
-              prevLen = demoted.x.length;
-              plan = d.planMaxPointsWindow(prevLen, n, maxPoints);
-            }
-          }
-
-          // Promote to modular ring when maxPoints is active so steady-state
-          // FIFO is O(append) on CPU columns (no O(n) dropPrefix every frame).
-          if (plan.isRing && plan.ringCapacity > 0 && !d.isRingXYColumns(raw)) {
-            const linear = raw as any;
-            const ring = d.createRingXYColumns(plan.ringCapacity);
-            // Tail of linear matches d.planMaxPointsWindow drop semantics when
-            // prevCount > capacity (keep last min(prev, cap) before packing new).
-            const seedCount = Math.min(linear.x.length, plan.ringCapacity);
-            const seedStart = Math.max(0, linear.x.length - seedCount);
-            for (let i = 0; i < seedCount; i++) {
-              ring.x[i] = linear.x[seedStart + i]!;
-              ring.y[i] = linear.y[seedStart + i]!;
-            }
-            ring.count = seedCount;
-            ring.start = 0;
-            raw = ring;
-            d.runtimeRawDataByIndex[seriesIndex] = ring;
-            // Re-plan against the ring's current length (may have trimmed seed).
-            const plan2 = d.planMaxPointsWindow(ring.count, n, maxPoints);
-            d.appendIntoRingXY(ring, cartesianData, plan2.newSrcOffset, plan2.keepNewCount, plan2.dropPrevCount);
-            if (plan2.didWindow) {
-              // Promote+window: cheap endpoint bounds (same as steady ring path).
-              // Note: y-range never shrinks on drop (O(1) conservative); x uses ends.
-              const x0 = d.getX(ring as unknown as CartesianSeriesData, 0);
-              const x1 = d.getX(ring as unknown as CartesianSeriesData, ring.count - 1);
-              const prevB = d.runtimeRawBoundsByIndex[seriesIndex];
-              let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
-              let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
-              const end = plan2.newSrcOffset + plan2.keepNewCount;
-              for (let i = plan2.newSrcOffset; i < end; i++) {
-                const y = d.getY(cartesianData, i);
+            // O(1) x endpoints from any (staging is mirrored) +
+            // O(append) y scan of the new batch. Never shrinks y on drop —
+            // same conservative product policy as any path.
+            const x0 = d.getX(raw as unknown as CartesianSeriesData, 0);
+            const x1 = d.getX(raw as unknown as CartesianSeriesData, Math.max(0, count - 1));
+            const prevB = d.runtimeRawBoundsByIndex[seriesIndex];
+            let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
+            let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
+            const end = plan.newSrcOffset + plan.keepNewCount;
+            // FIFO / compression suite: shared Float64 y columns — scan column
+            // directly (avoid d.getY dispatch × large append batches / frame).
+            const yCol =
+              typeof cartesianData === 'object' &&
+              cartesianData !== null &&
+              !Array.isArray(cartesianData) &&
+              !d.isStagingRingView(cartesianData) &&
+              !d.isRingXYColumns(cartesianData) &&
+              'y' in cartesianData
+                ? (cartesianData as { y: ArrayLike<number> }).y
+                : null;
+            if (yCol != null) {
+              for (let i = plan.newSrcOffset; i < end; i++) {
+                const y = yCol[i] as number;
                 if (Number.isFinite(y)) {
                   if (y < yMin) yMin = y;
                   if (y > yMax) yMax = y;
                 }
               }
-              if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
-                let xMin = x0;
-                let xMax = x1;
-                if (xMin === xMax) xMax = xMin + 1;
-                if (yMin === yMax) yMax = yMin + 1;
-                d.runtimeRawBoundsByIndex[seriesIndex] = {
-                  xMin,
-                  xMax,
-                  yMin,
-                  yMax,
-                };
-              } else {
-                didWindow = true;
-              }
             } else {
-              d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithCartesianData(
-                d.runtimeRawBoundsByIndex[seriesIndex],
-                cartesianData
-              );
-            }
-            continue;
-          }
-
-          if (d.isRingXYColumns(raw)) {
-            d.appendIntoRingXY(raw, cartesianData, plan.newSrcOffset, plan.keepNewCount, plan.dropPrevCount);
-            if (plan.didWindow) {
-              // O(1) endpoint bounds for ring (avoid O(n) full rescan every wrap frame).
-              // y-range never shrinks when peaks leave the window (intentionally
-              // conservative product behavior for high-rate FIFO). x uses
-              // chronological ends of the retained ring.
-              const prevB = d.runtimeRawBoundsByIndex[seriesIndex];
-              const x0 = d.getX(raw as unknown as CartesianSeriesData, 0);
-              const x1 = d.getX(raw as unknown as CartesianSeriesData, raw.count - 1);
-              let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
-              let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
-              const end = plan.newSrcOffset + plan.keepNewCount;
               for (let i = plan.newSrcOffset; i < end; i++) {
                 const y = d.getY(cartesianData, i);
                 if (Number.isFinite(y)) {
@@ -441,191 +312,321 @@ function flushPendingAppendsImplInner(d: any): boolean {
                   if (y > yMax) yMax = y;
                 }
               }
-              if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
-                let xMin = x0;
-                let xMax = x1;
-                if (xMin === xMax) xMax = xMin + 1;
-                if (yMin === yMax) yMax = yMin + 1;
-                d.runtimeRawBoundsByIndex[seriesIndex] = {
-                  xMin,
-                  xMax,
-                  yMin,
-                  yMax,
-                };
-              } else {
-                didWindow = true; // fall through to full rescan below
-              }
-            } else {
-              d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithCartesianData(
-                d.runtimeRawBoundsByIndex[seriesIndex],
-                cartesianData
-              );
             }
+            if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
+              let xMin = x0;
+              let xMax = x1;
+              if (xMin === xMax) xMax = xMin + 1;
+              if (yMin === yMax) yMax = yMin + 1;
+              d.runtimeRawBoundsByIndex[seriesIndex] = {
+                xMin,
+                xMax,
+                yMin,
+                yMax,
+              };
+            } else if (plan.didWindow) {
+              didWindow = true;
+            }
+          } catch {
+            // DataStore not ready or rebind failed after append — demote any
+            // stale any so fallthrough dual-pack can re-sync.
+            raw = d.demoteStagingViewAfterRebindFailure(raw);
+          }
+          if (d.isStagingRingView(raw)) {
             continue;
           }
+        }
 
-          // Linear any path (unbounded append or demoted ring).
-          const linear = raw as any;
-          if (plan.dropPrevCount > 0) {
-            d.dropPrefixXY(linear.x, linear.y, plan.dropPrevCount, linear.size);
-            didWindow = true;
-          }
-          const rawLenBefore = linear.x.length;
-          const end = plan.newSrcOffset + plan.keepNewCount;
-          for (let i = plan.newSrcOffset; i < end; i++) {
-            linear.x.push(d.getX(cartesianData, i));
-            linear.y.push(d.getY(cartesianData, i));
+        // Full column path (thin path ineligible / rebind failed).
+        if (raw == null || d.isStagingRingView(raw)) {
+          raw = d.ensureMutableRuntimeColumns(seriesIndex, s);
+        }
 
-            const sizeValue = d.getSize(cartesianData, i);
-            if (sizeValue !== undefined) {
-              if (!linear.size) {
-                linear.size = new Array(rawLenBefore + (i - plan.newSrcOffset));
-              }
-              linear.size.push(sizeValue);
-            } else if (linear.size) {
-              linear.size.push(undefined);
+        // Update runtime columnar storage with the same window policy as DataStore.
+        const n = d.getPointCount(cartesianData);
+        let plan = d.planMaxPointsWindow(prevLen, n, maxPoints);
+
+        // Leave-ring or capacity mismatch: demote RingXY → chronological linear
+        // so we match DataStore rebuild (linearize + ringStart=0).
+        if (d.isRingXYColumns(raw)) {
+          const capMismatch = plan.isRing && plan.ringCapacity > 0 && raw.capacity !== plan.ringCapacity;
+          if (!plan.isRing || capMismatch) {
+            const demoted = d.brandOwnedColumns({
+              x: [] as number[],
+              y: [] as number[],
+            });
+            const count = raw.count;
+            for (let i = 0; i < count; i++) {
+              demoted.x.push(d.getX(raw as unknown as CartesianSeriesData, i));
+              demoted.y.push(d.getY(raw as unknown as CartesianSeriesData, i));
             }
+            raw = demoted;
+            d.runtimeRawDataByIndex[seriesIndex] = demoted;
+            prevLen = demoted.x.length;
+            plan = d.planMaxPointsWindow(prevLen, n, maxPoints);
           }
+        }
 
-          if (!plan.didWindow) {
+        // Promote to modular ring when maxPoints is active so steady-state
+        // FIFO is O(append) on CPU columns (no O(n) dropPrefix every frame).
+        if (plan.isRing && plan.ringCapacity > 0 && !d.isRingXYColumns(raw)) {
+          const linear = raw as any;
+          const ring = d.createRingXYColumns(plan.ringCapacity);
+          // Tail of linear matches d.planMaxPointsWindow drop semantics when
+          // prevCount > capacity (keep last min(prev, cap) before packing new).
+          const seedCount = Math.min(linear.x.length, plan.ringCapacity);
+          const seedStart = Math.max(0, linear.x.length - seedCount);
+          for (let i = 0; i < seedCount; i++) {
+            ring.x[i] = linear.x[seedStart + i]!;
+            ring.y[i] = linear.y[seedStart + i]!;
+          }
+          ring.count = seedCount;
+          ring.start = 0;
+          raw = ring;
+          d.runtimeRawDataByIndex[seriesIndex] = ring;
+          // Re-plan against the ring's current length (may have trimmed seed).
+          const plan2 = d.planMaxPointsWindow(ring.count, n, maxPoints);
+          d.appendIntoRingXY(ring, cartesianData, plan2.newSrcOffset, plan2.keepNewCount, plan2.dropPrevCount);
+          if (plan2.didWindow) {
+            // Promote+window: cheap endpoint bounds (same as steady ring path).
+            // Note: y-range never shrinks on drop (O(1) conservative); x uses ends.
+            const x0 = d.getX(ring as unknown as CartesianSeriesData, 0);
+            const x1 = d.getX(ring as unknown as CartesianSeriesData, ring.count - 1);
+            const prevB = d.runtimeRawBoundsByIndex[seriesIndex];
+            let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
+            let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
+            const end = plan2.newSrcOffset + plan2.keepNewCount;
+            for (let i = plan2.newSrcOffset; i < end; i++) {
+              const y = d.getY(cartesianData, i);
+              if (Number.isFinite(y)) {
+                if (y < yMin) yMin = y;
+                if (y > yMax) yMax = y;
+              }
+            }
+            if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
+              let xMin = x0;
+              let xMax = x1;
+              if (xMin === xMax) xMax = xMin + 1;
+              if (yMin === yMax) yMax = yMin + 1;
+              d.runtimeRawBoundsByIndex[seriesIndex] = {
+                xMin,
+                xMax,
+                yMin,
+                yMax,
+              };
+            } else {
+              didWindow = true;
+            }
+          } else {
             d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithCartesianData(
               d.runtimeRawBoundsByIndex[seriesIndex],
               cartesianData
             );
+          }
+          continue;
+        }
+
+        if (d.isRingXYColumns(raw)) {
+          d.appendIntoRingXY(raw, cartesianData, plan.newSrcOffset, plan.keepNewCount, plan.dropPrevCount);
+          if (plan.didWindow) {
+            // O(1) endpoint bounds for ring (avoid O(n) full rescan every wrap frame).
+            // y-range never shrinks when peaks leave the window (intentionally
+            // conservative product behavior for high-rate FIFO). x uses
+            // chronological ends of the retained ring.
+            const prevB = d.runtimeRawBoundsByIndex[seriesIndex];
+            const x0 = d.getX(raw as unknown as CartesianSeriesData, 0);
+            const x1 = d.getX(raw as unknown as CartesianSeriesData, raw.count - 1);
+            let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
+            let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
+            const end = plan.newSrcOffset + plan.keepNewCount;
+            for (let i = plan.newSrcOffset; i < end; i++) {
+              const y = d.getY(cartesianData, i);
+              if (Number.isFinite(y)) {
+                if (y < yMin) yMin = y;
+                if (y > yMax) yMax = y;
+              }
+            }
+            if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
+              let xMin = x0;
+              let xMax = x1;
+              if (xMin === xMax) xMax = xMin + 1;
+              if (yMin === yMax) yMax = yMin + 1;
+              d.runtimeRawBoundsByIndex[seriesIndex] = {
+                xMin,
+                xMax,
+                yMin,
+                yMax,
+              };
+            } else {
+              didWindow = true; // fall through to full rescan below
+            }
           } else {
-            didWindow = true;
+            d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithCartesianData(
+              d.runtimeRawBoundsByIndex[seriesIndex],
+              cartesianData
+            );
+          }
+          continue;
+        }
+
+        // Linear any path (unbounded append or demoted ring).
+        const linear = raw as any;
+        if (plan.dropPrevCount > 0) {
+          d.dropPrefixXY(linear.x, linear.y, plan.dropPrevCount, linear.size);
+          didWindow = true;
+        }
+        const rawLenBefore = linear.x.length;
+        const end = plan.newSrcOffset + plan.keepNewCount;
+        for (let i = plan.newSrcOffset; i < end; i++) {
+          linear.x.push(d.getX(cartesianData, i));
+          linear.y.push(d.getY(cartesianData, i));
+
+          const sizeValue = d.getSize(cartesianData, i);
+          if (sizeValue !== undefined) {
+            if (!linear.size) {
+              linear.size = new Array(rawLenBefore + (i - plan.newSrcOffset));
+            }
+            linear.size.push(sizeValue);
+          } else if (linear.size) {
+            linear.size.push(undefined);
           }
         }
 
-        if (didWindow) {
-          // Dropping a prefix can invalidate xMin / y extrema — rescan retained window.
-          d.runtimeRawBoundsByIndex[seriesIndex] = d.computeRawBoundsFromCartesianData(raw as CartesianSeriesData);
+        if (!plan.didWindow) {
+          d.runtimeRawBoundsByIndex[seriesIndex] = d.extendBoundsWithCartesianData(
+            d.runtimeRawBoundsByIndex[seriesIndex],
+            cartesianData
+          );
+        } else {
+          didWindow = true;
         }
       }
 
-      // Data changed under a possibly-stable ref — clear filterGaps + sampled
-      // caches. Re-seed d.lastSetSeriesCache with the post-append runtime raw so
-      // the first idle prepare hits the identity skip instead of setSeries,
-      // which would linearize an active modular ring (issue 0.2).
-      d.lastSampledData[seriesIndex] = null;
-      d.filterGapsCache.delete(seriesIndex);
-      const reseedRaw = d.runtimeRawDataByIndex[seriesIndex];
-      if (reseedRaw != null) {
-        let reseedXOffset = 0;
-        if (d.isStagingRingView(reseedRaw)) {
-          reseedXOffset = reseedRaw.xOffset;
-        } else {
-          try {
-            reseedXOffset = d.dataStore.getSeriesXOffset(seriesIndex);
-          } catch {
-            reseedXOffset = 0;
-          }
-        }
-        d.lastSetSeriesCache.set(seriesIndex, {
-          data: reseedRaw,
-          xOffset: reseedXOffset,
-        });
-      } else {
-        d.lastSetSeriesCache.delete(seriesIndex);
+      if (didWindow) {
+        // Dropping a prefix can invalidate xMin / y extrema — rescan retained window.
+        d.runtimeRawBoundsByIndex[seriesIndex] = d.computeRawBoundsFromCartesianData(raw as CartesianSeriesData);
       }
     }
 
-    d.pendingAppendByIndex.clear();
-    if (!didAppendAny) return false;
+    // Data changed under a possibly-stable ref — clear filterGaps + sampled
+    // caches. Re-seed d.lastSetSeriesCache with the post-append runtime raw so
+    // the first idle prepare hits the identity skip instead of setSeries,
+    // which would linearize an active modular ring (issue 0.2).
+    d.lastSampledData[seriesIndex] = null;
+    d.filterGapsCache.delete(seriesIndex);
+    const reseedRaw = d.runtimeRawDataByIndex[seriesIndex];
+    if (reseedRaw != null) {
+      let reseedXOffset = 0;
+      if (d.isStagingRingView(reseedRaw)) {
+        reseedXOffset = reseedRaw.xOffset;
+      } else {
+        try {
+          reseedXOffset = d.dataStore.getSeriesXOffset(seriesIndex);
+        } catch {
+          reseedXOffset = 0;
+        }
+      }
+      d.lastSetSeriesCache.set(seriesIndex, {
+        data: reseedRaw,
+        xOffset: reseedXOffset,
+      });
+    } else {
+      d.lastSetSeriesCache.delete(seriesIndex);
+    }
+  }
 
-    // Dataset-aware zoom span constraints depend on raw point density.
-    // When streaming appends add points, recompute and apply constraints so wheel+slider remain consistent.
-    // Arm auto-scroll source kind before setSpanConstraints (clamping may emit onChange).
-    if (canAutoScroll) d.pendingZoomSourceKind = 'auto-scroll';
-    if (d.zoomState) {
-      const constraints = d.computeEffectiveZoomSpanConstraints();
-      const withConstraints = d.zoomState as unknown as {
-        setSpanConstraints?: (minSpan: number, maxSpan: number) => void;
+  d.pendingAppendByIndex.clear();
+  if (!didAppendAny) return false;
+
+  // Dataset-aware zoom span constraints depend on raw point density.
+  // When streaming appends add points, recompute and apply constraints so wheel+slider remain consistent.
+  // Arm auto-scroll source kind before setSpanConstraints (clamping may emit onChange).
+  if (canAutoScroll) d.pendingZoomSourceKind = 'auto-scroll';
+  if (d.zoomState) {
+    const constraints = d.computeEffectiveZoomSpanConstraints();
+    const withConstraints = d.zoomState as unknown as {
+      setSpanConstraints?: (minSpan: number, maxSpan: number) => void;
+    };
+    withConstraints.setSpanConstraints?.(constraints.minSpan, constraints.maxSpan);
+  }
+
+  // Auto-scroll is applied only on append (not on `setOptions`).
+  // Re-arm in case setSpanConstraints already triggered onChange and cleared.
+  if (canAutoScroll && zoomRangeBefore && prevVisibleXDomain) {
+    d.pendingZoomSourceKind = 'auto-scroll';
+    const r = zoomRangeBefore;
+    if (r.end >= 99.5) {
+      const span = r.end - r.start;
+      const anchored = d.zoomState! as unknown as {
+        setRangeAnchored?: (start: number, end: number, anchor: 'start' | 'end' | 'center') => void;
       };
-      withConstraints.setSpanConstraints?.(constraints.minSpan, constraints.maxSpan);
-    }
-
-    // Auto-scroll is applied only on append (not on `setOptions`).
-    // Re-arm in case setSpanConstraints already triggered onChange and cleared.
-    if (canAutoScroll && zoomRangeBefore && prevVisibleXDomain) {
-      d.pendingZoomSourceKind = 'auto-scroll';
-      const r = zoomRangeBefore;
-      if (r.end >= 99.5) {
-        const span = r.end - r.start;
-        const anchored = d.zoomState! as unknown as {
-          setRangeAnchored?: (start: number, end: number, anchor: 'start' | 'end' | 'center') => void;
-        };
-        // Keep end pinned when constraints clamp the span.
-        if (anchored.setRangeAnchored) {
-          anchored.setRangeAnchored(100 - span, 100, 'end');
-        } else {
-          d.zoomState!.setRange(100 - span, 100);
-        }
+      // Keep end pinned when constraints clamp the span.
+      if (anchored.setRangeAnchored) {
+        anchored.setRangeAnchored(100 - span, 100, 'end');
       } else {
-        const nextBaseXDomain = d.computeBaseXDomain(d.currentOptions, d.runtimeRawBoundsByIndex);
-        const span = nextBaseXDomain.max - nextBaseXDomain.min;
-        if (Number.isFinite(span) && span > 0) {
-          const nextStartRaw = ((prevVisibleXDomain.min - nextBaseXDomain.min) / span) * 100;
-          const nextEndRaw = ((prevVisibleXDomain.max - nextBaseXDomain.min) / span) * 100;
-          // Clamp defensively; ZoomState also clamps/orders internally.
-          const nextStart = Math.max(0, Math.min(100, nextStartRaw));
-          const nextEnd = Math.max(0, Math.min(100, nextEndRaw));
-          d.zoomState!.setRange(nextStart, nextEnd);
-        }
+        d.zoomState!.setRange(100 - span, 100);
+      }
+    } else {
+      const nextBaseXDomain = d.computeBaseXDomain(d.currentOptions, d.runtimeRawBoundsByIndex);
+      const span = nextBaseXDomain.max - nextBaseXDomain.min;
+      if (Number.isFinite(span) && span > 0) {
+        const nextStartRaw = ((prevVisibleXDomain.min - nextBaseXDomain.min) / span) * 100;
+        const nextEndRaw = ((prevVisibleXDomain.max - nextBaseXDomain.min) / span) * 100;
+        // Clamp defensively; ZoomState also clamps/orders internally.
+        const nextStart = Math.max(0, Math.min(100, nextStartRaw));
+        const nextEnd = Math.max(0, Math.min(100, nextEndRaw));
+        d.zoomState!.setRange(nextStart, nextEnd);
       }
     }
-    // Fallback clear if no onChange fired (e.g. range unchanged).
-    if (canAutoScroll) d.pendingZoomSourceKind = undefined;
+  }
+  // Fallback clear if no onChange fired (e.g. range unchanged).
+  if (canAutoScroll) d.pendingZoomSourceKind = undefined;
 
-    // Streaming append hot path: when every series is already GPU-decimation
-    // eligible on the baseline, patch rawData/rawBounds in place instead of
-    // reallocating the full resolved-series array (series compression / multi-
-    // chart line slots append every frame).
-    let patchedInPlace = false;
-    if (
-      d.runtimeBaseSeries.length === d.currentOptions.series.length &&
-      d.runtimeBaseSeries.length > 0
-    ) {
-      patchedInPlace = true;
-      for (let i = 0; i < d.runtimeBaseSeries.length; i++) {
-        const base = d.runtimeBaseSeries[i]!;
-        const cfg = d.currentOptions.series[i]!;
-        if (base.type === 'pie' || cfg.type === 'pie') continue;
-        if (base.type === 'candlestick' || cfg.type === 'candlestick') {
-          patchedInPlace = false;
-          break;
-        }
-        const rawCartesian =
-          (d.runtimeRawDataByIndex[i] as CartesianSeriesData | null) ??
-          ((cfg.rawData ?? cfg.data) as CartesianSeriesData);
-        if (!d.isGpuDecimationEligible(cfg, rawCartesian) || !d.isGpuDecimationEligible(base, rawCartesian)) {
-          patchedInPlace = false;
-          break;
-        }
-        const bounds = d.runtimeRawBoundsByIndex[i] ?? base.rawBounds ?? undefined;
-        // Mutate shared resolved object — display path only reads these fields.
-        (base as { rawData: CartesianSeriesData }).rawData = rawCartesian;
-        (base as { data: CartesianSeriesData }).data = rawCartesian;
-        if (bounds) {
-          (base as { rawBounds?: typeof bounds }).rawBounds = bounds;
-        }
+  // Streaming append hot path: when every series is already GPU-decimation
+  // eligible on the baseline, patch rawData/rawBounds in place instead of
+  // reallocating the full resolved-series array (series compression / multi-
+  // chart line slots append every frame).
+  let patchedInPlace = false;
+  if (d.runtimeBaseSeries.length === d.currentOptions.series.length && d.runtimeBaseSeries.length > 0) {
+    patchedInPlace = true;
+    for (let i = 0; i < d.runtimeBaseSeries.length; i++) {
+      const base = d.runtimeBaseSeries[i]!;
+      const cfg = d.currentOptions.series[i]!;
+      if (base.type === 'pie' || cfg.type === 'pie') continue;
+      if (base.type === 'candlestick' || cfg.type === 'candlestick') {
+        patchedInPlace = false;
+        break;
+      }
+      const rawCartesian =
+        (d.runtimeRawDataByIndex[i] as CartesianSeriesData | null) ??
+        ((cfg.rawData ?? cfg.data) as CartesianSeriesData);
+      if (!d.isGpuDecimationEligible(cfg, rawCartesian) || !d.isGpuDecimationEligible(base, rawCartesian)) {
+        patchedInPlace = false;
+        break;
+      }
+      const bounds = d.runtimeRawBoundsByIndex[i] ?? base.rawBounds ?? undefined;
+      // Mutate shared resolved object — display path only reads these fields.
+      (base as { rawData: CartesianSeriesData }).rawData = rawCartesian;
+      (base as { data: CartesianSeriesData }).data = rawCartesian;
+      if (bounds) {
+        (base as { rawBounds?: typeof bounds }).rawBounds = bounds;
       }
     }
-    if (!patchedInPlace) {
-      d.recomputeRuntimeBaseSeries();
-    }
+  }
+  if (!patchedInPlace) {
+    d.recomputeRuntimeBaseSeries();
+  }
 
-    // If zoom is disabled or full-span, `d.renderSeries` is just the baseline.
-    // (Zoom-visible resampling is handled by the unified flush when needed.)
-    const zoomRangeAfter = d.zoomState?.getRange() ?? null;
-    if (zoomRangeAfter == null || d.isFullSpanZoomRange(zoomRangeAfter)) {
-      d.renderSeries = d.runtimeBaseSeries;
-      // Recompute visible y-bounds from the baseline series
-      d.recomputeCachedVisibleYBoundsIfNeeded();
-    }
+  // If zoom is disabled or full-span, `d.renderSeries` is just the baseline.
+  // (Zoom-visible resampling is handled by the unified flush when needed.)
+  const zoomRangeAfter = d.zoomState?.getRange() ?? null;
+  if (zoomRangeAfter == null || d.isFullSpanZoomRange(zoomRangeAfter)) {
+    d.renderSeries = d.runtimeBaseSeries;
+    // Recompute visible y-bounds from the baseline series
+    d.recomputeCachedVisibleYBoundsIfNeeded();
+  }
 
-    return true;
-
+  return true;
 }
 
 export function createAppendFlush(getDeps: () => AppendFlushDeps): () => boolean {

--- a/src/core/renderCoordinator/data/canRangedAppendLine.ts
+++ b/src/core/renderCoordinator/data/canRangedAppendLine.ts
@@ -1,10 +1,14 @@
 /**
- * Pure eligibility for O(k) DataStore.appendSeries on line series.
+ * Pure eligibility for O(k) DataStore.appendSeries on line / area series.
  *
  * Full raw resident kinds (`fullRawLine`, `gpuDecimationRaw`) are append-safe at
  * any zoom — the buffer holds full raw, not a zoomed sampled slice.
  * Cold `unknown` unlocks when sampling is `'none'` or GPU decimation is eligible
  * (before the first prepare tags the kind).
+ *
+ * Pure `type: 'area'` is included so streaming dashboards can ranged-append into
+ * the same DataStore buffer the area renderer binds (private pack identity-cache
+ * cannot see in-place column growth under a stable ref).
  *
  * @module canRangedAppendLine
  * @internal
@@ -31,7 +35,9 @@ export type CanRangedAppendLineInput = {
  * True when ranged append may write only the new points without full setSeries.
  */
 export function canRangedAppendLine(input: CanRangedAppendLineInput): boolean {
-  if (input.seriesType !== 'line') return false;
+  // Line and pure area share the XY storage layout; both may ranged-append when
+  // the resident buffer is full raw. GPU decimation remains line-only (predicate).
+  if (input.seriesType !== 'line' && input.seriesType !== 'area') return false;
 
   const kind = input.kind;
   const isGpuDecimationActive = kind === 'gpuDecimationRaw';
@@ -40,13 +46,14 @@ export function canRangedAppendLine(input: CanRangedAppendLineInput): boolean {
   const seriesForEligibility: ResolvedSeriesConfig =
     input.series ??
     ({
-      type: 'line',
+      type: input.seriesType === 'area' ? 'area' : 'line',
       sampling: (sampling ?? 'lttb') as SeriesSampling,
     } as ResolvedSeriesConfig);
 
   const raw = input.rawData ?? null;
+  // Pure area is never GPU-decimation eligible; only line+lttb/min/max unlocks that path.
   const isGpuDecimationEligibleNow =
-    raw != null && isGpuDecimationEligible(seriesForEligibility, raw);
+    input.seriesType === 'line' && raw != null && isGpuDecimationEligible(seriesForEligibility, raw);
 
   // fullRawLine / gpuDecimationRaw: buffer holds full raw (any zoom).
   // unknown + (none | GPU-eligible): cold path before first prepare tags kind.

--- a/src/core/renderCoordinator/data/resolveLinePackingXOffset.ts
+++ b/src/core/renderCoordinator/data/resolveLinePackingXOffset.ts
@@ -8,12 +8,7 @@
  * @internal
  */
 
-import {
-  getPointCount,
-  getX,
-  isStagingRingView,
-  type CoordinatorCartesianData,
-} from '../../../data/cartesianData';
+import { getPointCount, getX, isStagingRingView, type CoordinatorCartesianData } from '../../../data/cartesianData';
 import type { DataStore } from '../../../data/createDataStore';
 
 type ResolveLinePackingXOffsetInput = {

--- a/src/core/renderCoordinator/data/resolveSeriesDisplayData.ts
+++ b/src/core/renderCoordinator/data/resolveSeriesDisplayData.ts
@@ -39,9 +39,7 @@ export function resolveCartesianDisplayData(input: {
     return (series.data as CartesianSeriesData) ?? raw;
   }
   const threshold =
-    sampleTarget != null && Number.isFinite(sampleTarget)
-      ? Math.max(2, sampleTarget | 0)
-      : series.samplingThreshold;
+    sampleTarget != null && Number.isFinite(sampleTarget) ? Math.max(2, sampleTarget | 0) : series.samplingThreshold;
   return sampleSeriesDataPoints(raw, series.sampling, threshold);
 }
 
@@ -82,10 +80,7 @@ export function computeZoomSampleTarget(
   const MAX_TARGET_MULTIPLIER = options?.maxMultiplier ?? 32;
   const spanFracSafe = Math.max(1e-3, Math.min(1, spanFraction));
   const baseT = Number.isFinite(baseThreshold) ? Math.max(1, baseThreshold | 0) : 1;
-  const maxTarget = Math.min(
-    MAX_TARGET_POINTS_ABS,
-    Math.max(MIN_TARGET_POINTS, baseT * MAX_TARGET_MULTIPLIER)
-  );
+  const maxTarget = Math.min(MAX_TARGET_POINTS_ABS, Math.max(MIN_TARGET_POINTS, baseT * MAX_TARGET_MULTIPLIER));
   const rounded = Math.round(baseT / spanFracSafe);
   return Math.min(maxTarget, Math.max(MIN_TARGET_POINTS, rounded));
 }

--- a/src/core/renderCoordinator/data/samplingDirty.ts
+++ b/src/core/renderCoordinator/data/samplingDirty.ts
@@ -143,11 +143,7 @@ export function patchSeriesPresentationKeepingSampledData(
   // Identity short-circuit: full series-array reuse from OptionResolver (same
   // user series ref) means every entry is === previous — return prior array
   // without allocating N patched objects (group 1 multi-series axes-only).
-  if (
-    nextSeries.length === previousSampled.length &&
-    nextSeries.length > 0 &&
-    nextSeries[0] === previousSampled[0]
-  ) {
+  if (nextSeries.length === previousSampled.length && nextSeries.length > 0 && nextSeries[0] === previousSampled[0]) {
     let allSame = true;
     for (let i = 1; i < nextSeries.length; i++) {
       if (nextSeries[i] !== previousSampled[i]) {

--- a/src/core/renderCoordinator/data/seriesPipeline.ts
+++ b/src/core/renderCoordinator/data/seriesPipeline.ts
@@ -22,12 +22,15 @@ import {
 /** Runtime raw slot — any runtime series raw ref (columns, ring, staging, OHLC, empty). */
 type RuntimeRawSlot = unknown;
 
-type RawBoundsSlot = Readonly<{
-  xMin: number;
-  xMax: number;
-  yMin: number;
-  yMax: number;
-}> | null | undefined;
+type RawBoundsSlot =
+  | Readonly<{
+      xMin: number;
+      xMax: number;
+      yMin: number;
+      yMax: number;
+    }>
+  | null
+  | undefined;
 
 /**
  * Build one baseline series entry (pie / candle / cartesian).
@@ -72,8 +75,7 @@ function resolveBaselineSeriesEntry(
     data?: unknown;
   };
   const rawCartesian: CartesianSeriesData =
-    (rawSlot as CartesianSeriesData | null | undefined) ??
-    ((anyS.rawData ?? anyS.data) as CartesianSeriesData);
+    (rawSlot as CartesianSeriesData | null | undefined) ?? ((anyS.rawData ?? anyS.data) as CartesianSeriesData);
   const bounds = boundsSlot ?? anyS.rawBounds ?? undefined;
   const baselineSampled = resolveCartesianDisplayData({
     series: s,
@@ -131,8 +133,7 @@ function resolveSetOptionsReuseSeriesEntry(
   }
 
   const rawCartesian: CartesianSeriesData =
-    (rawSlot as CartesianSeriesData | null | undefined) ??
-    ((anyS.rawData ?? anyS.data) as CartesianSeriesData);
+    (rawSlot as CartesianSeriesData | null | undefined) ?? ((anyS.rawData ?? anyS.data) as CartesianSeriesData);
   const bounds = boundsSlot ?? anyS.rawBounds ?? undefined;
   const display = resolveCartesianDisplayData({
     series: s,
@@ -179,11 +180,7 @@ export function resolveZoomedSeriesEntry(input: {
   readonly visibleMax: number;
   readonly spanFraction: number;
   readonly sliceX: (data: CartesianSeriesData, min: number, max: number) => CartesianSeriesData;
-  readonly sliceOHLC: (
-    data: ReadonlyArray<OHLCDataPoint>,
-    min: number,
-    max: number
-  ) => ReadonlyArray<OHLCDataPoint>;
+  readonly sliceOHLC: (data: ReadonlyArray<OHLCDataPoint>, min: number, max: number) => ReadonlyArray<OHLCDataPoint>;
 }): ZoomedSeriesResult {
   const s = input.series;
   const anyS = s as ResolvedSeriesConfig & {
@@ -216,8 +213,7 @@ export function resolveZoomedSeriesEntry(input: {
   }
 
   const rawCartesian: CartesianSeriesData =
-    (input.rawSlot as CartesianSeriesData | null | undefined) ??
-    ((anyS.rawData ?? anyS.data) as CartesianSeriesData);
+    (input.rawSlot as CartesianSeriesData | null | undefined) ?? ((anyS.rawData ?? anyS.data) as CartesianSeriesData);
   const bufferedRaw = input.sliceX(rawCartesian, input.bufferedMin, input.bufferedMax);
 
   // GPU decimation: keep full raw; compute scopes via visibleStart/End in prepare.

--- a/src/core/renderCoordinator/gpu/textureManager.ts
+++ b/src/core/renderCoordinator/gpu/textureManager.ts
@@ -257,8 +257,7 @@ export function createTextureManager(config: TextureManagerConfig): TextureManag
       state.overlayTargetsFormat === targetFormat;
     const mainOk = !needMainColor || !!state.mainColorTexture;
     const resolveOverlayOk =
-      !needResolveAndOverlay ||
-      (state.mainResolveTexture && state.overlayMsaaTexture && state.overlayBlitBindGroup);
+      !needResolveAndOverlay || (state.mainResolveTexture && state.overlayMsaaTexture && state.overlayBlitBindGroup);
 
     if (sizeOk && mainOk && resolveOverlayOk) {
       // Free unused targets when path switches to leaner modes.

--- a/src/core/renderCoordinator/interaction/__tests__/interactionHelpers.test.ts
+++ b/src/core/renderCoordinator/interaction/__tests__/interactionHelpers.test.ts
@@ -66,7 +66,6 @@ describe('clearPointer', () => {
   });
 });
 
-
 describe('gridToDomainX', () => {
   const xScale = createLinearScale().domain(0, 100).range(0, 800);
 
@@ -97,7 +96,6 @@ describe('gridToDomainX', () => {
     expect(recoveredDomain).toBeCloseTo(originalDomain, 10);
   });
 });
-
 
 describe('computeEffectivePointer', () => {
   const xScale = createLinearScale().domain(0, 100).range(0, 800);
@@ -262,7 +260,6 @@ describe('shouldUpdateInteractionX', () => {
   });
 });
 
-
 describe('integration: sync pointer workflow', () => {
   it('supports typical sync interaction cycle', () => {
     const xScale = createLinearScale().domain(0, 1000).range(0, 800);
@@ -296,5 +293,3 @@ describe('integration: sync pointer workflow', () => {
     expect(cleared.hasPointer).toBe(false);
   });
 });
-
-

--- a/src/core/renderCoordinator/render/__tests__/appendCacheReseed.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/appendCacheReseed.test.ts
@@ -296,5 +296,4 @@ describe('append cache re-seed / ring guard (issue 0.2)', () => {
     // Guard re-seeds so subsequent frames stay cheap.
     expect(lastSetSeriesCache.get(0)?.data).toBe(ring);
   });
-
 });

--- a/src/core/renderCoordinator/render/__tests__/denseHairlinePass.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/denseHairlinePass.test.ts
@@ -63,10 +63,7 @@ describe('hasDenseHairlineLines / renderDenseHairlineLines', () => {
   });
 
   it('returns true when a visible line is dense hairline (hit)', () => {
-    const renderers = emptyRenderers([
-      mockLine({ hairline: false }),
-      mockLine({ hairline: true }),
-    ]);
+    const renderers = emptyRenderers([mockLine({ hairline: false }), mockLine({ hairline: true })]);
     const prep = makePrep([
       { type: 'line', originalIndex: 0 },
       { type: 'line', originalIndex: 1 },

--- a/src/core/renderCoordinator/render/__tests__/filterGapsCache.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/filterGapsCache.test.ts
@@ -128,7 +128,4 @@ describe('filterGapsCache (P2-12)', () => {
       [2, 99],
     ]);
   });
-
-
-
 });

--- a/src/core/renderCoordinator/render/__tests__/frameRender.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/frameRender.test.ts
@@ -1,13 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  planGpuFrame,
-  framePlanIncludesDenseHairline,
-  framePlanIncludesAnnotationOverlay,
-} from '../frameRender';
-import {
-  MAIN_SCENE_MSAA_SAMPLE_COUNT,
-  ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT,
-} from '../../gpu/textureManager';
+import { planGpuFrame, framePlanIncludesDenseHairline, framePlanIncludesAnnotationOverlay } from '../frameRender';
+import { MAIN_SCENE_MSAA_SAMPLE_COUNT, ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT } from '../../gpu/textureManager';
 
 describe('frameRender pass graph', () => {
   it('uses 4× MSAA for main and overlay (textureManager constants)', () => {

--- a/src/core/renderCoordinator/render/__tests__/passGraphContract.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/passGraphContract.test.ts
@@ -3,10 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-  MAIN_SCENE_MSAA_SAMPLE_COUNT,
-  ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT,
-} from '../../gpu/textureManager';
+import { MAIN_SCENE_MSAA_SAMPLE_COUNT, ANNOTATION_OVERLAY_MSAA_SAMPLE_COUNT } from '../../gpu/textureManager';
 import {
   planGpuFrame,
   framePlanIncludesDenseHairline,

--- a/src/core/renderCoordinator/render/__tests__/prepareSeriesGpuDecimation.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/prepareSeriesGpuDecimation.test.ts
@@ -935,6 +935,92 @@ describe('prepareSeries GPU decimation (WG-P0-1 xOffset)', () => {
     expect(areaArgs[5]).toBeUndefined();
   });
 
+  it('pure type:area uploads via DataStore and binds external storage (streaming append path)', () => {
+    const points: Array<[number, number]> = [
+      [1, 10],
+      [2, 20],
+      [3, 15],
+      [4, 25],
+    ];
+    const series = {
+      type: 'area',
+      name: 'throughput',
+      data: points,
+      rawData: points,
+      color: '#3b82f6',
+      areaStyle: { opacity: 0.3, color: '#3b82f6' },
+      sampling: 'none',
+      samplingThreshold: 5000,
+      connectNulls: false,
+      yAxis: 'y',
+      baseline: 0,
+    } as any;
+
+    const rawBuffer = { label: 'area-raw' } as unknown as GPUBuffer;
+    const areaPrepare = vi.fn();
+    const setSeries = vi.fn();
+    const gpuSeriesKindByIndex: Array<'fullRawLine' | 'gpuDecimationRaw' | 'other' | 'unknown'> = ['unknown'];
+
+    prepareSeries(
+      {
+        lineRenderers: [],
+        areaRenderers: [{ prepare: areaPrepare, render: vi.fn(), dispose: vi.fn() } as any],
+        barRenderer: {
+          prepare: vi.fn(),
+          render: vi.fn(),
+          dispose: vi.fn(),
+        } as any,
+        scatterRenderers: [],
+        scatterDensityRenderers: [],
+        pieRenderers: [],
+        candlestickRenderers: [],
+        decimationComputes: [],
+      },
+      {
+        currentOptions: {
+          xAxis: { type: 'value' },
+          yAxes: [{ id: 'y', min: 0 }],
+          series: [series],
+        } as any,
+        seriesForRender: [series],
+        xScale: makeScale(0, 10),
+        yScales: new Map([['y', makeScale(0, 30)]]),
+        gridArea: makeGridArea(),
+        dataStore: {
+          setSeries,
+          appendSeries: vi.fn(),
+          removeSeries: vi.fn(),
+          getSeriesBuffer: vi.fn(() => rawBuffer),
+          getSeriesPointCount: vi.fn(() => points.length),
+          getSeriesRingLayout: vi.fn(() => ({ start: 0, capacity: 0 })),
+          isSeriesRingMode: vi.fn(() => false),
+          getSeriesContentHash: vi.fn(() => 0x2),
+          getSeriesStagingBuffer: vi.fn(() => new Float32Array(0)),
+          getSeriesXOffset: vi.fn(() => 0),
+          dispose: vi.fn(),
+        },
+        appendedGpuThisFrame: new Set(),
+        gpuSeriesKindByIndex,
+        zoomState: null,
+        visibleXDomain: { min: 0, max: 10 },
+        introPhase: 'done',
+        introProgress01: 1,
+        withAlpha: (c: string) => c,
+        maxRadiusCss: 4,
+        lastSetSeriesCache: new Map(),
+        filterGapsCache: createFilterGapsCache(),
+      }
+    );
+
+    expect(setSeries).toHaveBeenCalled();
+    expect(areaPrepare).toHaveBeenCalled();
+    const areaArgs = areaPrepare.mock.calls[0]!;
+    // storageBuffer + pointCount from DataStore (not private-only pack).
+    expect(areaArgs[5]).toBe(rawBuffer);
+    expect(areaArgs[6]).toBe(points.length);
+    expect(gpuSeriesKindByIndex[0]).toBe('fullRawLine');
+  });
+
   function runDecimationPrepare(
     opts: Readonly<{
       n: number;

--- a/src/core/renderCoordinator/render/renderSeries.ts
+++ b/src/core/renderCoordinator/render/renderSeries.ts
@@ -255,11 +255,48 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
     const s = seriesForRender[i];
     switch (s.type) {
       case 'area': {
+        // Pure `type: 'area'`: upload through DataStore (same XY layout as line) so
+        // streaming append can ranged-write GPU bytes and the area renderer binds
+        // that buffer. Private pack alone identity-caches on data ref and misses
+        // in-place column growth from appendData (empty until a zoom creates a new
+        // sliced array ref).
         const baseline = s.baseline ?? defaultBaseline;
         // When connectNulls is true, strip null/NaN gap entries so the area draws through gaps.
         // Cached by data ref identity (P2-12) so static frames do not re-allocate.
         const areaData = s.connectNulls ? getFilteredGapsCached(filterGapsCache, i, s.data) : s.data;
-        renderers.areaRenderers[i].prepare(s, areaData, xScale, getYScale(s), baseline);
+        const { packingXOffset, xOffset } = resolveLinePackingXOffset({
+          data: areaData,
+          dataStore,
+          seriesIndex: i,
+          xAxisType: currentOptions.xAxis.type,
+        });
+        if (!appendedGpuThisFrame.has(i)) {
+          setSeriesIfChanged(i, areaData, { xOffset: packingXOffset });
+        }
+        const areaBuffer = dataStore.getSeriesBuffer(i);
+        const areaRingLayout = dataStore.getSeriesRingLayout(i);
+        // Shared storage only when linear (capacity 0). After modular ring wrap,
+        // private-pack chronological areaData (same contract as line+areaStyle).
+        if (areaRingLayout.capacity === 0) {
+          renderers.areaRenderers[i].prepare(
+            s,
+            areaData,
+            xScale,
+            getYScale(s),
+            baseline,
+            areaBuffer,
+            dataStore.getSeriesPointCount(i),
+            xOffset
+          );
+        } else {
+          renderers.areaRenderers[i].prepare(s, areaData, xScale, getYScale(s), baseline);
+        }
+        // sampling:'none' keeps full raw resident → ranged append (mirrors line).
+        if (s.sampling === 'none') {
+          gpuSeriesKindByIndex[i] = 'fullRawLine';
+        } else {
+          gpuSeriesKindByIndex[i] = 'other';
+        }
         break;
       }
       case 'line': {
@@ -295,10 +332,7 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
           // continuous (1 sample/px aliases into long sparse segments that look
           // faint/dashed, especially with antialias:false + dpr:1).
           const dpr = Math.max(1e-6, gridArea.devicePixelRatio || 1);
-          const plotWidthCss = Math.max(
-            1,
-            gridArea.canvasWidth / dpr - gridArea.left - gridArea.right
-          );
+          const plotWidthCss = Math.max(1, gridArea.canvasWidth / dpr - gridArea.left - gridArea.right);
           const plotWidthDevice = Math.max(1, Math.floor(plotWidthCss * dpr));
           // Floor 128 so tiny slots still get a usable polyline; 2× width for Nyquist-ish LOD.
           const pixelCap = Math.max(128, plotWidthDevice * 2);
@@ -808,10 +842,7 @@ export function renderSeries(
  * True when any visible line series will draw via the dense hairline path.
  * Used to open the post-resolve single-sample pass only when needed.
  */
-export function hasDenseHairlineLines(
-  renderers: SeriesRenderers,
-  seriesPreparation: SeriesPreparationResult
-): boolean {
+export function hasDenseHairlineLines(renderers: SeriesRenderers, seriesPreparation: SeriesPreparationResult): boolean {
   const { visibleSeriesForRender } = seriesPreparation;
   for (let idx = 0; idx < visibleSeriesForRender.length; idx++) {
     const { series, originalIndex } = visibleSeriesForRender[idx]!;
@@ -884,14 +915,7 @@ export function renderAboveSeriesAnnotations(
   annotationRenderers: AnnotationRenderers,
   context: AboveSeriesAnnotationContext
 ): void {
-  const {
-    hasCartesianSeries,
-    gridArea,
-    overlayPass,
-    plotScissor,
-    referenceLineAboveCount,
-    markerAboveCount,
-  } = context;
+  const { hasCartesianSeries, gridArea, overlayPass, plotScissor, referenceLineAboveCount, markerAboveCount } = context;
 
   // Annotations (above series): reference lines then markers, clipped to plot scissor.
   // MSAA overlay renderers are prepared with *only* above-layer instances (start at 0).

--- a/src/core/renderCoordinator/renderers/__tests__/rendererPool.test.ts
+++ b/src/core/renderCoordinator/renderers/__tests__/rendererPool.test.ts
@@ -72,10 +72,7 @@ vi.mock('../../../renderers/createBarRenderer', () => ({
   createBarRenderer: vi.fn(() => createMockRenderer('Bar')),
 }));
 
-import {
-  createRendererPool,
-  ensureRendererPoolsForSeries,
-} from '../rendererPool';
+import { createRendererPool, ensureRendererPoolsForSeries } from '../rendererPool';
 type RendererPoolConfig = Parameters<typeof createRendererPool>[0];
 import type { ResolvedSeriesConfig } from '../../../../config/OptionResolver';
 
@@ -201,13 +198,12 @@ describe('RendererPool', () => {
     });
   });
 
-  
-describe('Type-aware pool needs via ensureRendererPoolsForSeries', () => {
-  // Needs sizing is internal; assert public ensure grows pools by series type mix.
-  it('is exported and callable', () => {
-    expect(typeof ensureRendererPoolsForSeries).toBe('function');
+  describe('Type-aware pool needs via ensureRendererPoolsForSeries', () => {
+    // Needs sizing is internal; assert public ensure grows pools by series type mix.
+    it('is exported and callable', () => {
+      expect(typeof ensureRendererPoolsForSeries).toBe('function');
+    });
   });
-});
 
   describe('Scatter Renderers', () => {
     it('grows scatter renderer pool', () => {

--- a/src/core/renderCoordinator/renderers/rendererPool.ts
+++ b/src/core/renderCoordinator/renderers/rendererPool.ts
@@ -155,9 +155,7 @@ type RendererPoolNeeds = Readonly<{
  * - Decimation pool only when any line uses a GPU-decimation sampling mode
  *   (`lttb`/`min`/`max`). `sampling: 'none'` charts (group 1) get **0**.
  */
-function computeRendererPoolNeeds(
-  series: ReadonlyArray<ResolvedSeriesConfig>
-): RendererPoolNeeds {
+function computeRendererPoolNeeds(series: ReadonlyArray<ResolvedSeriesConfig>): RendererPoolNeeds {
   const n = series.length;
   let anyArea = false;
   let anyLine = false;

--- a/src/core/renderCoordinator/ui/tooltipLegendHelpers.ts
+++ b/src/core/renderCoordinator/ui/tooltipLegendHelpers.ts
@@ -137,8 +137,8 @@ export function computeCandlestickTooltipAnchorFromMatch(
   const yCanvasCss = gridArea.top + yGridCss;
 
   // Convert to container-local CSS pixels
-  const xContainerCss = (typeof (canvas as any).offsetLeft === 'number') ? canvas.offsetLeft + xCanvasCss : xCanvasCss;
-  const yContainerCss = (typeof (canvas as any).offsetLeft === 'number') ? canvas.offsetTop + yCanvasCss : yCanvasCss;
+  const xContainerCss = typeof (canvas as any).offsetLeft === 'number' ? canvas.offsetLeft + xCanvasCss : xCanvasCss;
+  const yContainerCss = typeof (canvas as any).offsetLeft === 'number' ? canvas.offsetTop + yCanvasCss : yCanvasCss;
 
   if (!Number.isFinite(xContainerCss) || !Number.isFinite(yContainerCss)) {
     return null;
@@ -146,4 +146,3 @@ export function computeCandlestickTooltipAnchorFromMatch(
 
   return { x: xContainerCss, y: yContainerCss };
 }
-

--- a/src/core/renderCoordinator/utils/__tests__/utilities.test.ts
+++ b/src/core/renderCoordinator/utils/__tests__/utilities.test.ts
@@ -4,19 +4,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import {
-  getCanvasCssWidth,
-  getCanvasCssHeight,
-  getCanvasCssSizeFromDevicePixels,
-  clampInt,
-} from '../canvasUtils';
-import {
-  finiteOrNull,
-  finiteOrUndefined,
-  isTupleDataPoint,
-  getPointXY,
-  isTupleOHLCDataPoint,
-} from '../dataPointUtils';
+import { getCanvasCssWidth, getCanvasCssHeight, getCanvasCssSizeFromDevicePixels, clampInt } from '../canvasUtils';
+import { finiteOrNull, finiteOrUndefined, isTupleDataPoint, getPointXY, isTupleOHLCDataPoint } from '../dataPointUtils';
 import { normalizeDomain } from '../boundsComputation';
 import { clamp01 } from '../axisUtils';
 import {
@@ -77,11 +66,6 @@ describe('Data Point Utilities', () => {
 });
 
 describe('Bounds Computation', () => {
-
-
-
-
-
   it('normalizeDomain ensures min <= max', () => {
     expect(normalizeDomain(5, 10)).toEqual({ min: 5, max: 10 });
     expect(normalizeDomain(10, 5)).toEqual({ min: 5, max: 10 });

--- a/src/core/renderCoordinator/utils/timeAxisUtils.ts
+++ b/src/core/renderCoordinator/utils/timeAxisUtils.ts
@@ -105,9 +105,8 @@ export const resolvePieCenterPlotCss = (
  * @param radius - Pie radius configuration
  * @returns True if radius is a tuple
  */
-const isPieRadiusTuple = (
-  radius: PieRadius
-): radius is readonly [inner: number | string, outer: number | string] => Array.isArray(radius);
+const isPieRadiusTuple = (radius: PieRadius): radius is readonly [inner: number | string, outer: number | string] =>
+  Array.isArray(radius);
 
 /**
  * Resolves pie inner/outer radii with defaults, bounds checking.

--- a/src/core/renderCoordinator/zoom/__tests__/stickyAutoDomain.test.ts
+++ b/src/core/renderCoordinator/zoom/__tests__/stickyAutoDomain.test.ts
@@ -44,6 +44,21 @@ describe('applyStickyAutoDomain', () => {
     expect(next.max).toBeCloseTo(100_001 + 100_001 * 0.1, 5);
   });
 
+  it('X headroom 0 tracks exact max so streaming stays full-width (no empty-right gutter)', () => {
+    // Ultimate-benchmark pattern: generate N points, then append forever with auto X.
+    // Non-zero headroom left ~10% empty on the right that filled then re-jumped.
+    let sticky = applyStickyAutoDomain({ min: 0, max: 100_000 }, null, 0);
+    expect(sticky.max).toBe(100_000);
+    sticky = applyStickyAutoDomain({ min: 0, max: 100_001 }, sticky, 0);
+    expect(sticky.min).toBe(0);
+    expect(sticky.max).toBe(100_001);
+    sticky = applyStickyAutoDomain({ min: 0, max: 1_270_000 }, sticky, 0);
+    expect(sticky.max).toBe(1_270_000);
+    // Static frame reuses identity once max stops growing.
+    const held = applyStickyAutoDomain({ min: 0, max: 1_270_000 }, sticky, 0);
+    expect(held).toBe(sticky);
+  });
+
   it('expands min with headroom when data breaches sticky min', () => {
     const sticky = { min: 0, max: 100 };
     const next = applyStickyAutoDomain({ min: -10, max: 90 }, sticky, 0.1);

--- a/src/core/renderCoordinator/zoom/stickyAutoDomain.ts
+++ b/src/core/renderCoordinator/zoom/stickyAutoDomain.ts
@@ -1,16 +1,24 @@
 /**
- * Sticky auto-range domain with headroom (grow-by style amortization).
+ * Sticky auto-range domain with optional grow-by headroom.
  *
- * Streaming appends that expand data bounds every frame would otherwise force
- * grid/axis prepare + label rebuild every frame. Holding ~10% headroom and only
- * expanding when data breaches the sticky domain stabilizes overlay signatures
- * for many frames without changing the sampling contract.
+ * **Y axes** use ~10% headroom so streaming amplitude noise does not rebuild
+ * overlays every frame. **X axes** use zero headroom so unbounded `appendData`
+ * (e.g. ultimate-benchmark streaming) keeps the series full-width: non-zero X
+ * pad left an empty right gutter that filled then re-jumped on every breach.
  *
  * @module stickyAutoDomain
  * @internal
  */
 
+/** Default sticky headroom for Y (and generic callers). */
 export const DEFAULT_STICKY_DOMAIN_HEADROOM = 0.1;
+
+/**
+ * Sticky headroom for the **X** axis. Must stay 0 so auto-range streaming
+ * tracks data max tightly (full plot width). Non-zero pad reintroduces the
+ * empty-right grow/reset cycle under continuous `appendData`.
+ */
+export const DEFAULT_STICKY_X_DOMAIN_HEADROOM = 0;
 
 type StickyDomain = { min: number; max: number };
 
@@ -66,15 +74,17 @@ export function resolveStickyOrDataDomain(
  * mountain ascending X) must fill the plot — padding max by 10% on
  * establish left a permanent empty band on the right (100k pts → axis to ~110k).
  *
- * **Later breaches:** pad only the edge that moved (~10% growBy) so streaming
- * compression amortizes overlay rebuilds while data creeps within headroom.
+ * **Later breaches:** pad only the edge that moved (`headroom` growBy). Pass
+ * {@link DEFAULT_STICKY_DOMAIN_HEADROOM} for Y; pass
+ * {@link DEFAULT_STICKY_X_DOMAIN_HEADROOM} (0) for X so streaming max growth
+ * stays full-width instead of oscillating empty-right gutters.
  *
  * **Sliding windows (FIFO / maxPoints):** when the data min moves *up* (oldest
  * points dropped), do **not** freeze the historical min — re-establish from the
  * current data domain. Freezing min at the series origin while max scrolls
  * compresses the entire waveform into a thin strip on the right edge of the
  * plot (FIFO/ECG visual regression). Unbounded compression keeps min stable at
- * 0, so the reuse path still amortizes overlay prepare.
+ * 0; with X headroom 0 the sticky max tracks data max exactly while streaming.
  */
 export function applyStickyAutoDomain(
   dataDomain: { readonly min: number; readonly max: number },

--- a/src/core/renderCoordinator/zoom/stickyAutoDomain.ts
+++ b/src/core/renderCoordinator/zoom/stickyAutoDomain.ts
@@ -18,10 +18,7 @@ type StickyDomain = { min: number; max: number };
  * Sticky auto-domain applies only when **both** axis ends are auto.
  * Any one-sided explicit min/max must not receive growBy headroom past that edge.
  */
-export function shouldApplyStickyAutoDomain(
-  explicitMin: number | undefined,
-  explicitMax: number | undefined
-): boolean {
+export function shouldApplyStickyAutoDomain(explicitMin: number | undefined, explicitMax: number | undefined): boolean {
   return explicitMin === undefined && explicitMax === undefined;
 }
 

--- a/src/data/__tests__/cartesianData.test.ts
+++ b/src/data/__tests__/cartesianData.test.ts
@@ -191,12 +191,7 @@ describe('packXYInto - XY arrays unroll (FIFO typed columns)', () => {
     return { x, y };
   }
 
-  function expectedInterleaved(
-    n: number,
-    srcPointOffset: number,
-    pointCount: number,
-    xOffset: number
-  ): number[] {
+  function expectedInterleaved(n: number, srcPointOffset: number, pointCount: number, xOffset: number): number[] {
     const out: number[] = [];
     for (let i = 0; i < pointCount; i++) {
       const idx = srcPointOffset + i;
@@ -205,15 +200,12 @@ describe('packXYInto - XY arrays unroll (FIFO typed columns)', () => {
     return out;
   }
 
-  it.each([1, 3, 4, 5, 7, 8])(
-    'packs count=%s with xOffset 0 (unroll + remainder)',
-    (n) => {
-      const src = makeXY(n);
-      const out = new Float32Array(n * 2);
-      packXYInto(out, 0, src, 0, n, 0);
-      expect(Array.from(out)).toEqual(expectedInterleaved(n, 0, n, 0));
-    }
-  );
+  it.each([1, 3, 4, 5, 7, 8])('packs count=%s with xOffset 0 (unroll + remainder)', (n) => {
+    const src = makeXY(n);
+    const out = new Float32Array(n * 2);
+    packXYInto(out, 0, src, 0, n, 0);
+    expect(Array.from(out)).toEqual(expectedInterleaved(n, 0, n, 0));
+  });
 
   it('honors srcPointOffset > 0', () => {
     const src = makeXY(10);
@@ -329,17 +321,7 @@ describe('packXYInto - null gap handling', () => {
   });
 
   it('mid-series null forces safe tuple path (denseHomogeneous false-positive miss)', () => {
-    const data: (DataPoint | null)[] = [
-      [0, 0],
-      [1, 1],
-      null,
-      [3, 3],
-      [4, 4],
-      [5, 5],
-      [6, 6],
-      [7, 7],
-      [8, 8],
-    ];
+    const data: (DataPoint | null)[] = [[0, 0], [1, 1], null, [3, 3], [4, 4], [5, 5], [6, 6], [7, 7], [8, 8]];
     const out = new Float32Array(data.length * 2);
     packXYInto(out, 0, data as any, 0, data.length, 0);
     expect(out[0]).toBe(0);

--- a/src/data/__tests__/createDataStore.test.ts
+++ b/src/data/__tests__/createDataStore.test.ts
@@ -253,6 +253,37 @@ describe('createDataStore', () => {
       // Must not allocate the unclamped 256MiB headroom.
       expect(buf.size).toBeLessThan(256 * 1024 * 1024);
     });
+
+    it('auto-windows unbounded append when growth would exceed maxStorageBufferBindingSize', () => {
+      // 64 pts × 8 B = 512 B hard cap (simulates 128 MiB / 16.7M pts at tiny scale).
+      const tight = createMockDevice();
+      (tight.limits as { maxBufferSize: number; maxStorageBufferBindingSize: number }).maxBufferSize = 512;
+      (tight.limits as { maxBufferSize: number; maxStorageBufferBindingSize: number }).maxStorageBufferBindingSize =
+        512;
+      const store = createDataStore(tight);
+
+      const seed: Array<[number, number]> = [];
+      for (let i = 0; i < 64; i++) seed.push([i, i]);
+      store.setSeries(0, seed);
+      expect(store.getSeriesPointCount(0)).toBe(64);
+
+      const batch: Array<[number, number]> = [];
+      for (let i = 64; i < 74; i++) batch.push([i, i]);
+      // Must not throw — auto-window to device max (64) like maxPoints ring.
+      expect(() => store.appendSeries(0, batch)).not.toThrow();
+      expect(store.getSeriesPointCount(0)).toBe(64);
+
+      // Chronological ends: dropped 0..9, retained 10..63 + 64..73.
+      const layout = store.getSeriesRingLayout(0);
+      expect(layout.capacity).toBe(64);
+      const staging = store.getSeriesStagingBuffer(0);
+      const start = layout.start;
+      const x0 = staging[start * 2]!;
+      const lastPhys = (start + 63) % 64;
+      const xLast = staging[lastPhys * 2]!;
+      expect(x0).toBe(10);
+      expect(xLast).toBe(73);
+    });
   });
 
   describe('appendSeries with maxPoints (fixed-capacity ring FIFO)', () => {

--- a/src/data/createDataStore.ts
+++ b/src/data/createDataStore.ts
@@ -669,24 +669,22 @@ export function createDataStore(device: GPUDevice): DataStore {
 
     const existing = getSeriesEntry(index);
     const prevPointCount = existing.pointCount;
-    const maxPoints = normalizeMaxPoints(options?.maxPoints);
-    const plan = planMaxPointsWindow(prevPointCount, newPointCount, maxPoints);
-    const {
-      nextCount: nextPointCount,
-      dropPrevCount,
-      newSrcOffset,
-      keepNewCount,
-      isStrictReplace,
-      ringCapacity,
-      isRing,
-    } = plan;
+    let maxPoints = normalizeMaxPoints(options?.maxPoints);
+    let plan = planMaxPointsWindow(prevPointCount, newPointCount, maxPoints);
+    let nextPointCount = plan.nextCount;
+    let dropPrevCount = plan.dropPrevCount;
+    let newSrcOffset = plan.newSrcOffset;
+    let keepNewCount = plan.keepNewCount;
+    let isStrictReplace = plan.isStrictReplace;
+    let ringCapacity = plan.ringCapacity;
+    let isRing = plan.isRing;
 
     // Reserve peak ring capacity when maxPoints is set so streaming never
     // reallocates (full re-upload) on every geometric step.
-    const reservePoints =
+    let reservePoints =
       isRing && ringCapacity > 0 ? Math.max(nextPointCount, maxPointsPeakRetention(ringCapacity)) : nextPointCount;
-    const requiredBytes = roundUpToMultipleOf4(reservePoints * 2 * 4);
-    const targetBytes = Math.max(MIN_BUFFER_BYTES, requiredBytes);
+    let requiredBytes = roundUpToMultipleOf4(reservePoints * 2 * 4);
+    let targetBytes = Math.max(MIN_BUFFER_BYTES, requiredBytes);
 
     let buffer = existing.buffer;
     let capacityBytes = existing.capacityBytes;
@@ -697,6 +695,29 @@ export function createDataStore(device: GPUDevice): DataStore {
     const prevRingCap = existing.ringCapacityPoints;
     const prevRingStart = existing.ringStart;
     const wasRing = prevRingCap > 0;
+    const hardCap = Math.min(maxBufferSize, maxStorageBinding);
+
+    // Unbounded growth past the device storage-binding limit: auto-window to
+    // the max points that fit (same policy as maxPoints ring) instead of throw.
+    // Otherwise appendFlush's silent catch left CPU bounds growing while the
+    // GPU buffer stayed at ~16.7M pts (128 MiB) — empty right gutter under
+    // ultimate-benchmark multi-10M streaming.
+    if (targetBytes > hardCap && maxPoints == null) {
+      const deviceMaxPoints = Math.max(1, Math.floor(hardCap / (2 * 4)));
+      maxPoints = deviceMaxPoints;
+      plan = planMaxPointsWindow(prevPointCount, newPointCount, maxPoints);
+      nextPointCount = plan.nextCount;
+      dropPrevCount = plan.dropPrevCount;
+      newSrcOffset = plan.newSrcOffset;
+      keepNewCount = plan.keepNewCount;
+      isStrictReplace = plan.isStrictReplace;
+      ringCapacity = plan.ringCapacity;
+      isRing = plan.isRing;
+      reservePoints =
+        isRing && ringCapacity > 0 ? Math.max(nextPointCount, maxPointsPeakRetention(ringCapacity)) : nextPointCount;
+      requiredBytes = roundUpToMultipleOf4(reservePoints * 2 * 4);
+      targetBytes = Math.max(MIN_BUFFER_BYTES, requiredBytes);
+    }
 
     const needsGrowth = targetBytes > capacityBytes;
 
@@ -719,7 +740,6 @@ export function createDataStore(device: GPUDevice): DataStore {
     // window after packing — GPU prefix copy is skipped there to avoid a wasted
     // copy that would be overwritten by writeFullPointsToGpu.
     if (needsGrowth) {
-      const hardCap = Math.min(maxBufferSize, maxStorageBinding);
       if (targetBytes > hardCap) {
         throw new Error(
           `DataStore.appendSeries(${index}): required buffer size ${targetBytes} exceeds ` +

--- a/src/data/createDataStore.ts
+++ b/src/data/createDataStore.ts
@@ -1,8 +1,5 @@
 import type { CartesianSeriesData } from '../config/types';
-import {
-  destroyBufferAfterSubmit,
-  flushDeviceSubmit,
-} from '../core/gpu/submitBatcher';
+import { destroyBufferAfterSubmit, flushDeviceSubmit } from '../core/gpu/submitBatcher';
 import { getPointCount, packXYInto } from './cartesianData';
 import { maxPointsPeakRetention, normalizeMaxPoints, planMaxPointsWindow } from './maxPointsWindow';
 import { isYOnlyRewriteAgainstStaging, packYOnlyInto } from './seriesRewriteDetect';
@@ -237,7 +234,7 @@ function bumpContentVersion(hash: number, keepNewCount: number, dropPrevCount = 
     h = (h + 0x85ebca6b) >>> 0;
   }
   // Ensure a change even when keepNewCount is 0 (drop-only edge).
-  if (h === (hash >>> 0)) {
+  if (h === hash >>> 0) {
     h = (h + 1) >>> 0;
   }
   return h;
@@ -385,25 +382,13 @@ export function createDataStore(device: GPUDevice): DataStore {
     const floatsFirst = first * 2;
     if (first > 0) {
       stagingBuffer.set(scratch.subarray(0, floatsFirst), physStart * 2);
-      device.queue.writeBuffer(
-        gpuBuffer,
-        physStart * 2 * 4,
-        scratch.buffer,
-        scratch.byteOffset,
-        floatsFirst * 4
-      );
+      device.queue.writeBuffer(gpuBuffer, physStart * 2 * 4, scratch.buffer, scratch.byteOffset, floatsFirst * 4);
     }
     const rest = pointCount - first;
     if (rest > 0) {
       const floatsRest = rest * 2;
       stagingBuffer.set(scratch.subarray(floatsFirst, floatsFirst + floatsRest), 0);
-      device.queue.writeBuffer(
-        gpuBuffer,
-        0,
-        scratch.buffer,
-        scratch.byteOffset + floatsFirst * 4,
-        floatsRest * 4
-      );
+      device.queue.writeBuffer(gpuBuffer, 0, scratch.buffer, scratch.byteOffset + floatsFirst * 4, floatsRest * 4);
     }
   };
 
@@ -758,12 +743,7 @@ export function createDataStore(device: GPUDevice): DataStore {
         const capped = Math.min(preferred, MAX_STREAM_HEADROOM_POINTS * 2 * 4);
         grownCapacityBytes = Math.max(grownCapacityBytes, Math.max(targetBytes, capped));
       }
-      capacityBytes = clampSeriesCapacityBytes(
-        grownCapacityBytes,
-        targetBytes,
-        maxBufferSize,
-        maxStorageBinding
-      );
+      capacityBytes = clampSeriesCapacityBytes(grownCapacityBytes, targetBytes, maxBufferSize, maxStorageBinding);
       buffer = device.createBuffer({
         size: capacityBytes,
         usage: seriesBufferUsage(),
@@ -784,17 +764,7 @@ export function createDataStore(device: GPUDevice): DataStore {
       ringStart = 0;
 
       if (pureGrowthAppend) {
-        packAppendAndUpload(
-          stagingBuffer,
-          buffer,
-          0,
-          0,
-          newPoints,
-          0,
-          newPointCount,
-          existing.xOffset,
-          oldCount
-        );
+        packAppendAndUpload(stagingBuffer, buffer, 0, 0, newPoints, 0, newPointCount, existing.xOffset, oldCount);
         series.set(index, {
           buffer,
           capacityBytes,
@@ -871,17 +841,7 @@ export function createDataStore(device: GPUDevice): DataStore {
 
     // ── Pure linear ranged append (no maxPoints, no growth) ──
     if (pureLinearRanged) {
-      packAppendAndUpload(
-        stagingBuffer,
-        buffer,
-        0,
-        0,
-        newPoints,
-        0,
-        newPointCount,
-        existing.xOffset,
-        prevPointCount
-      );
+      packAppendAndUpload(stagingBuffer, buffer, 0, 0, newPoints, 0, newPointCount, existing.xOffset, prevPointCount);
 
       series.set(index, {
         buffer,

--- a/src/data/seriesContentHash.ts
+++ b/src/data/seriesContentHash.ts
@@ -57,4 +57,3 @@ export function cheapOHLCContentStamp(data: ReadonlyArray<OHLCDataPoint>): numbe
   h = mixUint(h, 0x0f1ce);
   return h >>> 0;
 }
-

--- a/src/data/seriesRewriteDetect.ts
+++ b/src/data/seriesRewriteDetect.ts
@@ -225,11 +225,7 @@ export function packYOnlyInto(out: Float32Array, src: CartesianSeriesData, point
  * - `false` if every y is identical (skip GPU write)
  * - `null` if any y is non-finite (caller must fall through to full sparse pack)
  */
-export function packYOnlyChannel(
-  out: Float32Array,
-  src: CartesianSeriesData,
-  pointCount: number
-): boolean | null {
+export function packYOnlyChannel(out: Float32Array, src: CartesianSeriesData, pointCount: number): boolean | null {
   const n = Math.min(pointCount, getPointCount(src));
   let changed = false;
   for (let i = 0; i < n; i++) {

--- a/src/renderers/__tests__/areaRendererGeometryCache.test.ts
+++ b/src/renderers/__tests__/areaRendererGeometryCache.test.ts
@@ -153,6 +153,26 @@ describe('createAreaRenderer geometry cache', () => {
     renderer.dispose();
   });
 
+  it('re-uploads when length grows under stable column ref (streaming append)', () => {
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createAreaRenderer(device);
+    // Owned XY columns — same object identity across appends, growing length.
+    const cols = { x: [0, 1], y: [1, 2] };
+    const xScale = createLinearScale().domain(0, 10).range(0, 100);
+    const yScale = createLinearScale().domain(0, 10).range(100, 0);
+    const cfg = areaConfig(cols as any);
+
+    renderer.prepare(cfg, cols as any, xScale, yScale, 0);
+    expect(writeBuffer).toHaveBeenCalledTimes(1);
+
+    cols.x.push(2);
+    cols.y.push(3);
+    renderer.prepare(cfg, cols as any, xScale, yScale, 0);
+    expect(writeBuffer).toHaveBeenCalledTimes(2);
+    renderer.dispose();
+  });
+
   it('packs N*8 bytes (not N*16 strip expansion) into private storage (1.4)', () => {
     const device = createMockDevice();
     const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
@@ -227,6 +247,47 @@ describe('createAreaRenderer geometry cache', () => {
     const y2 = createLinearScale().domain(-1, 3).range(100, 0);
     renderer.prepare(cfg, data, xScale, y2, 0);
     expect(writeUniformBufferMock.mock.calls.length).toBeGreaterThan(0);
+    renderer.dispose();
+  });
+
+  it('places packed time-axis origin on-screen via external storage (no bx+ax*xOffset cancellation)', () => {
+    const device = createMockDevice();
+    writeUniformBufferMock.mockClear();
+    const renderer = createAreaRenderer(device);
+    const origin = 1_704_067_200_000; // 2024-01-01T00:00:00Z
+    const span = 899 * 60_000;
+    const data: DataPoint[] = [
+      [origin, 0],
+      [origin + span, 1],
+    ];
+    const plotLeft = -0.8676748582230625;
+    const plotRight = 0.9546313799621928;
+    const xScale = createLinearScale()
+      .domain(origin, origin + span)
+      .range(plotLeft, plotRight);
+    const yScale = createLinearScale().domain(-0.2, 1).range(-0.9, 0.9);
+    const external = { size: 1024, destroy: vi.fn() } as unknown as GPUBuffer;
+
+    // External storage path uses packing-origin X affine (same as LineRenderer).
+    renderer.prepare(areaConfig(data), data, xScale, yScale, 0, external, 2, origin);
+
+    // Area VS uniforms: mat4 + baseline padding = 96 bytes.
+    const vsWrites = writeUniformBufferMock.mock.calls.filter((c) => {
+      const dataArg = c[2];
+      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+    });
+    expect(vsWrites.length).toBeGreaterThan(0);
+    const f32 = new Float32Array(vsWrites[0]![2] as ArrayBuffer);
+    // mat4: ax at [0], bx at [12] (column-major translation x)
+    const ax = f32[0]!;
+    const bx = f32[12]!;
+    // Packed x=0 maps to scale(origin) ≈ plotLeft; packed end maps near plotRight.
+    expect(bx).toBeCloseTo(plotLeft, 5);
+    expect(ax * span + bx).toBeCloseTo(plotRight, 5);
+    // Regression: old bx+ax*origin path yielded ~-3.7 (off-screen left).
+    expect(bx).toBeGreaterThan(-1.5);
+    expect(bx).toBeLessThan(1.5);
+
     renderer.dispose();
   });
 });

--- a/src/renderers/__tests__/barRendererGeometryCache.test.ts
+++ b/src/renderers/__tests__/barRendererGeometryCache.test.ts
@@ -496,7 +496,9 @@ describe('createBarRenderer geometry cache', () => {
 
     const ga = gridArea();
     const clip = plotClipFor(ga);
-    const xScale = createLinearScale().domain(0, n - 1).range(clip.left, clip.right);
+    const xScale = createLinearScale()
+      .domain(0, n - 1)
+      .range(clip.left, clip.right);
     const yScale = createLinearScale().domain(0, 10).range(clip.bottom, clip.top);
 
     renderer.prepare([barConfig(data)], xScale, yScale, ga);
@@ -547,17 +549,14 @@ describe('createBarRenderer geometry cache', () => {
 
     const ga = gridArea();
     const clip = plotClipFor(ga);
-    const xScale = createLinearScale().domain(0, n - 1).range(clip.left, clip.right);
+    const xScale = createLinearScale()
+      .domain(0, n - 1)
+      .range(clip.left, clip.right);
     const yScale = createLinearScale().domain(0, 3).range(clip.bottom, clip.top);
 
     const colorA = '#ff0000';
     const colorB = '#0000ff';
-    renderer.prepare(
-      [barConfig(dataA, { color: colorA }), barConfig(dataB, { color: colorB })],
-      xScale,
-      yScale,
-      ga
-    );
+    renderer.prepare([barConfig(dataA, { color: colorA }), barConfig(dataB, { color: colorB })], xScale, yScale, ga);
 
     expect(writeBuffer).toHaveBeenCalledTimes(1);
     const byteLength = writeBuffer.mock.calls[0][4] as number;

--- a/src/renderers/__tests__/lineDrawPolicy.test.ts
+++ b/src/renderers/__tests__/lineDrawPolicy.test.ts
@@ -77,7 +77,6 @@ describe('resolveLineDrawPolicy', () => {
     expect(r.effectiveLineWidthCssPx).toBeLessThan(DENSE_LINE_MIN_WIDTH_CSS);
   });
 
-
   it('never returns denseThin (removed dead policy)', () => {
     for (const n of [1, 10_000, 24_999, 25_000, 50_000, 1_000_000]) {
       const r = resolveLineDrawPolicy({ pointCount: n, lineWidthCssPx: 2 });

--- a/src/renderers/__tests__/lineRendererBounds.test.ts
+++ b/src/renderers/__tests__/lineRendererBounds.test.ts
@@ -1,6 +1,6 @@
 /**
  * P2-5: Line prepare must not O(n)-scan series data for bounds.
- * Affine is derived from scale.scale(0)/scale.scale(1) only.
+ * X affine samples near packing origin (epoch-ms safe); Y uses scale(0)/scale(1).
  */
 
 /// <reference types="@webgpu/types" />
@@ -152,7 +152,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
     renderer.dispose();
   });
 
-  it('samples scale affine only at 0 and 1 (not per-point)', () => {
+  it('samples scale affine only near packing origin / y (0,1) (not per-point)', () => {
     const device = createMockDevice();
     const renderer = createLineRenderer(device);
     const data: DataPoint[] = Array.from({ length: 10_000 }, (_, i) => [i, i]);
@@ -174,13 +174,13 @@ describe('createLineRenderer bounds (P2-5)', () => {
     const xScaleSpy = vi.spyOn(xScale, 'scale');
     const yScaleSpy = vi.spyOn(yScale, 'scale');
     const dataBuffer = { label: 'data' } as GPUBuffer;
+    const xOffset = 0;
 
-    renderer.prepare(series, dataBuffer, xScale, yScale, 0, 2, 1280, 720);
+    renderer.prepare(series, dataBuffer, xScale, yScale, xOffset, 2, 1280, 720);
 
-    // Affine from (0,1) only — four scale() calls total across both axes.
-    expect(xScaleSpy.mock.calls.map((c) => c[0])).toEqual([0, 1]);
+    // X: packing origin + unit probe; Y: (0,1). Four scale() calls total — not O(n).
+    expect(xScaleSpy.mock.calls.map((c) => c[0])).toEqual([xOffset, xOffset + 1]);
     expect(yScaleSpy.mock.calls.map((c) => c[0])).toEqual([0, 1]);
-    // Must not scale each data point (would be O(n)).
     expect(xScaleSpy).toHaveBeenCalledTimes(2);
     expect(yScaleSpy).toHaveBeenCalledTimes(2);
 
@@ -189,14 +189,69 @@ describe('createLineRenderer bounds (P2-5)', () => {
     renderer.dispose();
   });
 
+  it('places packed time-axis origin on-screen (no bx+ax*xOffset cancellation)', () => {
+    const device = createMockDevice();
+    const writeUniform = writeUniformBuffer as ReturnType<typeof vi.fn>;
+    writeUniform.mockClear();
+    const renderer = createLineRenderer(device);
+    const origin = 1_704_067_200_000; // 2024-01-01T00:00:00Z
+    const span = 899 * 60_000;
+    const data: DataPoint[] = [
+      [origin, 0],
+      [origin + span, 1],
+    ];
+    const series = {
+      type: 'line',
+      data,
+      rawData: data,
+      color: '#4a9eff',
+      lineStyle: { width: 2, opacity: 1, color: '#4a9eff' },
+      sampling: 'none',
+      samplingThreshold: 5000,
+      connectNulls: false,
+      yAxis: 'y',
+      visible: true,
+    } as ResolvedLineSeriesConfig;
+
+    const plotLeft = -0.8676748582230625;
+    const plotRight = 0.9546313799621928;
+    const xScale = createLinearScale()
+      .domain(origin, origin + span)
+      .range(plotLeft, plotRight);
+    const yScale = createLinearScale().domain(-0.2, 1).range(-0.9, 0.9);
+    const dataBuffer = { label: 'data' } as GPUBuffer;
+
+    renderer.prepare(series, dataBuffer, xScale, yScale, origin, 2, 2116, 1079);
+
+    const vsWrites = writeUniform.mock.calls.filter((c) => {
+      const dataArg = c[2];
+      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 80;
+    });
+    expect(vsWrites.length).toBeGreaterThan(0);
+    const f32 = new Float32Array(vsWrites[0]![2] as ArrayBuffer);
+    // mat4: ax at [0], bx at [12] (column-major translation x)
+    const ax = f32[0]!;
+    const bx = f32[12]!;
+    // Packed x=0 maps to scale(origin) ≈ plotLeft; packed end maps near plotRight.
+    expect(bx).toBeCloseTo(plotLeft, 5);
+    expect(ax * span + bx).toBeCloseTo(plotRight, 5);
+    // Regression: old bx+ax*origin path yielded ~-3.7 (off-screen left).
+    expect(bx).toBeGreaterThan(-1.5);
+    expect(bx).toBeLessThan(1.5);
+
+    renderer.dispose();
+  });
+
   it('structurally does not import bounds scan into prepare path', async () => {
-    // Source-level regression: prepare path must stay on affine (0,1).
+    // Source-level regression: prepare path must stay on packed-origin X affine + y (0,1).
+    // X samples near packing origin (epoch-ms safe); never fold bx+ax*xOffset from (0,1).
     const fs = await import('node:fs');
     const path = await import('node:path');
     const src = fs.readFileSync(path.resolve(__dirname, '../createLineRenderer.ts'), 'utf8');
     expect(src).not.toMatch(/computeRawBoundsFromCartesianData/);
-    expect(src).toMatch(/computeClipAffineFromScale\(xScale, 0, 1\)/);
+    expect(src).toMatch(/computePackedXAffineFromScale\(xScale, xOffset\)/);
     expect(src).toMatch(/computeClipAffineFromScale\(yScale, 0, 1\)/);
+    expect(src).not.toMatch(/bx \+ ax \* xOffset/);
   });
 
   it('denseHairline prepare writes floor line width into VS uniform at high N', () => {
@@ -235,12 +290,15 @@ describe('createLineRenderer bounds (P2-5)', () => {
     const renderer = createLineRenderer(device, { sampleCount: 4 });
     // Two pipelines: standard (main MSAA) + hairline (always sampleCount 1)
     expect(createPipe).toHaveBeenCalledTimes(2);
-    const configs = createPipe.mock.calls.map((c) => c[1] as {
-      label?: string;
-      primitive?: { topology?: string };
-      multisample?: { count?: number };
-      vertex?: { entryPoint?: string };
-    });
+    const configs = createPipe.mock.calls.map(
+      (c) =>
+        c[1] as {
+          label?: string;
+          primitive?: { topology?: string };
+          multisample?: { count?: number };
+          vertex?: { entryPoint?: string };
+        }
+    );
     const hairline = configs.find(
       (c) => c.label === 'lineRenderer/hairlinePipeline' || c.vertex?.entryPoint === 'vsMainHairline'
     );

--- a/src/renderers/__tests__/scatterConstRadius.test.ts
+++ b/src/renderers/__tests__/scatterConstRadius.test.ts
@@ -106,9 +106,7 @@ describe('scatter F32 column zero-copy path', () => {
     renderer.prepare(baseSeries(5), data as unknown as never, identityScale, identityScale, gridArea);
 
     // Two channel uploads sourced from column ArrayBuffers (byteOffset/byteLength form).
-    const colWrites = writeBuffer.mock.calls.filter(
-      (c) => c[2] === x.buffer || c[2] === y.buffer
-    );
+    const colWrites = writeBuffer.mock.calls.filter((c) => c[2] === x.buffer || c[2] === y.buffer);
     expect(colWrites.length).toBe(2);
     expect(colWrites.some((c) => c[2] === x.buffer && c[4] === n * 4)).toBe(true);
     expect(colWrites.some((c) => c[2] === y.buffer && c[4] === n * 4)).toBe(true);
@@ -126,9 +124,7 @@ describe('scatter F32 column zero-copy path', () => {
     renderer.prepare(baseSeries(5), data as unknown as never, identityScale, identityScale, gridArea);
 
     // Packed staging uses ArrayBuffer views that are NOT the number[] itself.
-    const sourcedFromNumberArray = writeBuffer.mock.calls.some(
-      (c) => c[2] === x || c[2] === y
-    );
+    const sourcedFromNumberArray = writeBuffer.mock.calls.some((c) => c[2] === x || c[2] === y);
     expect(sourcedFromNumberArray).toBe(false);
     // Still uploads N*4 channel bytes (from CPU staging).
     const channelBytes = writeBuffer.mock.calls.filter((c) => c[4] === n * 4);
@@ -145,9 +141,7 @@ describe('scatter F32 column zero-copy path', () => {
     const data = { x, y, __stagingRing: true };
     writeBuffer.mockClear();
     renderer.prepare(baseSeries(5), data as unknown as never, identityScale, identityScale, gridArea);
-    const colWrites = writeBuffer.mock.calls.filter(
-      (c) => c[2] === x.buffer || c[2] === y.buffer
-    );
+    const colWrites = writeBuffer.mock.calls.filter((c) => c[2] === x.buffer || c[2] === y.buffer);
     // Staging-ring flag forces pack path — must not zero-copy column buffers.
     expect(colWrites.length).toBe(0);
   });
@@ -166,9 +160,7 @@ describe('scatter F32 column zero-copy path', () => {
     y[3] = Number.NaN;
     writeBuffer.mockClear();
     renderer.prepare(baseSeries(5), { x, y } as unknown as never, identityScale, identityScale, gridArea);
-    const colWrites = writeBuffer.mock.calls.filter(
-      (c) => c[2] === x.buffer || c[2] === y.buffer
-    );
+    const colWrites = writeBuffer.mock.calls.filter((c) => c[2] === x.buffer || c[2] === y.buffer);
     expect(colWrites.length).toBe(0);
   });
 });

--- a/src/renderers/createAreaRenderer.ts
+++ b/src/renderers/createAreaRenderer.ts
@@ -4,8 +4,16 @@ import type { CartesianSeriesData } from '../config/types';
 import type { LinearScale } from '../utils/scales';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
-import { getPointCount, getX, getY, computeRawBoundsFromCartesianData } from '../data/cartesianData';
+import {
+  getPointCount,
+  getX,
+  getY,
+  computeRawBoundsFromCartesianData,
+  isStagingRingView,
+  isRingXYColumns,
+} from '../data/cartesianData';
 import type { PipelineCache } from '../core/PipelineCache';
+import { computePackedXAffineFromScale } from './packedXAffine';
 
 export interface AreaRenderer {
   prepare(
@@ -25,8 +33,8 @@ export interface AreaRenderer {
      */
     pointCountOverride?: number,
     /**
-     * X-origin subtracted during packing (time-axis Float32). Folded into
-     * the clip affine like LineRenderer.
+     * X-origin subtracted during packing (time-axis Float32). Clip affine
+     * samples near this origin: clipX = ax * x' + scale(xOffset).
      */
     xOffset?: number
   ): void;
@@ -317,16 +325,20 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
       boundDataRef = null; // external ownership
       bindStorage(storageBuffer);
 
-      // Affine sample at 0/1 like line; fold xOffset for packed time axes.
-      const { a: ax, b: bx } = computeClipAffineFromScale(xScale, 0, 1);
+      // Packed-origin X affine (stable for epoch-ms); Y samples (0,1).
+      const { a: ax, b: bxPacked } = computePackedXAffineFromScale(xScale, xOffset);
       const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
-      const bxAdjusted = bx + ax * xOffset;
       const baselineValue = Number.isFinite(baseline ?? Number.NaN) ? (baseline as number) : 0;
-      writeVsUniforms(ax, bxAdjusted, ay, by, baselineValue);
+      writeVsUniforms(ax, bxPacked, ay, by, baselineValue);
     } else {
       // Private pack path with identity cache + pow2 growth.
+      // Also re-pack when length changes under a stable ref (streaming append grows
+      // owned XY columns in place; modular-ring fallback path uses this branch).
+      // Staging/ring views reuse object identity with constant count while
+      // start/staging floats mutate — always re-pack those (FIFO after wrap).
       const n = getPointCount(data);
-      if (boundDataRef !== data) {
+      const ringOrStaging = isStagingRingView(data) || isRingXYColumns(data);
+      if (boundDataRef !== data || n !== pointCount || ringOrStaging) {
         ensureCpuStaging(n * 2);
         packAreaPointsInto(cpuStaging, data, n);
         const requiredBytes = Math.max(4, n * 8);

--- a/src/renderers/createBarRenderer.ts
+++ b/src/renderers/createBarRenderer.ts
@@ -722,10 +722,7 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
       const packGapDomain = gapDomain * densityStride;
       const packClusterWidthDomain = clusterWidthDomain * densityStride;
       // Independent per-series budget — do not let earlier series consume the global pack.
-      const seriesMaxOutFloats = Math.min(
-        maxOutFloats,
-        outFloats + perSeriesCap * INSTANCE_STRIDE_FLOATS
-      );
+      const seriesMaxOutFloats = Math.min(maxOutFloats, outFloats + perSeriesCap * INSTANCE_STRIDE_FLOATS);
 
       for (let i = 0; i < count; i += densityStride) {
         if (outFloats >= seriesMaxOutFloats) break;
@@ -738,8 +735,7 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
         // Under reversed x (xDir < 0), mirror slot index so series 0 stays left
         // in clip without shifting the single-series center (idx stays 0).
         const effectiveClusterIndex = xDir < 0 ? clusterCount - 1 - clusterIndex : clusterIndex;
-        const left =
-          x - packClusterWidthDomain / 2 + effectiveClusterIndex * (packBarWidthDomain + packGapDomain);
+        const left = x - packClusterWidthDomain / 2 + effectiveClusterIndex * (packBarWidthDomain + packGapDomain);
 
         let baseDomain = baselineDomain;
         let heightDomain = 0;

--- a/src/renderers/createLineRenderer.ts
+++ b/src/renderers/createLineRenderer.ts
@@ -6,6 +6,7 @@ import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from '.
 import { getPointCount } from '../data/cartesianData';
 import type { PipelineCache } from '../core/PipelineCache';
 import { resolveLineDrawPolicy, type LineDrawPolicy } from './lineDrawPolicy';
+import { computePackedXAffineFromScale } from './packedXAffine';
 
 export interface LineRenderer {
   /**
@@ -50,10 +51,7 @@ export interface LineRenderer {
    * @param options.skipSetPipeline - When true, assumes the hairline pipeline
    *   is already bound (multi-series batch: set once, then N draw calls).
    */
-  renderHairline(
-    passEncoder: GPURenderPassEncoder,
-    options?: Readonly<{ skipSetPipeline?: boolean }>
-  ): void;
+  renderHairline(passEncoder: GPURenderPassEncoder, options?: Readonly<{ skipSetPipeline?: boolean }>): void;
   /**
    * Bind the dense-hairline pipeline (for multi-series batching).
    * Safe to call even when this instance is not hairline this frame.
@@ -306,18 +304,13 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
         ? Math.floor(pointCountOverride)
         : getPointCount(seriesConfig.data);
 
-    // Linear scales: sample affine at (0, 1) instead of O(n) bounds scan.
-    // Matches scatter / area / candlestick and is correct for any linear scale.
-    const { a: ax, b: bx } = computeClipAffineFromScale(xScale, 0, 1);
+    // X: packed-origin affine (stable for epoch-ms time axes). Y: sample (0,1)
+    // — y values stay O(1)–O(1e6), no packing offset.
+    const { a: ax, b: bxPacked } = computePackedXAffineFromScale(xScale, xOffset);
     const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
 
-    // When the vertex buffer packs x as (x - xOffset) (to preserve Float32 precision for large
-    // domains like epoch-ms), fold the offset back into the affine's intercept in f64 on CPU:
-    // clipX = ax * (x - xOffset) + (bx + ax * xOffset)
-    const bxAdjusted = bx + ax * xOffset;
-
     // Write VS uniforms: mat4x4 (16 floats) + canvasSize (2 floats) + dpr (1 float) + lineWidth (1 float).
-    writeTransformMat4F32(vsUniformScratchF32, ax, bxAdjusted, ay, by);
+    writeTransformMat4F32(vsUniformScratchF32, ax, bxPacked, ay, by);
     const dpr = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1;
     const canvasW = Number.isFinite(canvasWidthDevicePx) && canvasWidthDevicePx > 0 ? canvasWidthDevicePx : 1;
     const canvasH = Number.isFinite(canvasHeightDevicePx) && canvasHeightDevicePx > 0 ? canvasHeightDevicePx : 1;
@@ -348,7 +341,7 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
     {
       const vsDirty =
         lastAx !== ax ||
-        lastBx !== bxAdjusted ||
+        lastBx !== bxPacked ||
         lastAy !== ay ||
         lastBy !== by ||
         lastCanvasW !== canvasW ||
@@ -358,7 +351,7 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
       if (vsDirty) {
         writeUniformBuffer(device, vsUniformBuffer, vsUniformScratchBuffer);
         lastAx = ax;
-        lastBx = bxAdjusted;
+        lastBx = bxPacked;
         lastAy = ay;
         lastBy = by;
         lastCanvasW = canvasW;

--- a/src/renderers/createScatterRenderer.ts
+++ b/src/renderers/createScatterRenderer.ts
@@ -8,10 +8,7 @@ import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from '.
 import { getPointCount, getX, getY, getSize, hasAnyPerPointSize } from '../data/cartesianData';
 import type { PipelineCache } from '../core/PipelineCache';
 import { resolveUploadPolicy } from '../data/seriesResidency';
-import {
-  isYOnlyRewriteAgainstXStaging,
-  packYOnlyChannel,
-} from '../data/seriesRewriteDetect';
+import { isYOnlyRewriteAgainstXStaging, packYOnlyChannel } from '../data/seriesRewriteDetect';
 import { resolveScatterDrawPolicy } from './scatterDrawPolicy';
 
 export interface ScatterRenderer {

--- a/src/renderers/lineDrawPolicy.ts
+++ b/src/renderers/lineDrawPolicy.ts
@@ -64,7 +64,6 @@ export const DENSE_HAIRLINE_POINT_THRESHOLD = 25_000;
  */
 export const MULTI_SERIES_HAIRLINE_SEGMENT_BUDGET = 500_000;
 
-
 /** Floor width reported for hairline bookkeeping (CSS px). Native stroke is 1 device px. */
 export const DENSE_LINE_MIN_WIDTH_CSS = 1;
 
@@ -76,10 +75,8 @@ export const DENSE_LINE_MIN_WIDTH_CSS = 1;
  *   (only when main MSAA is 4× — see {@link LineDrawPolicyInput.msaaSampleCount})
  */
 export function resolveLineDrawPolicy(input: LineDrawPolicyInput): LineDrawPolicyResult {
-  const w =
-    Number.isFinite(input.lineWidthCssPx) && input.lineWidthCssPx > 0 ? input.lineWidthCssPx : 2;
-  const pointCount =
-    Number.isFinite(input.pointCount) && input.pointCount > 0 ? Math.floor(input.pointCount) : 0;
+  const w = Number.isFinite(input.lineWidthCssPx) && input.lineWidthCssPx > 0 ? input.lineWidthCssPx : 2;
+  const pointCount = Number.isFinite(input.pointCount) && input.pointCount > 0 ? Math.floor(input.pointCount) : 0;
   const lineSeriesCount =
     Number.isFinite(input.lineSeriesCount) && (input.lineSeriesCount as number) > 0
       ? Math.floor(input.lineSeriesCount as number)
@@ -97,8 +94,7 @@ export function resolveLineDrawPolicy(input: LineDrawPolicyInput): LineDrawPolic
   const perSeriesHairline = pointCount >= DENSE_HAIRLINE_POINT_THRESHOLD;
   const segmentsPerSeries = Math.max(0, pointCount - 1);
   const approxTotalSegments = lineSeriesCount * segmentsPerSeries;
-  const multiSeriesHairline =
-    lineSeriesCount >= 2 && approxTotalSegments >= MULTI_SERIES_HAIRLINE_SEGMENT_BUDGET;
+  const multiSeriesHairline = lineSeriesCount >= 2 && approxTotalSegments >= MULTI_SERIES_HAIRLINE_SEGMENT_BUDGET;
 
   if (!perSeriesHairline && !multiSeriesHairline) {
     return { policy: 'standard', effectiveLineWidthCssPx: w };

--- a/src/renderers/packedXAffine.ts
+++ b/src/renderers/packedXAffine.ts
@@ -1,0 +1,28 @@
+import type { LinearScale } from '../utils/scales';
+
+/**
+ * Clip affine for buffers packed as `x' = x - xOffset` (time-axis Float32 safety).
+ *
+ * Must sample near `xOffset` — `computeClipAffineFromScale(0,1)` then `bx + ax*xOffset`
+ * loses digits when domain is ~1e12 epoch-ms (catastrophic cancellation). Same contract as
+ * candlestick packing-origin affine.
+ *
+ * clipX = ax * x' + b  with  b = scale(xOffset), ax = scale(xOffset+δ) - scale(xOffset) for δ=1.
+ */
+export function computePackedXAffineFromScale(
+  scale: LinearScale,
+  xOffset: number
+): { readonly a: number; readonly b: number } {
+  const origin = Number.isFinite(xOffset) ? xOffset : 0;
+  const p0 = scale.scale(origin);
+  // Unit probe: for linear scales equals (rangeSpan/domainSpan); stays exact near origin.
+  const p1 = scale.scale(origin + 1);
+  if (!Number.isFinite(p0)) {
+    return { a: 0, b: 0 };
+  }
+  if (!Number.isFinite(p1)) {
+    return { a: 0, b: p0 };
+  }
+  const a = p1 - p0;
+  return { a: Number.isFinite(a) ? a : 0, b: p0 };
+}

--- a/src/shaders/__tests__/decimationMulDiv.test.ts
+++ b/src/shaders/__tests__/decimationMulDiv.test.ts
@@ -148,9 +148,7 @@ describe('decimation dense-bucket candidate cap (FIFO 10M LTTB)', () => {
     const candCount = bucketCandidateCount(rangeLen);
     expect(candCount).toBe(512);
     expect(candidateRawIndex(rangeStart, rangeLen, 0, candCount)).toBe(rangeStart);
-    expect(candidateRawIndex(rangeStart, rangeLen, candCount - 1, candCount)).toBe(
-      rangeStart + rangeLen - 1
-    );
+    expect(candidateRawIndex(rangeStart, rangeLen, candCount - 1, candCount)).toBe(rangeStart + rangeLen - 1);
     // Monotonic non-decreasing candidate indices
     let prev = -1;
     for (let s = 0; s < candCount; s++) {


### PR DESCRIPTION
## Summary

- **Time-axis packing affine:** Sample line/area X clip affine near the packing origin so epoch-ms domains no longer cancel off-screen.
- **Pure area streaming:** Route `type: area` through DataStore with ranged append and re-pack private area geometry for ring/staging views.
- **Full-width unbounded streaming:** Set sticky X headroom to 0 so auto-range `appendData` tracks data max tightly (no empty-right grow/reset loop).
- **Device storage cap:** When growth would exceed `maxStorageBufferBindingSize` (often ~16.7M points / 128 MiB), auto-window like `maxPoints` and skip batches on GPU append failure so domain stays in sync with GPU-resident data (fixes ultimate-benchmark multi-10M empty-right gutter).

## Test plan

- [ ] Unit: `bun run test -- src/core/renderCoordinator/zoom/__tests__/stickyAutoDomain.test.ts`
- [ ] Unit: `bun run test -- src/data/__tests__/createDataStore.test.ts -t "auto-windows unbounded"`
- [ ] Ultimate benchmark: generate line data, start streaming — series stays full width as points append (no grow/reset loop)
- [ ] Ultimate benchmark: stream past ~17M points on a 128 MiB-storage device — chart stays full width with sliding window (no empty right gutter while axis extends)
- [ ] Time-axis line/area (epoch-ms x): series remains visible across domain (no off-screen cancel)
- [ ] Pure `type: area` streaming append / ring / staging still renders correctly