### PR TITLE
fix: candlestick streaming re-upload after initial render

### DIFF
--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -42,6 +42,7 @@ import {
   patchSeriesPresentationKeepingSampledData,
   didRawBoundsModeChange,
 } from './data/samplingDirty';
+import { syncCandlestickOwnedFromUserSeries } from './data/syncCandlestickRuntime';
 import { processAnnotations } from './annotations/processAnnotations';
 import {
   prepareSeries,
@@ -2244,6 +2245,27 @@ export function createRenderCoordinator(
       // resample — and toYBaseDomains can disagree with fromSnapshot,
       // spuriously starting a domain-change animation on theme-only updates.
       recomputeCachedVisibleYBoundsIfNeeded();
+    }
+
+    // Candlestick streaming: consumer may mutate a stable OHLC array (forming
+    // bar) and call setOption. Presentation-only dirty checks treat same-ref
+    // data as unchanged, while the coordinator keeps a sliced owned copy for
+    // appendData — copy user edits into owned so prepare/geometry see them.
+    {
+      const candleSync = syncCandlestickOwnedFromUserSeries({
+        series: resolvedOptions.series,
+        runtimeRawDataByIndex,
+        runtimeRawBoundsByIndex,
+        extendBounds: extendBoundsWithOHLCDataPoints,
+      });
+      if (candleSync.didReplaceRef) {
+        recomputeRuntimeBaseSeries();
+        recomputeRenderSeries();
+      } else if (candleSync.didMutate) {
+        // Owned array mutated in place (same ref as renderSeries.data). Refresh
+        // y-bounds so auto domain tracks the forming bar high/low.
+        recomputeCachedVisibleYBoundsIfNeeded();
+      }
     }
 
     // Tooltip enablement may change at runtime.

--- a/src/core/renderCoordinator/data/__tests__/syncCandlestickRuntime.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/syncCandlestickRuntime.test.ts
@@ -1,0 +1,121 @@
+/**
+ * syncCandlestickOwnedFromUserSeries — forming-bar / length resync for setOption.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OHLCDataPoint } from '../../../../config/types';
+import { extendBoundsWithOHLCDataPoints } from '../../utils/boundsComputation';
+import { syncCandlestickOwnedFromUserSeries } from '../syncCandlestickRuntime';
+
+const candle = (t: number, o: number, c: number, l: number, h: number): OHLCDataPoint => [t, o, c, l, h];
+
+function seriesWithData(data: OHLCDataPoint[]) {
+  return [{ type: 'candlestick' as const, data, rawData: data }] as any;
+}
+
+describe('syncCandlestickOwnedFromUserSeries', () => {
+  it('no-ops when owned is the same array as user data', () => {
+    const data = [candle(0, 1, 2, 0.5, 2.5)];
+    const runtimeRawDataByIndex: unknown[] = [data];
+    const runtimeRawBoundsByIndex: any[] = [null];
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(data),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+    expect(result.didMutate).toBe(false);
+    expect(runtimeRawDataByIndex[0]).toBe(data);
+  });
+
+  it('copies last candle into owned when consumer mutates forming bar (same length)', () => {
+    const user = [candle(0, 10, 11, 9, 12), candle(1, 11, 11, 11, 11)];
+    const owned = [candle(0, 10, 11, 9, 12), candle(1, 11, 11, 11, 11)];
+    const runtimeRawDataByIndex: unknown[] = [owned];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    // Forming bar: close/high moved on consumer array only.
+    user[1] = candle(1, 11, 16, 10, 17);
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(result.didReplaceRef).toBe(false);
+    expect(runtimeRawDataByIndex[0]).toBe(owned); // same owned ref
+    expect(owned[1]).toEqual(candle(1, 11, 16, 10, 17));
+    expect(owned[0]).toEqual(candle(0, 10, 11, 9, 12));
+  });
+
+  it('appends onto owned when consumer array grew (stable owned ref)', () => {
+    const user = [candle(0, 10, 11, 9, 12), candle(1, 11, 12, 10, 13)];
+    const owned = [candle(0, 10, 11, 9, 12)];
+    const runtimeRawDataByIndex: unknown[] = [owned];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(runtimeRawDataByIndex[0]).toBe(owned);
+    expect(owned).toHaveLength(2);
+    expect(owned[1]).toEqual(candle(1, 11, 12, 10, 13));
+  });
+
+  it('truncates owned when consumer array shrank', () => {
+    const user = [candle(0, 10, 11, 9, 12)];
+    const owned = [candle(0, 10, 11, 9, 12), candle(1, 11, 12, 10, 13)];
+    const runtimeRawDataByIndex: unknown[] = [owned];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(owned).toHaveLength(1);
+    expect(owned[0]).toEqual(candle(0, 10, 11, 9, 12));
+  });
+
+  it('seeds owned with a slice when slot is empty', () => {
+    const user = [candle(0, 1, 2, 0.5, 2.5)];
+    const runtimeRawDataByIndex: unknown[] = [null];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(result.didReplaceRef).toBe(true);
+    expect(runtimeRawDataByIndex[0]).not.toBe(user);
+    expect(runtimeRawDataByIndex[0]).toEqual(user);
+  });
+
+  it('skips non-candlestick series', () => {
+    const runtimeRawDataByIndex: unknown[] = [null];
+    const runtimeRawBoundsByIndex: any[] = [null];
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: [{ type: 'line', data: [[0, 1]] }] as any,
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+    expect(result.didMutate).toBe(false);
+    expect(runtimeRawDataByIndex[0]).toBeNull();
+  });
+});

--- a/src/core/renderCoordinator/data/syncCandlestickRuntime.ts
+++ b/src/core/renderCoordinator/data/syncCandlestickRuntime.ts
@@ -1,0 +1,140 @@
+/**
+ * Resync coordinator-owned OHLC from consumer series data on setOption.
+ *
+ * Streaming examples (e.g. candlestick-streaming) keep a stable OHLC array,
+ * mutate the forming bar in place, and call setOption. The coordinator stores a
+ * **sliced owned copy** for appendData, so presentation-only setOption (same
+ * data ref → didSeriesDataLikelyChange false) would never update what the
+ * candlestick renderer packs unless we copy user edits into the owned store.
+ *
+ * Prefers in-place mutation of the owned array so geometry identity can keep
+ * the same data ref while length / last-candle fingerprints force re-upload.
+ *
+ * @module syncCandlestickRuntime
+ * @internal
+ */
+
+import type { ResolvedSeriesConfig } from '../../../config/OptionResolver';
+import type { OHLCDataPoint } from '../../../config/types';
+import { isTupleOHLCDataPoint } from '../utils/dataPointUtils';
+
+export type OhlcBounds = Readonly<{
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}>;
+
+export type SyncCandlestickRuntimeResult = {
+  /** True when any owned OHLC slot was written. */
+  readonly didMutate: boolean;
+  /** True when an owned array was replaced (new ref) — caller should recompute baseline. */
+  readonly didReplaceRef: boolean;
+  /** Series indices that were mutated. */
+  readonly indices: readonly number[];
+};
+
+const ohlcEqual = (a: OHLCDataPoint, b: OHLCDataPoint): boolean => {
+  if (a === b) return true;
+  if (isTupleOHLCDataPoint(a) && isTupleOHLCDataPoint(b)) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3] && a[4] === b[4];
+  }
+  if (!isTupleOHLCDataPoint(a) && !isTupleOHLCDataPoint(b)) {
+    return (
+      a.timestamp === b.timestamp && a.open === b.open && a.close === b.close && a.low === b.low && a.high === b.high
+    );
+  }
+  // Mixed shapes: normalize via tuple fields.
+  const at = isTupleOHLCDataPoint(a) ? a : ([a.timestamp, a.open, a.close, a.low, a.high] as const);
+  const bt = isTupleOHLCDataPoint(b) ? b : ([b.timestamp, b.open, b.close, b.low, b.high] as const);
+  return at[0] === bt[0] && at[1] === bt[1] && at[2] === bt[2] && at[3] === bt[3] && at[4] === bt[4];
+};
+
+/**
+ * Copy consumer candlestick OHLC into coordinator-owned runtime slots.
+ *
+ * @param extendBounds - Bounds helper (injected for testability)
+ */
+export function syncCandlestickOwnedFromUserSeries(input: {
+  readonly series: ReadonlyArray<ResolvedSeriesConfig>;
+  readonly runtimeRawDataByIndex: unknown[];
+  readonly runtimeRawBoundsByIndex: Array<OhlcBounds | null>;
+  readonly extendBounds: (bounds: OhlcBounds | null, points: ReadonlyArray<OHLCDataPoint>) => OhlcBounds | null;
+}): SyncCandlestickRuntimeResult {
+  const { series, runtimeRawDataByIndex, runtimeRawBoundsByIndex, extendBounds } = input;
+  const indices: number[] = [];
+  let didMutate = false;
+  let didReplaceRef = false;
+
+  for (let i = 0; i < series.length; i++) {
+    const s = series[i]!;
+    if (s.type !== 'candlestick') continue;
+
+    const user = ((s as { rawData?: unknown; data?: unknown }).rawData ?? (s as { data?: unknown }).data) as
+      | ReadonlyArray<OHLCDataPoint>
+      | null
+      | undefined;
+    if (user == null || !Array.isArray(user)) continue;
+
+    const existing = runtimeRawDataByIndex[i];
+
+    // Same array identity as the consumer: already shared; mutations are visible.
+    if (existing === user) {
+      continue;
+    }
+
+    // No owned slot yet — take a copy (matches initRuntimeSeriesFromOptions).
+    if (existing == null || !Array.isArray(existing)) {
+      runtimeRawDataByIndex[i] = user.slice();
+      runtimeRawBoundsByIndex[i] = extendBounds(null, user);
+      didMutate = true;
+      didReplaceRef = true;
+      indices.push(i);
+      continue;
+    }
+
+    const owned = existing as OHLCDataPoint[];
+
+    if (owned.length !== user.length) {
+      // Length mismatch: rewrite owned contents in place when possible to keep
+      // the array ref stable for geometry identity (length fingerprint re-packs).
+      if (user.length > owned.length) {
+        for (let j = 0; j < owned.length; j++) {
+          if (!ohlcEqual(owned[j]!, user[j]!)) {
+            owned[j] = user[j]!;
+          }
+        }
+        for (let j = owned.length; j < user.length; j++) {
+          owned.push(user[j]!);
+        }
+      } else {
+        // Truncate then copy.
+        owned.length = user.length;
+        for (let j = 0; j < user.length; j++) {
+          owned[j] = user[j]!;
+        }
+      }
+      runtimeRawBoundsByIndex[i] = extendBounds(null, owned);
+      didMutate = true;
+      indices.push(i);
+      continue;
+    }
+
+    // Same length, different refs (owned slice vs consumer array): streaming
+    // forming-bar path mutates only the last candle under a stable consumer ref.
+    // O(1) last-candle sync; mid-series in-place edits should pass a new array ref.
+    if (user.length === 0) continue;
+
+    const lastIdx = user.length - 1;
+    const userLast = user[lastIdx]!;
+    const ownedLast = owned[lastIdx]!;
+    if (!ohlcEqual(ownedLast, userLast)) {
+      owned[lastIdx] = userLast;
+      runtimeRawBoundsByIndex[i] = extendBounds(runtimeRawBoundsByIndex[i], [userLast]);
+      didMutate = true;
+      indices.push(i);
+    }
+  }
+
+  return { didMutate, didReplaceRef, indices };
+}

