### PR TITLE
fix: preserve line null gaps under zoom; stack legend above axis labels

### DIFF
--- a/src/components/__tests__/createLegend.test.ts
+++ b/src/components/__tests__/createLegend.test.ts
@@ -62,6 +62,15 @@ describe('createLegend identity skip', () => {
     legend.dispose();
   });
 
+  it('sets z-index above axis text overlay so legend masks labels (issue #149)', () => {
+    const legend = createLegend(container);
+    legend.update(lineSeries(2), theme);
+    // createTextOverlay uses z-index 10; legend must paint above it.
+    expect(Number(getRoot(container).style.zIndex)).toBeGreaterThan(10);
+    expect(getRoot(container).style.zIndex).toBe('15');
+    legend.dispose();
+  });
+
   it('skips replaceChildren when series + theme identity are stable (axes-only)', () => {
     const legend = createLegend(container);
     const series = lineSeries(50);

--- a/src/components/__tests__/createTooltip.test.ts
+++ b/src/components/__tests__/createTooltip.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+/**
+ * Tooltip stacking vs legend / axis text overlay (issue #149).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTooltip } from '../createTooltip';
+
+describe('createTooltip z-index stacking', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it('defaults z-index above legend (15) and axis text overlay (10)', () => {
+    const tooltip = createTooltip(container);
+    const root = container.firstElementChild as HTMLElement;
+    // Inline style retains the CSS var expression with fallback 20.
+    expect(root.style.zIndex).toBe('var(--chartgpu-tooltip-z, 20)');
+    const fallbackMatch = root.style.zIndex.match(/,\s*(\d+)\s*\)/);
+    expect(fallbackMatch).not.toBeNull();
+    const fallback = Number(fallbackMatch![1]);
+    expect(fallback).toBe(20);
+    expect(fallback).toBeGreaterThan(15); // legend
+    expect(fallback).toBeGreaterThan(10); // createTextOverlay
+    tooltip.dispose();
+  });
+});

--- a/src/components/createLegend.ts
+++ b/src/components/createLegend.ts
@@ -60,6 +60,8 @@ export function createLegend(
   root.style.pointerEvents = 'auto';
   root.style.userSelect = 'none';
   root.style.boxSizing = 'border-box';
+  // Above axis label canvas (createTextOverlay z-index 10) so legend masks labels.
+  root.style.zIndex = '15';
 
   // Theme-driven styling (set/update in update()).
   root.style.padding = '8px';

--- a/src/components/createTooltip.ts
+++ b/src/components/createTooltip.ts
@@ -34,7 +34,8 @@ export function createTooltip(container: HTMLElement): Tooltip {
   root.style.boxSizing = 'border-box';
 
   // Theme-friendly default visuals with CSS variable override points.
-  root.style.zIndex = 'var(--chartgpu-tooltip-z, 10)';
+  // Default above legend (15) and axis text overlay (10) so hover always wins.
+  root.style.zIndex = 'var(--chartgpu-tooltip-z, 20)';
   root.style.padding = 'var(--chartgpu-tooltip-padding, 6px 8px)';
   root.style.borderRadius = 'var(--chartgpu-tooltip-radius, 8px)';
   root.style.borderStyle = 'solid';

--- a/src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts
@@ -250,6 +250,49 @@ describe('computeVisibleSlice', () => {
       ]);
     });
 
+    it('preserves null gap markers between in-range points (issue #150)', () => {
+      // Repro: null at index 5; zoom window that spans both sides of the gap.
+      const data: Array<DataPoint | null> = [];
+      for (let i = 0; i < 10; i++) data.push([i, i % 2 ? 1.1 : 1.2]);
+      data[5] = null;
+
+      const result = sliceVisibleRangeByX(data as any, 2, 8) as Array<DataPoint | null>;
+      expect(result).toEqual([[2, 1.2], [3, 1.1], [4, 1.2], null, [6, 1.2], [7, 1.1], [8, 1.2]]);
+    });
+
+    it('preserves multiple interior null gaps in one zoom window', () => {
+      const data: Array<DataPoint | null> = [[0, 0], [1, 1], null, [3, 3], null, [5, 5], [6, 6]];
+      expect(sliceVisibleRangeByX(data as any, 1, 5)).toEqual([[1, 1], null, [3, 3], null, [5, 5]]);
+    });
+
+    it('keeps interior nulls but drops mid-span out-of-range finite points (non-monotonic)', () => {
+      // first kept idx=0 ([0,0]), last kept idx=5 ([2,3]); [100,1] is finite but out of range.
+      const data: Array<DataPoint | null> = [[0, 0], null, [100, 1], null, [1, 2], [2, 3]];
+      expect(sliceVisibleRangeByX(data as any, 0, 2)).toEqual([[0, 0], null, null, [1, 2], [2, 3]]);
+    });
+
+    it('preserves null gaps with object-form DataPoints', () => {
+      const data: Array<DataPoint | null> = [{ x: 0, y: 0 }, { x: 1, y: 1 }, null, { x: 3, y: 3 }, { x: 4, y: 4 }];
+      // Linear path materializes finite points as tuples; nulls stay null.
+      expect(sliceVisibleRangeByX(data as any, 1, 4)).toEqual([[1, 1], null, [3, 3], [4, 4]]);
+    });
+
+    it('drops leading/trailing nulls outside the kept finite span', () => {
+      const data: Array<DataPoint | null> = [null, [1, 10], [2, 20], null, [4, 40], null];
+      // Zoom only left segment — no interior null between first and last kept.
+      expect(sliceVisibleRangeByX(data as any, 1, 2)).toEqual([
+        [1, 10],
+        [2, 20],
+      ]);
+      // Zoom spanning the interior gap keeps the null between segments.
+      expect(sliceVisibleRangeByX(data as any, 1, 4)).toEqual([[1, 10], [2, 20], null, [4, 40]]);
+    });
+
+    it('returns empty when only nulls fall in range', () => {
+      const data: Array<DataPoint | null> = [[0, 0], null, [10, 10]];
+      expect(sliceVisibleRangeByX(data as any, 3, 7)).toEqual([]);
+    });
+
     it('handles boundary values correctly (inclusive)', () => {
       const data: DataPoint[] = [
         [1, 10],

--- a/src/core/renderCoordinator/data/__tests__/resolveSeriesDisplayData.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/resolveSeriesDisplayData.test.ts
@@ -56,6 +56,68 @@ describe('resolveCartesianDisplayData', () => {
     const data = resolveCartesianDisplayData({ series, raw, mode: 'setOptionsReuse' });
     expect(data).toBe(raw);
   });
+
+  it.each(['lttb', 'min', 'max', 'average'] as const)(
+    'keeps raw (skips %s sampling) when null gap markers are present — baseline (issue #150)',
+    (sampling) => {
+      // Above samplingThreshold so sampleSeries would otherwise strip nulls.
+      const rawWithGaps: Array<[number, number] | null> = Array.from({ length: 50 }, (_, i) =>
+        i === 25 ? null : ([i, i] as [number, number])
+      );
+      const series = {
+        type: 'line',
+        sampling,
+        samplingThreshold: 10,
+      } as ResolvedSeriesConfig;
+      const data = resolveCartesianDisplayData({
+        series,
+        raw: rawWithGaps as any,
+        mode: 'baseline',
+      });
+      expect(data).toBe(rawWithGaps);
+      expect((data as readonly unknown[]).includes(null)).toBe(true);
+    }
+  );
+
+  it.each(['lttb', 'min', 'max', 'average'] as const)(
+    'keeps raw (skips %s sampling) when null gaps present on zoomed path (issue #150)',
+    (sampling) => {
+      const rawWithGaps: Array<[number, number] | null> = Array.from({ length: 100 }, (_, i) =>
+        i === 50 ? null : ([i, i % 2 ? 1.1 : 1.2] as [number, number])
+      );
+      const series = {
+        type: 'line',
+        sampling,
+        samplingThreshold: 10,
+      } as ResolvedSeriesConfig;
+      const data = resolveCartesianDisplayData({
+        series,
+        raw: rawWithGaps as any,
+        mode: 'zoomed',
+        sampleTarget: 20,
+      });
+      expect(data).toBe(rawWithGaps);
+      expect((data as readonly unknown[]).includes(null)).toBe(true);
+    }
+  );
+
+  it('area series also bypasses sampling when null gaps are present (issue #150)', () => {
+    const rawWithGaps: Array<[number, number] | null> = Array.from({ length: 40 }, (_, i) =>
+      i === 20 ? null : ([i, i] as [number, number])
+    );
+    const series = {
+      type: 'area',
+      sampling: 'lttb',
+      samplingThreshold: 10,
+    } as ResolvedSeriesConfig;
+    const data = resolveCartesianDisplayData({
+      series,
+      raw: rawWithGaps as any,
+      mode: 'zoomed',
+      sampleTarget: 15,
+    });
+    expect(data).toBe(rawWithGaps);
+  });
 });
 
 describe('resolveCandlestickDisplayData', () => {

--- a/src/core/renderCoordinator/data/__tests__/seriesPipeline.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/seriesPipeline.test.ts
@@ -3,8 +3,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { packToFloat32ArrayAbsolute } from '../../../../data/sampleSeries';
+import { sliceVisibleRangeByX } from '../computeVisibleSlice';
 import { buildRuntimeBaseSeries, buildSetOptionsReuseSeries, resolveZoomedSeriesEntry } from '../seriesPipeline';
 import type { ResolvedSeriesConfig } from '../../../../config/OptionResolver';
+import type { CartesianSeriesData, DataPoint } from '../../../../config/types';
 
 const raw100 = {
   x: Float64Array.from(Array.from({ length: 100 }, (_, i) => i)),
@@ -154,5 +157,57 @@ describe('resolveZoomedSeriesEntry', () => {
     expect(r.series.data).toBeTruthy();
     expect(r.cacheEntry).not.toBeNull();
     expect(r.cacheEntry!.cachedRange).toEqual({ min: 0, max: 99 });
+  });
+
+  it('null-gap line data is not stripped by zoom sample path (issue #150)', () => {
+    const rawWithGaps: Array<[number, number] | null> = Array.from({ length: 100 }, (_, i) =>
+      i === 50 ? null : ([i, i % 2 ? 1.1 : 1.2] as [number, number])
+    );
+    const lineWithGaps = {
+      type: 'line',
+      sampling: 'lttb',
+      samplingThreshold: 10,
+      data: rawWithGaps,
+      rawData: rawWithGaps,
+    } as unknown as ResolvedSeriesConfig;
+
+    const visibleMin = 20;
+    const visibleMax = 80;
+    const r = resolveZoomedSeriesEntry({
+      series: lineWithGaps,
+      rawSlot: rawWithGaps,
+      bufferedMin: 10,
+      bufferedMax: 90,
+      visibleMin,
+      visibleMax,
+      spanFraction: 0.6,
+      sliceX: sliceVisibleRangeByX,
+      sliceOHLC: sliceOHLC as any,
+    });
+
+    const display = r.series.data as ReadonlyArray<DataPoint | null>;
+    expect(Array.isArray(display)).toBe(true);
+    expect(display.includes(null)).toBe(true);
+    // Windowed: every finite point is inside the visible range (not full raw).
+    for (const p of display) {
+      if (p === null) continue;
+      const x = Array.isArray(p) ? p[0] : (p as { x: number }).x;
+      expect(x).toBeGreaterThanOrEqual(visibleMin);
+      expect(x).toBeLessThanOrEqual(visibleMax);
+    }
+    expect(display.some((p) => p !== null && Array.isArray(p) && p[0] === 20)).toBe(true);
+    expect(display.some((p) => p !== null && Array.isArray(p) && p[0] === 80)).toBe(true);
+    // Gap at x=50 sits between neighbors in the display sequence.
+    const nullIdx = display.indexOf(null);
+    expect(nullIdx).toBeGreaterThan(0);
+    expect(nullIdx).toBeLessThan(display.length - 1);
+    expect(r.cacheEntry).not.toBeNull();
+    expect(r.cacheEntry!.cachedRange).toEqual({ min: 10, max: 90 });
+
+    // Layering: pack path turns preserved nulls into NaN gap slots for shader discard
+    // (full packXYInto null→NaN coverage lives in cartesianData.test.ts).
+    const packed = packToFloat32ArrayAbsolute(display as CartesianSeriesData);
+    expect(Number.isNaN(packed[nullIdx * 2])).toBe(true);
+    expect(Number.isNaN(packed[nullIdx * 2 + 1])).toBe(true);
   });
 });

--- a/src/core/renderCoordinator/data/computeVisibleSlice.ts
+++ b/src/core/renderCoordinator/data/computeVisibleSlice.ts
@@ -215,6 +215,7 @@ function isInterleavedXYData(data: CartesianSeriesData): data is InterleavedXYDa
 /**
  * Materialize a chronological [start, end) window via getX/getY.
  * Used for modular ring columns and StagingRingView (no Array.prototype.slice).
+ * Callers never hold null gap markers (rings/staging are columnar floats only).
  */
 function materializeCartesianSlice(data: CoordinatorCartesianData, start: number, end: number): DataPoint[] {
   const out: DataPoint[] = new Array(Math.max(0, end - start));
@@ -331,8 +332,47 @@ export function sliceVisibleRangeByX(data: CartesianSeriesData, xMin: number, xM
     return sliceCartesianData(data, lo, hi);
   }
 
-  // Safe fallback: linear filter (preserves order, ignores non-finite x)
-  // For non-monotonic data, we must return a filtered array
+  // Safe fallback: linear filter (preserves order).
+  // For non-monotonic data, we must return a filtered array.
+  // DataPoint[] may contain `null` gap markers (line segmentation). Those make
+  // X non-finite so the monotonic path never runs — preserve nulls that sit
+  // between the first and last in-range finite points so zoom does not join gaps.
+  // Product stance: only explicit `null` is a supported gap marker (matches
+  // hasNullGaps / connectNulls docs). Sparse `undefined` holes are skipped, not
+  // re-emitted as nulls.
+  if (Array.isArray(data)) {
+    const arr = data as ReadonlyArray<DataPoint | null>;
+    let first = -1;
+    let last = -1;
+    for (let i = 0; i < n; i++) {
+      const p = arr[i];
+      if (p === null || p === undefined) continue;
+      const x = getX(data, i);
+      if (!Number.isFinite(x)) continue;
+      if (x >= xMin && x <= xMax) {
+        if (first < 0) first = i;
+        last = i;
+      }
+    }
+    if (first < 0) return [];
+    const out: Array<DataPoint | null> = [];
+    for (let i = first; i <= last; i++) {
+      const p = arr[i];
+      if (p === null) {
+        out.push(null);
+        continue;
+      }
+      if (p === undefined) continue;
+      const x = getX(data, i);
+      if (!Number.isFinite(x)) continue;
+      if (x >= xMin && x <= xMax) {
+        out.push([x, getY(data, i)]);
+      }
+    }
+    return out;
+  }
+
+  // Non-array formats cannot hold null gap markers.
   const out: DataPoint[] = [];
   for (let i = 0; i < n; i++) {
     const x = getX(data, i);

--- a/src/core/renderCoordinator/data/resolveSeriesDisplayData.ts
+++ b/src/core/renderCoordinator/data/resolveSeriesDisplayData.ts
@@ -10,6 +10,7 @@
 
 import type { ResolvedSeriesConfig } from '../../../config/OptionResolver';
 import type { CartesianSeriesData, OHLCDataPoint } from '../../../config/types';
+import { hasNullGaps } from '../../../data/cartesianData';
 import { isGpuDecimationEligible } from '../../../data/gpuDecimationEligibility';
 import { sampleSeriesDataPoints } from '../../../data/sampleSeries';
 import { ohlcSample } from '../../../data/ohlcSample';
@@ -18,7 +19,7 @@ type DisplayResolveMode = 'baseline' | 'zoomed' | 'setOptionsReuse';
 
 /**
  * Baseline / setOptions: choose series `data` for one cartesian line-like series.
- * GPU-eligible → raw; else sample at samplingThreshold.
+ * GPU-eligible → raw; null-gap data → raw (preserve segmentation); else sample.
  */
 export function resolveCartesianDisplayData(input: {
   readonly series: ResolvedSeriesConfig;
@@ -37,6 +38,12 @@ export function resolveCartesianDisplayData(input: {
   if (mode === 'setOptionsReuse') {
     // Keep OptionResolver-sampled data when present; caller merges rawData/bounds.
     return (series.data as CartesianSeriesData) ?? raw;
+  }
+  // Mirror OptionResolver: bypass sampling when null gap markers are present so
+  // LTTB/min/max do not filter nulls and join line segments (zoom path issue #150).
+  // sampling:'none' already returns data as-is inside sampleSeriesDataPoints.
+  if (series.sampling !== 'none' && hasNullGaps(raw)) {
+    return raw;
   }
   const threshold =
     sampleTarget != null && Number.isFinite(sampleTarget) ? Math.max(2, sampleTarget | 0) : series.samplingThreshold;


### PR DESCRIPTION
## Summary

- **#150**: Keep line segmentation (`null` gaps) when zoomed. Zoom no longer drops null markers in `sliceVisibleRangeByX`, and the zoomed sampling path mirrors OptionResolver’s `hasNullGaps` bypass so LTTB/min/max/average do not strip gaps.
- **#149**: Raise legend z-index above the axis text overlay so labels are masked by the legend box; keep tooltip stacked above the legend.

Closes #150  
Closes #149  

## Stack

1. **This PR** → `main`  
2. **#173** → this branch (candlestick streaming re-upload)

Merge this PR first; #173 stacks on top.

## Test plan

- [x] Unit tests pass for slice, resolve display data, series pipeline, legend, and tooltip z-index
- [ ] Visual: line with mid-series `null` + `dataZoom` slider — gap visible at full span **and** after zoom into a window that includes the gap
- [ ] Visual: many series with right legend — axis tick labels do not paint on top of the legend panel
- [ ] Tooltip still appears above the legend on hover
- [ ] Optional: `connectNulls: true` still bridges gaps under zoom