### PR TITLE
fix: area fill null gaps fan to origin (#153)

### DIFF
--- a/src/renderers/__tests__/areaRendererGeometryCache.test.ts
+++ b/src/renderers/__tests__/areaRendererGeometryCache.test.ts
@@ -290,4 +290,305 @@ describe('createAreaRenderer geometry cache', () => {
 
     renderer.dispose();
   });
+
+  it('render uses instanced trapezoid draw(6, segments) not continuous strip (issue #153)', () => {
+    const device = createMockDevice();
+    const renderer = createAreaRenderer(device);
+    // Issue #153 repro shape: three finite runs separated by nulls.
+    const data: Array<DataPoint | null> = [
+      [0, 0.75],
+      [0.25, 0.75],
+      null,
+      [0.75, 0.75],
+      [1.0, 0.75],
+      null,
+      [1.5, 0.75],
+      [2, 0.75],
+    ];
+    const xScale = createLinearScale().domain(0, 2).range(0, 100);
+    const yScale = createLinearScale().domain(0, 1).range(100, 0);
+    const cfg = areaConfig(data as DataPoint[]);
+
+    renderer.prepare(cfg, data as DataPoint[], xScale, yScale, 0.5);
+
+    const draws: Array<{ v: number; i: number }> = [];
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn((v: number, i: number) => {
+        draws.push({ v, i });
+      }),
+    } as unknown as GPURenderPassEncoder;
+
+    renderer.render(pass);
+    // 8 points → 7 segments; 6 verts/instance (not legacy strip draw(N*2)).
+    expect(draws).toEqual([{ v: 6, i: 7 }]);
+    renderer.dispose();
+  });
+
+  it('external storage path draws draw(6, pointCountOverride-1) without private writeBuffer', () => {
+    // Line+areaStyle / pure-area DataStore path: shared buffer + override count.
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createAreaRenderer(device);
+    // data.length deliberately differs from override to prove draw uses override.
+    const data: DataPoint[] = [
+      [0, 1],
+      [1, 2],
+    ];
+    const overrideN = 5;
+    const xScale = createLinearScale().domain(0, 4).range(0, 100);
+    const yScale = createLinearScale().domain(0, 4).range(100, 0);
+    const external = { size: 1024, destroy: vi.fn() } as unknown as GPUBuffer;
+
+    renderer.prepare(areaConfig(data), data, xScale, yScale, 0, external, overrideN, 0);
+    expect(writeBuffer).not.toHaveBeenCalled();
+
+    const draws: Array<{ v: number; i: number }> = [];
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn((v: number, i: number) => {
+        draws.push({ v, i });
+      }),
+    } as unknown as GPURenderPassEncoder;
+    renderer.render(pass);
+    expect(draws).toEqual([{ v: 6, i: overrideN - 1 }]);
+    renderer.dispose();
+  });
+
+  it('external storage with pointCountOverride < 2 skips draw', () => {
+    const device = createMockDevice();
+    const renderer = createAreaRenderer(device);
+    const data: DataPoint[] = [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+    ];
+    const xScale = createLinearScale().domain(0, 2).range(0, 100);
+    const yScale = createLinearScale().domain(0, 3).range(100, 0);
+    const external = { size: 1024, destroy: vi.fn() } as unknown as GPUBuffer;
+
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn(),
+    } as unknown as GPURenderPassEncoder;
+
+    renderer.prepare(areaConfig(data), data, xScale, yScale, 0, external, 0, 0);
+    renderer.render(pass);
+    expect(pass.draw).not.toHaveBeenCalled();
+
+    (pass.draw as ReturnType<typeof vi.fn>).mockClear();
+    renderer.prepare(areaConfig(data), data, xScale, yScale, 0, external, 1, 0);
+    renderer.render(pass);
+    expect(pass.draw).not.toHaveBeenCalled();
+    renderer.dispose();
+  });
+
+  it('skips draw when fewer than 2 points (private pack, single and empty)', () => {
+    const device = createMockDevice();
+    const renderer = createAreaRenderer(device);
+    const xScale = createLinearScale().domain(0, 1).range(0, 100);
+    const yScale = createLinearScale().domain(0, 1).range(100, 0);
+
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn(),
+    } as unknown as GPURenderPassEncoder;
+
+    const single: DataPoint[] = [[0, 1]];
+    renderer.prepare(areaConfig(single), single, xScale, yScale, 0);
+    renderer.render(pass);
+    expect(pass.draw).not.toHaveBeenCalled();
+
+    (pass.draw as ReturnType<typeof vi.fn>).mockClear();
+    const empty: DataPoint[] = [];
+    renderer.prepare(areaConfig(empty), empty, xScale, yScale, 0);
+    renderer.render(pass);
+    expect(pass.draw).not.toHaveBeenCalled();
+    renderer.dispose();
+  });
+
+  it('packs NaN for null gap entries so VS dual-endpoint discard can fire (issue #153)', () => {
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createAreaRenderer(device);
+    // Minimal repro from issue #153.
+    const data: Array<DataPoint | null> = [
+      [0, 0.75],
+      [0.25, 0.75],
+      null,
+      [0.75, 0.75],
+      [1.0, 0.75],
+      null,
+      [1.5, 0.75],
+      [2, 0.75],
+    ];
+    const xScale = createLinearScale().domain(0, 2).range(0, 100);
+    const yScale = createLinearScale().domain(0, 1).range(100, 0);
+
+    renderer.prepare(areaConfig(data as DataPoint[]), data as DataPoint[], xScale, yScale, 0.5);
+
+    expect(writeBuffer).toHaveBeenCalledTimes(1);
+    const ab = writeBuffer.mock.calls[0]![2] as ArrayBuffer;
+    const byteOffset = writeBuffer.mock.calls[0]![3] as number;
+    const byteLength = writeBuffer.mock.calls[0]![4] as number;
+    const packed = new Float32Array(ab, byteOffset, byteLength / 4);
+    // Index 2 and 5 are null → NaN pairs at floats [4,5] and [10,11].
+    expect(Number.isNaN(packed[4])).toBe(true);
+    expect(Number.isNaN(packed[5])).toBe(true);
+    expect(Number.isNaN(packed[10])).toBe(true);
+    expect(Number.isNaN(packed[11])).toBe(true);
+    // Finite neighbors stay finite (no silent NaN bleed).
+    expect(packed[0]).toBe(0);
+    expect(packed[1]).toBe(0.75);
+    expect(packed[6]).toBe(0.75);
+    expect(packed[7]).toBe(0.75);
+    expect(packed[14]).toBe(2);
+    expect(packed[15]).toBe(0.75);
+    renderer.dispose();
+  });
+
+  it('packs leading nulls as NaN without shifting subsequent points', () => {
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createAreaRenderer(device);
+    const data: Array<DataPoint | null> = [null, [1, 2], [3, 4]];
+    const xScale = createLinearScale().domain(0, 3).range(0, 100);
+    const yScale = createLinearScale().domain(0, 4).range(100, 0);
+
+    renderer.prepare(areaConfig(data as DataPoint[]), data as DataPoint[], xScale, yScale, 0);
+
+    const ab = writeBuffer.mock.calls[0]![2] as ArrayBuffer;
+    const byteOffset = writeBuffer.mock.calls[0]![3] as number;
+    const byteLength = writeBuffer.mock.calls[0]![4] as number;
+    const packed = new Float32Array(ab, byteOffset, byteLength / 4);
+    expect(Number.isNaN(packed[0])).toBe(true);
+    expect(Number.isNaN(packed[1])).toBe(true);
+    expect(packed[2]).toBe(1);
+    expect(packed[3]).toBe(2);
+    expect(packed[4]).toBe(3);
+    expect(packed[5]).toBe(4);
+    renderer.dispose();
+  });
+
+  it('packs consecutive and trailing nulls as NaN pairs; draw still uses N-1 segments', () => {
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createAreaRenderer(device);
+    // Indices 1,2 consecutive nulls; index 4 trailing null.
+    const data: Array<DataPoint | null> = [[0, 1], null, null, [3, 4], null];
+    const xScale = createLinearScale().domain(0, 3).range(0, 100);
+    const yScale = createLinearScale().domain(0, 4).range(100, 0);
+
+    renderer.prepare(areaConfig(data as DataPoint[]), data as DataPoint[], xScale, yScale, 0);
+
+    const ab = writeBuffer.mock.calls[0]![2] as ArrayBuffer;
+    const byteOffset = writeBuffer.mock.calls[0]![3] as number;
+    const byteLength = writeBuffer.mock.calls[0]![4] as number;
+    const packed = new Float32Array(ab, byteOffset, byteLength / 4);
+    expect(packed.length).toBe(10); // 5 points × 2
+    expect(packed[0]).toBe(0);
+    expect(packed[1]).toBe(1);
+    expect(Number.isNaN(packed[2])).toBe(true);
+    expect(Number.isNaN(packed[3])).toBe(true);
+    expect(Number.isNaN(packed[4])).toBe(true);
+    expect(Number.isNaN(packed[5])).toBe(true);
+    expect(packed[6]).toBe(3);
+    expect(packed[7]).toBe(4);
+    expect(Number.isNaN(packed[8])).toBe(true);
+    expect(Number.isNaN(packed[9])).toBe(true);
+
+    const draws: Array<{ v: number; i: number }> = [];
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn((v: number, i: number) => {
+        draws.push({ v, i });
+      }),
+    } as unknown as GPURenderPassEncoder;
+    renderer.render(pass);
+    // 5 points → 4 segment instances (gap discard is GPU-side).
+    expect(draws).toEqual([{ v: 6, i: 4 }]);
+    renderer.dispose();
+  });
+
+  it('connectNulls-modeled continuous input packs all-finite and draws draw(6, N-1)', () => {
+    // Models coordinator connectNulls path: filterGaps strips nulls before prepare,
+    // so the area renderer only ever sees continuous finite points.
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createAreaRenderer(device);
+    // filterGaps([[0,1], null, [2,3], null, [4,5]]) → these 3 points.
+    const bridged: DataPoint[] = [
+      [0, 1],
+      [2, 3],
+      [4, 5],
+    ];
+    const xScale = createLinearScale().domain(0, 4).range(0, 100);
+    const yScale = createLinearScale().domain(0, 5).range(100, 0);
+
+    renderer.prepare(areaConfig(bridged, { connectNulls: true }), bridged, xScale, yScale, 0);
+
+    const ab = writeBuffer.mock.calls[0]![2] as ArrayBuffer;
+    const byteOffset = writeBuffer.mock.calls[0]![3] as number;
+    const byteLength = writeBuffer.mock.calls[0]![4] as number;
+    const packed = new Float32Array(ab, byteOffset, byteLength / 4);
+    expect(packed.length).toBe(6);
+    for (let i = 0; i < packed.length; i++) {
+      expect(Number.isFinite(packed[i]!)).toBe(true);
+    }
+    expect(Array.from(packed)).toEqual([0, 1, 2, 3, 4, 5]);
+
+    const draws: Array<{ v: number; i: number }> = [];
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn((v: number, i: number) => {
+        draws.push({ v, i });
+      }),
+    } as unknown as GPURenderPassEncoder;
+    renderer.render(pass);
+    expect(draws).toEqual([{ v: 6, i: 2 }]);
+    renderer.dispose();
+  });
+});
+
+describe('area.wgsl gap contract (issue #153)', () => {
+  it('vsMain dual-endpoint NaN-checks both segment ends (not single-point strip collapse)', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const src = fs.readFileSync(path.resolve(__dirname, '../../shaders/area.wgsl'), 'utf8');
+    const vsStart = src.indexOf('fn vsMain');
+    expect(vsStart).toBeGreaterThan(-1);
+    const vsBody = src.slice(vsStart, src.indexOf('fn fsMain'));
+    // Per-segment endpoints (instanced), not vertex_index/2 continuous strip.
+    expect(vsBody).toMatch(/points\[instanceIndex\]/);
+    expect(vsBody).toMatch(/points\[instanceIndex \+ 1u\]/);
+    expect(vsBody).toMatch(/pA\.x != pA\.x/);
+    expect(vsBody).toMatch(/pA\.y != pA\.y/);
+    expect(vsBody).toMatch(/pB\.x != pB\.x/);
+    expect(vsBody).toMatch(/pB\.y != pB\.y/);
+    // Gap collapse must zero clip position (rasterizer discard), not leave a spur.
+    expect(vsBody).toMatch(/clipPosition\s*=\s*vec4<f32>\(\s*0\.0\s*,\s*0\.0\s*,\s*0\.0\s*,\s*0\.0\s*\)/);
+    // Must not claim strip collapse "breaks" gaps (stale contract).
+    expect(src).not.toMatch(/zero-area strip breaks/i);
+  });
+
+  it('uses triangle-list instanced topology (6 verts × segments), not continuous strip', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const shader = fs.readFileSync(path.resolve(__dirname, '../../shaders/area.wgsl'), 'utf8');
+    const rendererSrc = fs.readFileSync(path.resolve(__dirname, '../createAreaRenderer.ts'), 'utf8');
+    // Shader contract: instancing + dual-endpoint (topology is enforced on the TS pipeline).
+    expect(shader).toMatch(/instance_index/);
+    expect(shader).toMatch(/pA\.x != pA\.x/);
+    expect(shader).toMatch(/pB\.x != pB\.x/);
+    expect(rendererSrc).toMatch(/topology:\s*['"]triangle-list['"]/);
+    expect(rendererSrc).toMatch(/draw\(6,\s*segments\)/);
+    // Legacy continuous strip path must stay gone.
+    expect(rendererSrc).not.toMatch(/draw\(pointCount \* 2\)/);
+  });
 });