--- a/src/renderers/__tests__/candlestickGeometryCache.test.ts
+++ b/src/renderers/__tests__/candlestickGeometryCache.test.ts
@@ -154,6 +154,54 @@ describe('candlestick geometry cache (issue 1.3)', () => {
     renderer.dispose();
   });
 
+  it('re-uploads when same data ref grows in length (streaming append)', () => {
+    // appendData mutates the coordinator-owned OHLC array in place; identity skip
+    // must miss when length changes or new candles never reach the GPU buffer.
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createCandlestickRenderer(device, { sampleCount: 1 });
+    const ga = gridArea();
+    const x = createLinearScale().domain(0, 5).range(-1, 1);
+    const y = createLinearScale().domain(0, 20).range(-1, 1);
+
+    const growing = [
+      [0, 10, 12, 9, 13],
+      [1, 12, 11, 10, 14],
+    ] as Array<[number, number, number, number, number]>;
+
+    renderer.prepare(candleSeries(growing as never), growing as never, x, y, ga);
+    writeBuffer.mockClear();
+
+    growing.push([2, 11, 15, 10, 16]);
+    renderer.prepare(candleSeries(growing as never), growing as never, x, y, ga);
+    expect(writeBuffer.mock.calls.length).toBeGreaterThan(0);
+    renderer.dispose();
+  });
+
+  it('re-uploads when last candle mutates under same data ref (forming candle)', () => {
+    // Streaming examples update the open candle via setOption with a stable array
+    // and an in-place last-element replace — must not hit axes-only identity skip.
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createCandlestickRenderer(device, { sampleCount: 1 });
+    const ga = gridArea();
+    const x = createLinearScale().domain(0, 2).range(-1, 1);
+    const y = createLinearScale().domain(0, 20).range(-1, 1);
+
+    const forming = [
+      [0, 10, 12, 9, 13],
+      [1, 12, 11, 10, 14],
+    ] as Array<[number, number, number, number, number]>;
+
+    renderer.prepare(candleSeries(forming as never), forming as never, x, y, ga);
+    writeBuffer.mockClear();
+
+    forming[1] = [1, 12, 16, 10, 17]; // close/high moved
+    renderer.prepare(candleSeries(forming as never), forming as never, x, y, ga);
+    expect(writeBuffer.mock.calls.length).toBeGreaterThan(0);
+    renderer.dispose();
+  });
+
   it('re-uploads after invalidateGeometry with same data ref', () => {
     const device = createMockDevice();
     const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;

--- a/src/renderers/createCandlestickRenderer.ts
+++ b/src/renderers/createCandlestickRenderer.ts
@@ -222,6 +222,22 @@ const nearEqual = (a: number, b: number): boolean => Math.abs(a - b) <= 1e-9 * M
 type CandleGeometryCache = {
   readonly data: ResolvedCandlestickSeriesConfig['data'];
   /**
+   * Source array length. Streaming `appendData` mutates the coordinator-owned
+   * OHLC array in place (stable ref + growing length). Identity skip must miss
+   * when length changes or new candles never reach the instance buffer.
+   */
+  readonly dataLength: number;
+  /**
+   * Last candle OHLC fingerprint for equal-N in-place updates (forming candle
+   * via setOption on a stable data array). Axes-only prepares keep the same
+   * values so the skip still hits.
+   */
+  readonly lastTimestamp: number;
+  readonly lastOpen: number;
+  readonly lastClose: number;
+  readonly lastLow: number;
+  readonly lastHigh: number;
+  /**
    * Absolute domain origin subtracted from each instance `x` before Float32
    * upload. Large time-axis timestamps (ms epoch) lose spacing as f32; packing
    * relative to this origin keeps candle x separable. VS transform bakes it
@@ -239,6 +255,28 @@ type CandleGeometryCache = {
   readonly backgroundColor: string | undefined;
   readonly instanceCount: number;
   readonly hollowInstanceCount: number;
+};
+
+/** Last candle OHLC for geometry-cache content fingerprint (or NaNs when empty). */
+const lastCandleFingerprint = (
+  data: ResolvedCandlestickSeriesConfig['data']
+): {
+  readonly timestamp: number;
+  readonly open: number;
+  readonly close: number;
+  readonly low: number;
+  readonly high: number;
+} => {
+  if (data.length === 0) {
+    return {
+      timestamp: Number.NaN,
+      open: Number.NaN,
+      close: Number.NaN,
+      low: Number.NaN,
+      high: Number.NaN,
+    };
+  }
+  return getOHLC(data[data.length - 1]!);
 };
 
 /** First finite OHLC timestamp — packing origin for f32 domain x. */
@@ -442,12 +480,21 @@ export function createCandlestickRenderer(
     const upBorderKey = series.itemStyle.upBorderColor;
     const downBorderKey = series.itemStyle.downBorderColor;
 
-    // Geometry identity skip: same data + domain layout → no instance rewrite.
-    // Policy verb shared via seriesResidency (issue 3.4).
+    // Geometry identity skip: same data ref + domain layout → no instance rewrite.
+    // Also require stable length and last-candle OHLC so streaming append
+    // (in-place push) and forming-candle setOption (mutate last bar) re-upload.
+    // Policy verb shared via seriesResidency (issue 3.4 / 1.3).
+    const lastFp = lastCandleFingerprint(data);
     const geometryHit =
       geometryCache != null &&
       instanceBuffer != null &&
       geometryCache.data === data &&
+      geometryCache.dataLength === data.length &&
+      nearEqual(geometryCache.lastTimestamp, lastFp.timestamp) &&
+      nearEqual(geometryCache.lastOpen, lastFp.open) &&
+      nearEqual(geometryCache.lastClose, lastFp.close) &&
+      nearEqual(geometryCache.lastLow, lastFp.low) &&
+      nearEqual(geometryCache.lastHigh, lastFp.high) &&
       nearEqual(geometryCache.packingOrigin, packingOrigin) &&
       nearEqual(geometryCache.categoryStep, categoryStep) &&
       nearEqual(geometryCache.bodyWidthDomain, bodyWidthDomain) &&
@@ -626,6 +673,12 @@ export function createCandlestickRenderer(
 
     geometryCache = {
       data,
+      dataLength: data.length,
+      lastTimestamp: lastFp.timestamp,
+      lastOpen: lastFp.open,
+      lastClose: lastFp.close,
+      lastLow: lastFp.low,
+      lastHigh: lastFp.high,
       packingOrigin,
       categoryStep,
       bodyWidthDomain,


### PR DESCRIPTION
## Summary

Fixes candlestick **streaming** so candles keep drawing after the initial historical pack (empty right / frozen live edge under auto-scroll).

1. **Geometry identity skip** — re-upload when owned OHLC length grows (`appendData`) or the last candle mutates (forming bar fingerprint).
2. **Owned vs consumer array sync** — on `setOption`, copy forming-bar edits from the consumer’s stable OHLC array into the coordinator’s owned slice so prepare sees live values after append switches display data to owned.

## Stack

Depends on **#172** (base branch: `fix/150-149-null-gap-zoom-legend-zindex`).

That PR also addresses:

- **#150** — line segmentation (`null` gaps) preserved under zoom  
- **#149** — legend stacks above axis labels (masks labels)

Merge order: **#172 first**, then this PR (or merge this into #172’s branch then #172 into `main`).

Related issues from the base of the stack: #150, #149.

## Test plan

- [x] Unit tests: candlestick geometry cache, `syncCandlestickOwnedFromUserSeries`
- [ ] Visual: `examples/candlestick-streaming` — historical candles, then new 1s candles at the right edge while streaming
- [ ] Visual: forming bar OHLC moves with ticks (not frozen after open)
- [ ] Auto-scroll keeps the live edge near the right (no growing empty void)
- [ ] Hard reload after pulling this stack so geometry + sync modules load