--- a/src/renderers/createAreaRenderer.ts
+++ b/src/renderers/createAreaRenderer.ts
@@ -121,8 +121,11 @@ const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: nu
 };
 
 /**
- * Pack N domain points into staging (not N→2N strip verts). Shader expands
- * baseline via vertex_index parity against storage points (issue 1.4).
+ * Pack N domain points into staging (not expanded geometry). Shader expands
+ * each segment `i → i+1` into a baseline trapezoid via instance_index + vertex_index
+ * (issue 1.4 storage layout; issue #153 per-segment gap discard).
+ * Null / non-finite points are written as NaN so the VS dual-endpoint check can
+ * collapse only gap-spanning segments (matches packXYInto / line.wgsl).
  */
 function packAreaPointsInto(out: Float32Array, data: CartesianSeriesData, pointCount: number): void {
   for (let i = 0; i < pointCount; i++) {
@@ -203,7 +206,9 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
           },
         },
       },
-      primitive: { topology: 'triangle-strip', cullMode: 'none' },
+      // Instanced triangle-list: 6 verts × (N-1) segments (matches line AA path).
+      // Per-segment topology allows dual-endpoint NaN discard without strip fans (#153).
+      primitive: { topology: 'triangle-list', cullMode: 'none' },
       multisample: { count: sampleCount },
     },
     pipelineCache
@@ -214,7 +219,7 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
   /** Bound storage for draw (private or external). */
   let boundDataBuffer: GPUBuffer | null = null;
   let currentBindGroup: GPUBindGroup | null = null;
-  /** Logical point count (not strip verts). */
+  /** Logical point count (draw uses N-1 segment instances). */
   let pointCount = 0;
   // Geometry identity: reuse private pack when data ref stable (axes-only).
   let boundDataRef: CartesianSeriesData | null = null;
@@ -396,12 +401,14 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
 
   const render: AreaRenderer['render'] = (passEncoder) => {
     assertNotDisposed();
-    // Need ≥2 points → ≥4 strip verts for a non-empty fill.
+    // Need ≥2 points → ≥1 segment instance for a non-empty fill.
     if (!currentBindGroup || pointCount < 2) return;
 
+    const segments = pointCount - 1;
     passEncoder.setPipeline(pipeline);
     passEncoder.setBindGroup(0, currentBindGroup);
-    passEncoder.draw(pointCount * 2);
+    // 6 vertices per instance (trapezoid), (pointCount - 1) instances (segments).
+    passEncoder.draw(6, segments);
   };
 
   const dispose: AreaRenderer['dispose'] = () => {

--- a/src/shaders/area.wgsl
+++ b/src/shaders/area.wgsl
@@ -1,9 +1,12 @@
 // area.wgsl
 // Area-fill from a storage buffer of domain points (shared with line stroke):
 // - points[i] = vec2(x, y) in data coords (optionally x - xOffset packed)
-// - Draw triangle-strip with vertexCount = pointCount * 2
-// - vertex_index / 2 selects the point; parity selects top (y) vs baseline
-// - Null/NaN points collapse to a degenerate position (zero-area strip breaks)
+// - Draw triangle-list with 6 vertices × (pointCount - 1) instances
+//   (one trapezoid per consecutive pair point[i] → point[i+1])
+// - instance_index selects the segment; vertex_index selects the 6 quad corners
+// - Dual-endpoint NaN check collapses gap-spanning segments (matches line.wgsl).
+//   Continuous triangle-strip collapse to clip origin does NOT restart a strip
+//   and incorrectly fans through (0,0,0,0) — see GitHub issue #153.
 
 struct VSUniforms {
   transform: mat4x4<f32>,
@@ -26,20 +29,43 @@ struct VSOut {
   @builtin(position) clipPosition: vec4<f32>,
 };
 
-@vertex
-fn vsMain(@builtin(vertex_index) vertexIndex: u32) -> VSOut {
-  var out: VSOut;
-  let pointIndex = vertexIndex / 2u;
-  let useBaseline = (vertexIndex & 1u) == 1u;
-  let p = points[pointIndex];
+// 6 vertices of a segment quad (2 triangles = trapezoid to baseline):
+//   0: A top, 1: B top, 2: A baseline
+//   3: A baseline, 4: B top, 5: B baseline
+// uv.x: 0 → endpoint A, 1 → endpoint B
+// uv.y: 0 → series y (top), 1 → baseline
+fn segmentUv(vid: u32) -> vec2<f32> {
+  switch (vid) {
+    case 0u: { return vec2<f32>(0.0, 0.0); }
+    case 1u: { return vec2<f32>(1.0, 0.0); }
+    case 2u: { return vec2<f32>(0.0, 1.0); }
+    case 3u: { return vec2<f32>(0.0, 1.0); }
+    case 4u: { return vec2<f32>(1.0, 0.0); }
+    default: { return vec2<f32>(1.0, 1.0); }
+  }
+}
 
-  // Gap detection: NaN != NaN (same contract as line.wgsl).
-  if (p.x != p.x || p.y != p.y) {
+@vertex
+fn vsMain(
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32,
+) -> VSOut {
+  var out: VSOut;
+  let pA = points[instanceIndex];
+  let pB = points[instanceIndex + 1u];
+
+  // Dual-endpoint gap detection (same contract as line.wgsl).
+  // Null entries are packed as NaN by the CPU. WGSL has no isnan(); use NaN != NaN.
+  // Collapsing only one vertex of a continuous strip fans finite neighbors through
+  // clip origin — per-segment instances fully discard when either endpoint is NaN.
+  if (pA.x != pA.x || pA.y != pA.y || pB.x != pB.x || pB.y != pB.y) {
     out.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
     return out;
   }
 
-  let y = select(p.y, vsUniforms.baseline, useBaseline);
+  let uv = segmentUv(vertexIndex);
+  let p = select(pA, pB, uv.x > 0.5);
+  let y = select(p.y, vsUniforms.baseline, uv.y > 0.5);
   let pos = vec2<f32>(p.x, y);
   out.clipPosition = vsUniforms.transform * vec4<f32>(pos, 0.0, 1.0);
   return out;


### PR DESCRIPTION
## Summary

- Fixes area (and line+`areaStyle`) fill incorrectly fanning through clip origin when `null` entries mark gaps with `connectNulls: false`.
- Root cause: continuous `triangle-strip` + single-vertex NaN collapse does not restart a strip; neighbors still formed non-zero triangles with gap verts.
- Solution: instanced per-segment trapezoids (`triangle-list`, `draw(6, N-1)`) with dual-endpoint NaN discard matching `line.wgsl`. Storage layout (`array<vec2>`) and shared DataStore / line+areaStyle paths unchanged.

Closes #153

## Test plan

- [x] `bun run test -- src/renderers/__tests__/areaRendererGeometryCache.test.ts` (19 tests)
- [ ] Visual: `bun run build:examples && bun run preview:examples` → `http://localhost:4173/exchange-gaps/` with `connectNulls: false` — fill breaks at gaps, no origin fans
- [ ] Toggle `connectNulls: true` — fill bridges continuously
- [ ] Optional: #153 repro green area with nulls vs red height-to-baseline workaround