### PR TITLE
feat: logarithmic axes (#135) and streaming candlestick re-upload

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -109,15 +109,30 @@ Notes (density mode):
 ## Axis Configuration
 
 - **`AxisConfig`**: configuration for `xAxis` / `yAxes`. See [`types.ts`](../../src/config/types.ts).
+- **`AxisType`**: `'value' | 'time' | 'category' | 'log'`.
+- **Logarithmic axes (`type: 'log'`)**:
+  - Available on **`xAxis`** and each **`yAxis` / `yAxes[]`** independently.
+  - **`logBase?: number`**: logarithm base (default **10**). Must be finite, > 0, and ≠ 1; invalid values fall back to 10 with a dev warning.
+  - **Projection**: data stays in linear storage (DataStore / GPU buffers). Log is applied in series vertex shaders before the clip affine — toggling log does not force a full re-upload.
+  - **Ticks / grid**: major ticks at integer powers of the base (e.g. \(10^{-2}, 10^{0}, 10^{3}\)) for the **visible** domain (updates on zoom/pan; not locked to full explicit `min`/`max`). When the window has few majors, intermediate ticks densify (e.g. 2×/5× within a decade). GPU grid lines for log axes are co-located with those ticks (not even data-space splits). Labels use a scientific/`1eN` hybrid by default; custom **`tickFormatter`** still receives **data-space** values (e.g. `1000`, not `3`).
+  - **Domain must be strictly positive**: auto-bounds ignore ≤0 samples; if no positive data exists the domain falls back to `[1, 10]` with a warning. Explicit `min`/`max` ≤ 0 are clamped using the smallest positive data value `pd`: prefer `pd × 0.5`, then **floor to a power of `logBase`** (`base ** floor(log_b(pd × 0.5))`), with a dev warning. Example (base 10): `pd = 9` → half `4.5` → floored power `1`.
+  - **Non-positive points**: treated as **gaps** on line/area (NaN packing path / VS discard) and **omitted** on scatter under log projection.
+  - **Area / bar baseline**: classic “fill to zero” is unsupported on log; baseline uses the positive axis min (or first major ≤ data min). Document that fill-to-zero is not available on log Y.
+  - **Sticky headroom** on log axes is applied in **log space** (decade headroom).
+  - **Zoom** `start`/`end` percents remain percent of **data-space** base domain (not log-percent).
+  - **No library UI log toggle** — config only (`setOption({ yAxis: { type: 'log' } })`). Examples may include demo chrome.
+  - Showcase: [`examples/log-axis-y/`](../../examples/log-axis-y/), [`log-axis-x/`](../../examples/log-axis-x/), [`log-axis-scatter/`](../../examples/log-axis-scatter/), [`log-axis-multi/`](../../examples/log-axis-multi/), [`log-axis-compare/`](../../examples/log-axis-compare/).
 - **Multiple Y-Axes**:
   - Instead of a single `yAxis` object, ChartGPU supports an array of `yAxes` objects for independent scales (e.g. Price vs Volume).
   - Each `yAxis` in the `yAxes` array must specify an `id: string` (default is `"primary"` for the first axis).
-  - Series map to a specific axis via `yAxisIndex` in their config.
+  - Series map to a specific axis via `yAxis` id in their config.
   - Axes can be positioned on the right using `position: "right"` (default is `"left"`).
+  - Dual Y may mix log + linear (e.g. log pressure + linear temperature). Horizontal grid follows the **primary** (first) Y axis ticks when that axis is log.
 - **Explicit domains (override auto-bounds)**:
   - **`AxisConfig.min?: number` / `AxisConfig.max?: number`**: when set, ChartGPU uses these explicit axis bounds and does **not** auto-derive bounds from data for that axis.
   - **Precedence**: explicit `min`/`max` always override any auto-bounds behavior.
   - **One-sided explicit**: if only `min` or only `max` is set, the other end is still data-derived; sticky auto-domain headroom (below) is **disabled** whenever either end is explicit so growBy padding never extends past a locked edge.
+  - **Log**: both ends must resolve to strictly positive values (see log policy above).
 - **Sticky auto-domain headroom (streaming / multi-chart)**:
   - When **both** ends of an axis are auto (no explicit `min`/`max`), ChartGPU uses a sticky domain: **first establish matches the data extrema exactly** (static column/mountain charts fill the plot).
   - **Y**: ~**10% growBy headroom** is added only when data **breaches** that domain (amortizes overlay rebuild under amplitude noise).
@@ -133,8 +148,9 @@ Notes (density mode):
 - **`AxisConfig.tickFormatter?: (value: number) => string | null`**: custom formatter for axis tick labels. When provided, replaces the built-in tick label formatting for that axis.
   - For `type: 'value'` axes, `value` is the numeric tick value.
   - For `type: 'time'` axes, `value` is a timestamp in milliseconds (epoch-ms, same unit as `new Date(ms)`).
+  - For `type: 'log'` axes, `value` is the **data-space** tick value (e.g. `1000` for \(10^3\)), not the log exponent.
   - Return a `string` to display as the label, or `null` to suppress that specific tick label.
-  - When omitted, ChartGPU uses its built-in formatting: `Intl.NumberFormat` for value axes, adaptive tier-based date formatting for time axes.
+  - When omitted, ChartGPU uses its built-in formatting: `Intl.NumberFormat` for value axes, adaptive tier-based date formatting for time axes, and scientific/`1eN` hybrid labels for log axes.
   - The formatter is also used for label width measurement in the adaptive time x-axis tick count algorithm, ensuring overlap avoidance uses the correct label widths.
 
 #### Tick Formatter Examples

--- a/docs/api/scales.md
+++ b/docs/api/scales.md
@@ -2,9 +2,20 @@
 
 ChartGPU exports a small set of pure utilities for mapping numeric and categorical domains to numeric ranges. See [`scales.ts`](../../src/utils/scales.ts).
 
-## `createLinearScale(): LinearScale`
+## `ContinuousScale`
 
-Creates a linear scale with an initial identity mapping (domain `[0, 1]` -> range `[0, 1]`).
+Shared interface for linear and logarithmic continuous scales:
+
+- **`kind: 'linear' | 'log'`** — discriminator for GPU projection
+- **`base?: number`** — present when `kind === 'log'`
+- **`domain` / `range` / `scale` / `invert`** — chainable mapping
+- **`getDomain()` / `getRange()`** — current endpoints
+
+`LinearScale` is a type alias of `ContinuousScale` (backward compatible).
+
+## `createLinearScale(): ContinuousScale`
+
+Creates a linear scale with an initial identity mapping (domain `[0, 1]` -> range `[0, 1]`). Instances have `kind: 'linear'`.
 
 **Behavior notes (essential):**
 
@@ -12,9 +23,25 @@ Creates a linear scale with an initial identity mapping (domain `[0, 1]` -> rang
 - **`scale(value)`**: maps domain -> range with no clamping (values outside the domain extrapolate). If the domain span is zero (`min === max`), returns the midpoint of the range.
 - **`invert(pixel)`**: maps range -> domain with no clamping (pixels outside the range extrapolate). If the domain span is zero (`min === max`), returns `min` for any input.
 
+## `createLogScale(base?: number): ContinuousScale`
+
+Creates a logarithmic continuous scale (`kind: 'log'`). Default base is **10**. Invalid bases (non-finite, ≤0, or 1) fall back to 10.
+
+**Behavior notes (essential):**
+
+- Mapping is linear in \(\log_b(value)\): equal decades occupy equal pixel spans.
+- **`scale(value)`** returns `NaN` for non-positive inputs (log is undefined).
+- **`domain(min, max)`** requires strictly positive endpoints; non-positive values are clamped to a safe positive fallback.
+- **GPU path**: ChartGPU keeps DataStore buffers in **data space** and applies `log` in the vertex shader before the clip affine. Toggling `type: 'log'` does not re-upload series buffers.
+- Exported helpers: `generateLogTicks`, `generateLogTicksForVisibleDomain` (zoom-aware densified ticks), `formatLogTickValue` (via package entry).
+
+## `createAxisScale(axis): ContinuousScale`
+
+Factory used by the render coordinator: returns `createLogScale(axis.logBase)` when `axis.type === 'log'`, otherwise `createLinearScale()`.
+
 ## `LinearScale`
 
-Type definition for the scale returned by `createLinearScale()`. See [`scales.ts`](../../src/utils/scales.ts).
+Type alias of `ContinuousScale` for backward compatibility. See [`scales.ts`](../../src/utils/scales.ts).
 
 ## `createCategoryScale(): CategoryScale`
 

--- a/examples/acceptance/log-axis-scale.ts
+++ b/examples/acceptance/log-axis-scale.ts
@@ -1,0 +1,115 @@
+/**
+ * Acceptance: logarithmic axis scale + ticks + option resolution (no WebGPU).
+ * Run: tsx examples/acceptance/log-axis-scale.ts
+ *
+ * Imports pure TS modules only (avoid package entry / WGSL raw imports).
+ */
+import {
+  createLogScale,
+  createAxisScale,
+  createLinearScale,
+  normalizeLogBase,
+} from '../../src/utils/scales';
+import { resolveOptions } from '../../src/config/OptionResolver';
+import { sanitizeLogDomain } from '../../src/core/renderCoordinator/utils/boundsComputation';
+import {
+  generateLogTicks,
+  generateLogTicksForVisibleDomain,
+  formatLogTickValue,
+} from '../../src/core/renderCoordinator/axis/computeAxisTicks';
+import {
+  computeClipAffineFromContinuousScale,
+  computeClipAffineFromScale,
+} from '../../src/renderers/packedXAffine';
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+// --- createLogScale round-trip ---
+{
+  const s = createLogScale(10).domain(0.01, 1000).range(0, 500);
+  for (const v of [0.01, 1, 10, 1000]) {
+    const p = s.scale(v);
+    const back = s.invert(p);
+    assert(Math.abs(back / v - 1) < 1e-10, `round-trip failed for ${v}: got ${back}`);
+  }
+  assert(s.kind === 'log', 'kind should be log');
+  assert(s.base === 10, 'base should be 10');
+}
+
+// --- generateLogTicks boundaries ---
+{
+  const ticks = generateLogTicks(0.01, 1000, 10);
+  const expected = [0.01, 0.1, 1, 10, 100, 1000];
+  assert(ticks.length === expected.length, `tick count ${ticks.length} != ${expected.length}`);
+  for (let i = 0; i < expected.length; i++) {
+    assert(Math.abs(ticks[i]! - expected[i]!) < 1e-12, `tick[${i}] ${ticks[i]} != ${expected[i]}`);
+  }
+}
+
+// --- generateLogTicksForVisibleDomain densifies zoomed sub-range ---
+{
+  const ticks = generateLogTicksForVisibleDomain(2e3, 8e3, 10);
+  assert(ticks.length >= 3, `zoomed log ticks should densify, got ${ticks.length}`);
+  assert(!ticks.includes(1e3) && !ticks.includes(1e4), 'must not emit out-of-window decade powers');
+  assert(
+    ticks.every((t) => t >= 2e3 * (1 - 1e-12) && t <= 8e3 * (1 + 1e-12)),
+    'all ticks must lie in visible domain'
+  );
+  assert(ticks.includes(2e3) && ticks.includes(5e3), 'expected 2e3 and 5e3 mantissas');
+}
+
+{
+  const ticks = generateLogTicksForVisibleDomain(500, 2e4, 10);
+  assert(ticks.includes(1e3) && ticks.includes(1e4), 'majors inside window must remain');
+}
+
+// --- OptionResolver type: log + default base ---
+{
+  const r = resolveOptions({
+    yAxis: { type: 'log', name: 'Pressure' },
+    series: [{ type: 'line', data: [[1, 1], [2, 10]] }],
+  });
+  assert(r.yAxes[0]!.type === 'log', 'resolved yAxis type should be log');
+  assert(r.yAxes[0]!.logBase === 10, `default logBase should be 10, got ${r.yAxes[0]!.logBase}`);
+}
+
+{
+  const r = resolveOptions({
+    xAxis: { type: 'log', logBase: 2, min: 1, max: 1024 },
+    series: [{ type: 'line', data: [[1, 0], [2, 1]] }],
+  });
+  assert(r.xAxis.type === 'log', 'xAxis type log');
+  assert(r.xAxis.logBase === 2, 'xAxis logBase 2');
+}
+
+// --- Non-positive domain sanitizer ---
+{
+  const s = sanitizeLogDomain(-1, 0, { base: 10, warn: false });
+  assert(s.min > 0 && s.max > s.min, 'sanitized domain must be positive');
+  assert(s.warned, 'should warn on non-positive');
+}
+
+// --- Affine helper linear parity ---
+{
+  const lin = createLinearScale().domain(-5, 15).range(-1, 1);
+  const a = computeClipAffineFromContinuousScale(lin);
+  const b = computeClipAffineFromScale(lin, 0, 1);
+  assert(Math.abs(a.a - b.a) < 1e-12 && Math.abs(a.b - b.b) < 1e-12, 'linear affine parity');
+}
+
+// --- createAxisScale ---
+{
+  assert(createAxisScale({ type: 'log' }).kind === 'log', 'axis factory log');
+  assert(createAxisScale({ type: 'value' }).kind === 'linear', 'axis factory linear');
+  assert(normalizeLogBase(1) === 10, 'invalid base falls back');
+}
+
+// --- formatLogTickValue ---
+{
+  assert(formatLogTickValue(1000, 10) === '1e3', 'format 1e3');
+  assert(formatLogTickValue(1, 10) === '1', 'format 1');
+}
+
+console.log('log-axis-scale acceptance: OK');

--- a/examples/index.html
+++ b/examples/index.html
@@ -256,6 +256,36 @@
           <div class="example-description">Crypto price data with exchange maintenance windows &mdash; null gap entries, connectNulls toggle, multi-asset independent outages, and trading session concatenation</div>
         </a>
       </li>
+      <li class="example-item">
+        <a href="./log-axis-y/index.html" class="example-link">
+          <div class="example-title">Log Y axis</div>
+          <div class="example-description">Multi-decade line series with native logarithmic Y, major log ticks, and log-aligned grid</div>
+        </a>
+      </li>
+      <li class="example-item">
+        <a href="./log-axis-x/index.html" class="example-link">
+          <div class="example-title">Log X axis</div>
+          <div class="example-description">Bode-style frequency sweep on log X with linear magnitude (dB)</div>
+        </a>
+      </li>
+      <li class="example-item">
+        <a href="./log-axis-scatter/index.html" class="example-link">
+          <div class="example-title">Log axes scatter</div>
+          <div class="example-description">50k-point power-law scatter with log X and log Y</div>
+        </a>
+      </li>
+      <li class="example-item">
+        <a href="./log-axis-multi/index.html" class="example-link">
+          <div class="example-title">Log + linear dual Y</div>
+          <div class="example-description">Left log pressure and right linear temperature on independent scales</div>
+        </a>
+      </li>
+      <li class="example-item">
+        <a href="./log-axis-compare/index.html" class="example-link">
+          <div class="example-title">Linear vs log comparison</div>
+          <div class="example-description">Same multi-decade data on linear Y (top) and log Y (bottom)</div>
+        </a>
+      </li>
     </ul>
   </div>
 </body>

--- a/examples/log-axis-compare/index.html
+++ b/examples/log-axis-compare/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Linear vs log comparison - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; padding: 0; background-color: #0a0a0a; color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+    .page {
+      min-height: 100%; display: grid; grid-template-rows: auto 1fr; gap: 12px;
+      padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto;
+    }
+    header h1 { margin: 0; font-size: 1.4rem; color: #fff; }
+    header p { margin: 8px 0 0; color: #aaa; line-height: 1.45; font-size: 0.95rem; }
+    .charts {
+      display: grid;
+      grid-template-rows: 1fr 1fr;
+      gap: 16px;
+      min-height: 640px;
+    }
+    .chart-wrap { display: flex; flex-direction: column; gap: 6px; min-height: 0; }
+    .chart-wrap h2 { margin: 0; font-size: 0.95rem; color: #ccc; font-weight: 600; }
+    .chart {
+      flex: 1;
+      min-height: 280px;
+      border-radius: 8px;
+      border: 1px solid #222;
+      background: #0d0d12;
+    }
+    #error { display: none; margin-top: 12px; padding: 12px; background: #3a1515; border: 1px solid #833; border-radius: 6px; color: #f88; }
+    a.back { color: #8ab4ff; text-decoration: none; font-size: 0.9rem; }
+    a.back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="back" href="../index.html">← Examples</a>
+      <h1>Linear vs log comparison</h1>
+      <p>
+        Same multi-decade series on linear Y (top) and logarithmic Y (bottom).
+        Log maps orders of magnitude to equal pixel spacing; linear compresses large decades.
+      </p>
+    </header>
+    <div class="charts">
+      <div class="chart-wrap">
+        <h2>Linear Y</h2>
+        <div id="chart-linear" class="chart"></div>
+      </div>
+      <div class="chart-wrap">
+        <h2>Log Y</h2>
+        <div id="chart-log" class="chart"></div>
+      </div>
+    </div>
+    <div id="error"></div>
+  </div>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/examples/log-axis-compare/main.ts
+++ b/examples/log-axis-compare/main.ts
@@ -1,0 +1,95 @@
+/**
+ * Linear vs log comparison — same data, two ChartGPU instances.
+ */
+import { ChartGPU } from '../../src/index';
+import type { ChartGPUOptions, DataPoint } from '../../src/index';
+
+const N = 3000;
+
+function generateMultiDecade(n: number): ReadonlyArray<DataPoint> {
+  const out: DataPoint[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const x = t * 10;
+    const logY = -2 + t * 6 + 0.35 * Math.sin(t * Math.PI * 5);
+    out[i] = [x, 10 ** logY];
+  }
+  return out;
+}
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+async function main() {
+  const linearEl = document.getElementById('chart-linear');
+  const logEl = document.getElementById('chart-log');
+  if (!linearEl || !logEl) throw new Error('Chart containers not found');
+
+  const data = generateMultiDecade(N);
+
+  const base: Omit<ChartGPUOptions, 'yAxis'> = {
+    grid: { left: 72, right: 20, top: 16, bottom: 40 },
+    xAxis: { type: 'value', name: 'x', min: 0, max: 10 },
+    animation: { duration: 0 },
+    series: [
+      {
+        type: 'line',
+        name: 'Signal',
+        data,
+        color: '#4a9eff',
+        lineStyle: { width: 2 },
+        sampling: 'lttb',
+        samplingThreshold: 2000,
+      },
+    ],
+  };
+
+  const linearChart = await ChartGPU.create(linearEl, {
+    ...base,
+    yAxis: { type: 'value', name: 'Amplitude (linear)', min: 0, max: 12000 },
+  });
+
+  const logChart = await ChartGPU.create(logEl, {
+    ...base,
+    yAxis: { type: 'log', name: 'Amplitude (log)', min: 0.01, max: 10000 },
+  });
+
+  let scheduled = false;
+  const ro = new ResizeObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      linearChart.resize();
+      logChart.resize();
+    });
+  });
+  ro.observe(linearEl);
+  ro.observe(logEl);
+  linearChart.resize();
+  logChart.resize();
+
+  window.addEventListener('beforeunload', () => {
+    ro.disconnect();
+    linearChart.dispose();
+    logChart.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    });
+  });
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/examples/log-axis-multi/index.html
+++ b/examples/log-axis-multi/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Log + linear dual Y - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; padding: 0; background-color: #0a0a0a; color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+    .page {
+      min-height: 100%; display: grid; grid-template-rows: auto 1fr; gap: 12px;
+      padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto;
+    }
+    header h1 { margin: 0; font-size: 1.4rem; color: #fff; }
+    header p { margin: 8px 0 0; color: #aaa; line-height: 1.45; font-size: 0.95rem; }
+    #chart { width: 100%; height: min(70vh, 560px); min-height: 360px; border-radius: 8px; border: 1px solid #222; background: #0d0d12; }
+    #error { display: none; margin-top: 12px; padding: 12px; background: #3a1515; border: 1px solid #833; border-radius: 6px; color: #f88; }
+    a.back { color: #8ab4ff; text-decoration: none; font-size: 0.9rem; }
+    a.back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="back" href="../index.html">← Examples</a>
+      <h1>Log + linear dual Y</h1>
+      <p>Left log pressure and right linear temperature on independent scales.</p>
+    </header>
+    <div id="chart"></div>
+    <div id="error"></div>
+  </div>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/examples/log-axis-multi/main.ts
+++ b/examples/log-axis-multi/main.ts
@@ -1,0 +1,110 @@
+/**
+ * Log + linear dual Y — Mollier-inspired layout (pressure log, temperature linear).
+ */
+import { ChartGPU } from '../../src/index';
+import type { ChartGPUOptions, DataPoint } from '../../src/index';
+
+const N = 500;
+
+function generatePressure(n: number): ReadonlyArray<DataPoint> {
+  const out: DataPoint[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const h = 100 + t * 400; // enthalpy-like x
+    // Pressure drops exponentially along path: 100 bar → 0.1 bar
+    const p = 100 * 10 ** (-3 * t) * (1 + 0.05 * Math.sin(t * 12));
+    out[i] = [h, Math.max(0.05, p)];
+  }
+  return out;
+}
+
+function generateTemperature(n: number): ReadonlyArray<DataPoint> {
+  const out: DataPoint[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const h = 100 + t * 400;
+    const temp = 20 + t * 280 + 8 * Math.sin(t * 6);
+    out[i] = [h, temp];
+  }
+  return out;
+}
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+async function main() {
+  const container = document.getElementById('chart');
+  if (!container) throw new Error('Chart container not found');
+
+  const pressure = generatePressure(N);
+  const temperature = generateTemperature(N);
+
+  const options: ChartGPUOptions = {
+    grid: { left: 72, right: 72, top: 28, bottom: 56 },
+    xAxis: { type: 'value', name: 'Enthalpy (kJ/kg)', min: 100, max: 500 },
+    axes: {
+      y: [
+        { id: 'p', type: 'log', position: 'left', name: 'P (bar)', min: 0.05, max: 200 },
+        { id: 't', type: 'value', position: 'right', name: 'T (°C)', min: 0, max: 350 },
+      ],
+    },
+    dataZoom: [{ type: 'inside', start: 0, end: 100 }],
+    animation: { duration: 0 },
+    palette: ['#4a9eff', '#ff9f43'],
+    series: [
+      {
+        type: 'line',
+        name: 'Pressure',
+        yAxis: 'p',
+        data: pressure,
+        color: '#4a9eff',
+        lineStyle: { width: 2 },
+      },
+      {
+        type: 'line',
+        name: 'Temperature',
+        yAxis: 't',
+        data: temperature,
+        color: '#ff9f43',
+        lineStyle: { width: 2 },
+      },
+    ],
+  };
+
+  const chart = await ChartGPU.create(container, options);
+
+  let scheduled = false;
+  const ro = new ResizeObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      chart.resize();
+    });
+  });
+  ro.observe(container);
+  chart.resize();
+
+  window.addEventListener('beforeunload', () => {
+    ro.disconnect();
+    chart.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    });
+  });
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/examples/log-axis-scatter/index.html
+++ b/examples/log-axis-scatter/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Log axes scatter - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; padding: 0; background-color: #0a0a0a; color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+    .page {
+      min-height: 100%; display: grid; grid-template-rows: auto 1fr; gap: 12px;
+      padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto;
+    }
+    header h1 { margin: 0; font-size: 1.4rem; color: #fff; }
+    header p { margin: 8px 0 0; color: #aaa; line-height: 1.45; font-size: 0.95rem; }
+    #chart { width: 100%; height: min(70vh, 560px); min-height: 360px; border-radius: 8px; border: 1px solid #222; background: #0d0d12; }
+    #error { display: none; margin-top: 12px; padding: 12px; background: #3a1515; border: 1px solid #833; border-radius: 6px; color: #f88; }
+    a.back { color: #8ab4ff; text-decoration: none; font-size: 0.9rem; }
+    a.back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="back" href="../index.html">← Examples</a>
+      <h1>Log axes scatter</h1>
+      <p>Large scatter cloud with log Y; positive-only domain filtering.</p>
+    </header>
+    <div id="chart"></div>
+    <div id="error"></div>
+  </div>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/examples/log-axis-scatter/main.ts
+++ b/examples/log-axis-scatter/main.ts
@@ -1,0 +1,83 @@
+/**
+ * Log axes scatter — power-law cloud with log Y (all coordinates > 0).
+ */
+import { ChartGPU } from '../../src/index';
+import type { ChartGPUOptions, DataPoint } from '../../src/index';
+
+const N = 50_000;
+
+function generatePowerLawCloud(n: number): ReadonlyArray<DataPoint> {
+  const out: DataPoint[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    // Log-uniform X and power-law-ish Y with noise
+    const x = 10 ** (Math.random() * 3); // 1 … 1000
+    const y = (x ** -0.7) * 10 ** (Math.random() * 0.5) * 100;
+    out[i] = [x, Math.max(1e-3, y)];
+  }
+  return out;
+}
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+async function main() {
+  const container = document.getElementById('chart');
+  if (!container) throw new Error('Chart container not found');
+
+  const data = generatePowerLawCloud(N);
+
+  const options: ChartGPUOptions = {
+    grid: { left: 72, right: 24, top: 24, bottom: 56 },
+    xAxis: { type: 'log', name: 'X', min: 1, max: 1000 },
+    yAxis: { type: 'log', name: 'Y', min: 0.01, max: 1000 },
+    dataZoom: [{ type: 'inside', start: 0, end: 100 }],
+    animation: { duration: 0 },
+    series: [
+      {
+        type: 'scatter',
+        name: 'Cloud',
+        data,
+        color: '#ff4ab0',
+        symbolSize: 3,
+        symbol: 'circle',
+      },
+    ],
+  };
+
+  const chart = await ChartGPU.create(container, options);
+
+  let scheduled = false;
+  const ro = new ResizeObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      chart.resize();
+    });
+  });
+  ro.observe(container);
+  chart.resize();
+
+  window.addEventListener('beforeunload', () => {
+    ro.disconnect();
+    chart.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    });
+  });
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/examples/log-axis-x/index.html
+++ b/examples/log-axis-x/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Log X axis - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; padding: 0; background-color: #0a0a0a; color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+    .page {
+      min-height: 100%; display: grid; grid-template-rows: auto 1fr; gap: 12px;
+      padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto;
+    }
+    header h1 { margin: 0; font-size: 1.4rem; color: #fff; }
+    header p { margin: 8px 0 0; color: #aaa; line-height: 1.45; font-size: 0.95rem; }
+    #chart { width: 100%; height: min(70vh, 560px); min-height: 360px; border-radius: 8px; border: 1px solid #222; background: #0d0d12; }
+    #error { display: none; margin-top: 12px; padding: 12px; background: #3a1515; border: 1px solid #833; border-radius: 6px; color: #f88; }
+    a.back { color: #8ab4ff; text-decoration: none; font-size: 0.9rem; }
+    a.back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="back" href="../index.html">← Examples</a>
+      <h1>Log X axis</h1>
+      <p>Frequency-style sweep on a logarithmic X axis (Bode-like magnitude).</p>
+    </header>
+    <div id="chart"></div>
+    <div id="error"></div>
+  </div>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/examples/log-axis-x/main.ts
+++ b/examples/log-axis-x/main.ts
@@ -1,0 +1,89 @@
+/**
+ * Log X axis — Bode-style frequency sweep (log frequency, linear magnitude dB).
+ */
+import { ChartGPU } from '../../src/index';
+import type { ChartGPUOptions, DataPoint } from '../../src/index';
+
+const N = 2000;
+const F_MIN = 1;
+const F_MAX = 1e5;
+
+/** Smooth low-pass-like magnitude (dB) over log-spaced frequency. */
+function generateBodeMagnitude(n: number): ReadonlyArray<DataPoint> {
+  const out: DataPoint[] = new Array(n);
+  const logMin = Math.log10(F_MIN);
+  const logMax = Math.log10(F_MAX);
+  const f0 = 1e3; // corner frequency
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const f = 10 ** (logMin + t * (logMax - logMin));
+    // First-order low-pass |H| in dB
+    const mag = -10 * Math.log10(1 + (f / f0) ** 2);
+    out[i] = [f, mag];
+  }
+  return out;
+}
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+async function main() {
+  const container = document.getElementById('chart');
+  if (!container) throw new Error('Chart container not found');
+
+  const data = generateBodeMagnitude(N);
+
+  const options: ChartGPUOptions = {
+    grid: { left: 72, right: 24, top: 24, bottom: 56 },
+    xAxis: { type: 'log', name: 'Frequency (Hz)', min: F_MIN, max: F_MAX },
+    yAxis: { type: 'value', name: 'Magnitude (dB)', min: -80, max: 5 },
+    dataZoom: [{ type: 'inside', start: 0, end: 100 }],
+    animation: { duration: 0 },
+    series: [
+      {
+        type: 'line',
+        name: 'H(f)',
+        data,
+        color: '#40d17c',
+        lineStyle: { width: 2, opacity: 1 },
+      },
+    ],
+  };
+
+  const chart = await ChartGPU.create(container, options);
+
+  let scheduled = false;
+  const ro = new ResizeObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      chart.resize();
+    });
+  });
+  ro.observe(container);
+  chart.resize();
+
+  window.addEventListener('beforeunload', () => {
+    ro.disconnect();
+    chart.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    });
+  });
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/examples/log-axis-y/index.html
+++ b/examples/log-axis-y/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Log Y axis - ChartGPU</title>
+  <style>
+    :root { color-scheme: dark; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; padding: 0; background-color: #0a0a0a; color: #e0e0e0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    }
+    .page {
+      min-height: 100%; display: grid; grid-template-rows: auto 1fr; gap: 12px;
+      padding: 20px; box-sizing: border-box; max-width: 1100px; margin: 0 auto;
+    }
+    header h1 { margin: 0; font-size: 1.4rem; color: #fff; }
+    header p { margin: 8px 0 0; color: #aaa; line-height: 1.45; font-size: 0.95rem; }
+    #chart { width: 100%; height: min(70vh, 560px); min-height: 360px; border-radius: 8px; border: 1px solid #222; background: #0d0d12; }
+    #error { display: none; margin-top: 12px; padding: 12px; background: #3a1515; border: 1px solid #833; border-radius: 6px; color: #f88; }
+    a.back { color: #8ab4ff; text-decoration: none; font-size: 0.9rem; }
+    a.back:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <a class="back" href="../index.html">← Examples</a>
+      <h1>Log Y axis</h1>
+      <p>Line series with Y spanning ~10⁻²…10⁴; native log projection, major log ticks, and log-aligned grid.</p>
+    </header>
+    <div id="chart"></div>
+    <div id="error"></div>
+  </div>
+  <script type="module" src="./main.ts"></script>
+</body>
+</html>

--- a/examples/log-axis-y/main.ts
+++ b/examples/log-axis-y/main.ts
@@ -1,0 +1,86 @@
+/**
+ * Log Y axis — multi-decade amplitude with native log projection.
+ */
+import { ChartGPU } from '../../src/index';
+import type { ChartGPUOptions, DataPoint } from '../../src/index';
+
+const N = 4000;
+
+/** y = 10^(smooth envelope) with mild noise — spans ~1e-2 … 1e4 */
+function generateMultiDecade(n: number): ReadonlyArray<DataPoint> {
+  const out: DataPoint[] = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = i / (n - 1);
+    const x = t * 10;
+    // Envelope from 1e-2 to 1e4 in log space with a dip and rise
+    const logY = -2 + t * 6 + 0.4 * Math.sin(t * Math.PI * 4) + (Math.random() - 0.5) * 0.08;
+    out[i] = [x, 10 ** logY];
+  }
+  return out;
+}
+
+const showError = (message: string): void => {
+  const el = document.getElementById('error');
+  if (!el) return;
+  el.textContent = message;
+  el.style.display = 'block';
+};
+
+async function main() {
+  const container = document.getElementById('chart');
+  if (!container) throw new Error('Chart container not found');
+
+  const data = generateMultiDecade(N);
+
+  const options: ChartGPUOptions = {
+    grid: { left: 72, right: 24, top: 24, bottom: 56 },
+    xAxis: { type: 'value', name: 'Time (s)', min: 0, max: 10 },
+    yAxis: { type: 'log', name: 'Amplitude', min: 0.01, max: 10000 },
+    dataZoom: [{ type: 'inside', start: 0, end: 100 }],
+    animation: { duration: 0 },
+    series: [
+      {
+        type: 'line',
+        name: 'Signal',
+        data,
+        color: '#4a9eff',
+        lineStyle: { width: 2, opacity: 1 },
+        sampling: 'lttb',
+        samplingThreshold: 2500,
+      },
+    ],
+  };
+
+  const chart = await ChartGPU.create(container, options);
+
+  let scheduled = false;
+  const ro = new ResizeObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    requestAnimationFrame(() => {
+      scheduled = false;
+      chart.resize();
+    });
+  });
+  ro.observe(container);
+  chart.resize();
+
+  window.addEventListener('beforeunload', () => {
+    ro.disconnect();
+    chart.dispose();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    main().catch((err) => {
+      console.error(err);
+      showError(err instanceof Error ? err.message : String(err));
+    });
+  });
+} else {
+  main().catch((err) => {
+    console.error(err);
+    showError(err instanceof Error ? err.message : String(err));
+  });
+}

--- a/src/ChartGPU.ts
+++ b/src/ChartGPU.ts
@@ -27,7 +27,7 @@ import { computeCandlestickBodyWidthRange, findCandlestick } from './interaction
 import { findNearestPoint } from './interaction/findNearestPoint';
 import type { NearestPointMatch } from './interaction/findNearestPoint';
 import { findPieSlice } from './interaction/findPieSlice';
-import { createLinearScale } from './utils/scales';
+import { createAxisScale } from './utils/scales';
 import type { LinearScale } from './utils/scales';
 import { checkWebGPUSupport } from './utils/checkWebGPU';
 import type { PipelineCache } from './core/PipelineCache';
@@ -1672,8 +1672,9 @@ export async function createChartGPU(
 
     if (!canReuseScales) {
       // IMPORTANT: grid-local CSS px ranges (0..plotWidth/Height), for interaction hit-testing.
-      const xScale = createLinearScale().domain(xDomain.min, xDomain.max).range(0, plotWidthCss);
-      const yScale = createLinearScale().domain(yDomain.min, yDomain.max).range(plotHeightCss, 0);
+      const xScale = createAxisScale(resolvedOptions.xAxis).domain(xDomain.min, xDomain.max).range(0, plotWidthCss);
+      const yAxis0 = resolvedOptions.yAxes[0] ?? { type: 'value' as const };
+      const yScale = createAxisScale(yAxis0).domain(yDomain.min, yDomain.max).range(plotHeightCss, 0);
       interactionScalesCache = {
         rectWidthCss: layout.layoutWidth,
         rectHeightCss: layout.layoutHeight,
@@ -2775,8 +2776,9 @@ export async function createChartGPU(
         interactionScalesCache.yDomainMax === yDomain.max;
 
       if (!canReuseScales) {
-        const xScale = createLinearScale().domain(xDomain.min, xDomain.max).range(0, plotWidthCss);
-        const yScale = createLinearScale().domain(yDomain.min, yDomain.max).range(plotHeightCss, 0);
+        const xScale = createAxisScale(resolvedOptions.xAxis).domain(xDomain.min, xDomain.max).range(0, plotWidthCss);
+        const yAxis0 = resolvedOptions.yAxes[0] ?? { type: 'value' as const };
+        const yScale = createAxisScale(yAxis0).domain(yDomain.min, yDomain.max).range(plotHeightCss, 0);
         interactionScalesCache = {
           rectWidthCss: layout.layoutWidth,
           rectHeightCss: layout.layoutHeight,

--- a/src/config/OptionResolver.ts
+++ b/src/config/OptionResolver.ts
@@ -702,6 +702,36 @@ const normalizeAxisAutoBounds = (value: unknown): AxisConfig['autoBounds'] | und
   return v === 'global' || v === 'visible' ? (v as AxisConfig['autoBounds']) : undefined;
 };
 
+const VALID_AXIS_TYPES = new Set(['value', 'time', 'category', 'log']);
+
+const normalizeAxisType = (value: unknown, fallback: AxisConfig['type']): AxisConfig['type'] => {
+  if (typeof value === 'string' && VALID_AXIS_TYPES.has(value)) {
+    return value as AxisConfig['type'];
+  }
+  return fallback;
+};
+
+/**
+ * Resolve `logBase` for log axes. Default 10; invalid bases fall back to 10 with a
+ * one-shot dev warning. Omitted / non-log axes leave logBase undefined.
+ */
+const resolveAxisLogBase = (type: AxisConfig['type'], logBase: unknown): number | undefined => {
+  if (type !== 'log') return undefined;
+  if (logBase === undefined || logBase === null) return 10;
+  if (typeof logBase === 'number' && Number.isFinite(logBase) && logBase > 0 && logBase !== 1) {
+    return logBase;
+  }
+  console.warn(`[ChartGPU] Invalid axis logBase (${String(logBase)}); falling back to 10.`);
+  return 10;
+};
+
+const finalizeAxisConfig = (axis: AxisConfig): AxisConfig => {
+  const type = normalizeAxisType(axis.type, 'value');
+  const logBase = resolveAxisLogBase(type, axis.logBase);
+  if (type === axis.type && logBase === axis.logBase) return axis;
+  return logBase !== undefined ? { ...axis, type, logBase } : { ...axis, type };
+};
+
 const isTupleOHLCDataPoint = (p: OHLCDataPoint): p is OHLCDataPointTuple => Array.isArray(p);
 
 const computeRawBoundsFromOHLC = (data: ReadonlyArray<OHLCDataPoint>): RawBounds | undefined => {
@@ -1075,47 +1105,60 @@ export function resolveOptions(
 
   const gridLines = resolveGridLines(userOptions.gridLines, theme);
 
-  const xAxis: AxisConfig = userOptions.xAxis
-    ? {
-        ...defaultOptions.xAxis,
-        ...userOptions.xAxis,
-        // runtime safety for JS callers
-        type: (userOptions.xAxis as unknown as Partial<AxisConfig>).type ?? defaultOptions.xAxis.type,
-        autoBounds:
-          normalizeAxisAutoBounds((userOptions.xAxis as unknown as { readonly autoBounds?: unknown }).autoBounds) ??
-          (defaultOptions.xAxis as AxisConfig).autoBounds,
-      }
-    : { ...defaultOptions.xAxis };
+  const xAxis: AxisConfig = finalizeAxisConfig(
+    userOptions.xAxis
+      ? {
+          ...defaultOptions.xAxis,
+          ...userOptions.xAxis,
+          // runtime safety for JS callers
+          type: normalizeAxisType(
+            (userOptions.xAxis as unknown as Partial<AxisConfig>).type,
+            defaultOptions.xAxis.type
+          ),
+          autoBounds:
+            normalizeAxisAutoBounds((userOptions.xAxis as unknown as { readonly autoBounds?: unknown }).autoBounds) ??
+            (defaultOptions.xAxis as AxisConfig).autoBounds,
+        }
+      : { ...defaultOptions.xAxis }
+  );
 
   const yAxes: AxisConfig[] = [];
   if (userOptions.axes?.y && userOptions.axes.y.length > 0) {
     for (let index = 0; index < userOptions.axes.y.length; index++) {
       const yConfig = userOptions.axes.y[index]!;
-      yAxes.push({
-        ...defaultOptions.yAxis,
-        ...yConfig,
-        id: yConfig.id ?? (index === 0 ? 'y' : `y${index}`),
-        position: yConfig.position ?? 'left',
-        type: yConfig.type ?? defaultOptions.yAxis.type,
-        autoBounds:
-          normalizeAxisAutoBounds((yConfig as unknown as { readonly autoBounds?: unknown }).autoBounds) ??
-          defaultOptions.yAxis.autoBounds,
-      });
+      yAxes.push(
+        finalizeAxisConfig({
+          ...defaultOptions.yAxis,
+          ...yConfig,
+          id: yConfig.id ?? (index === 0 ? 'y' : `y${index}`),
+          position: yConfig.position ?? 'left',
+          type: normalizeAxisType(yConfig.type, defaultOptions.yAxis.type),
+          autoBounds:
+            normalizeAxisAutoBounds((yConfig as unknown as { readonly autoBounds?: unknown }).autoBounds) ??
+            defaultOptions.yAxis.autoBounds,
+        })
+      );
     }
   } else {
     yAxes.push(
-      userOptions.yAxis
-        ? {
-            ...defaultOptions.yAxis,
-            ...userOptions.yAxis,
-            id: userOptions.yAxis.id ?? 'y',
-            position: userOptions.yAxis.position ?? 'left',
-            type: (userOptions.yAxis as unknown as Partial<AxisConfig>).type ?? defaultOptions.yAxis.type,
-            autoBounds:
-              normalizeAxisAutoBounds((userOptions.yAxis as unknown as { readonly autoBounds?: unknown }).autoBounds) ??
-              defaultOptions.yAxis.autoBounds,
-          }
-        : { ...defaultOptions.yAxis, id: 'y', position: 'left' }
+      finalizeAxisConfig(
+        userOptions.yAxis
+          ? {
+              ...defaultOptions.yAxis,
+              ...userOptions.yAxis,
+              id: userOptions.yAxis.id ?? 'y',
+              position: userOptions.yAxis.position ?? 'left',
+              type: normalizeAxisType(
+                (userOptions.yAxis as unknown as Partial<AxisConfig>).type,
+                defaultOptions.yAxis.type
+              ),
+              autoBounds:
+                normalizeAxisAutoBounds(
+                  (userOptions.yAxis as unknown as { readonly autoBounds?: unknown }).autoBounds
+                ) ?? defaultOptions.yAxis.autoBounds,
+            }
+          : { ...defaultOptions.yAxis, id: 'y', position: 'left' }
+      )
     );
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -4,7 +4,7 @@
 
 import type { ThemeConfig } from '../themes/types';
 
-export type AxisType = 'value' | 'time' | 'category';
+export type AxisType = 'value' | 'time' | 'category' | 'log';
 export type SeriesType = 'line' | 'area' | 'bar' | 'scatter' | 'pie' | 'candlestick';
 
 /**
@@ -128,9 +128,16 @@ export interface AxisConfig {
    * Custom formatter for axis tick labels.
    * When provided, replaces the built-in tick label formatting.
    * For time axes, `value` is a timestamp in milliseconds (epoch-ms).
+   * For log axes, `value` is the **data-space** tick value (e.g. `1000`, not `3` for \(10^3\)).
    * Return `null` to suppress a specific tick label.
    */
   readonly tickFormatter?: (value: number) => string | null;
+  /**
+   * Logarithm base when `type === 'log'`. Default: `10`.
+   * Must be finite and > 0, and ≠ 1. Invalid values fall back to 10 with a dev warning.
+   * Ignored for non-log axes.
+   */
+  readonly logBase?: number;
 }
 
 export interface DataZoomConfig {

--- a/src/core/renderCoordinator/animation/__tests__/animationHelpers.test.ts
+++ b/src/core/renderCoordinator/animation/__tests__/animationHelpers.test.ts
@@ -10,6 +10,7 @@ import {
   createEasingWithDelay,
   hasAnyDrawableMarks,
   lerpDomain,
+  lerpLogDomain,
   interpolateCartesianData,
   interpolatePieData,
   isDomainEqual,
@@ -286,6 +287,33 @@ describe('lerpDomain', () => {
 
     expect(result.min).toBe(-75);
     expect(result.max).toBe(25);
+  });
+});
+
+describe('lerpLogDomain', () => {
+  it('interpolates multi-decade domains in log space', () => {
+    const from = { min: 1, max: 100 };
+    const to = { min: 1, max: 10000 };
+    // Geometric mean of max: sqrt(100 * 10000) = 1000
+    const mid = lerpLogDomain(from, to, 0.5);
+    expect(mid.min).toBeCloseTo(1, 10);
+    expect(mid.max).toBeCloseTo(1000, 10);
+  });
+
+  it('returns endpoints at t=0 and t=1', () => {
+    const from = { min: 0.1, max: 10 };
+    const to = { min: 1, max: 1000 };
+    expect(lerpLogDomain(from, to, 0)).toEqual(from);
+    expect(lerpLogDomain(from, to, 1)).toEqual(to);
+  });
+
+  it('falls back to linear lerp when any endpoint is non-positive', () => {
+    const from = { min: -10, max: 100 };
+    const to = { min: 1, max: 100 };
+    const mid = lerpLogDomain(from, to, 0.5);
+    // Linear: min = -10 + (1 - -10)*0.5 = -4.5
+    expect(mid.min).toBeCloseTo(-4.5, 10);
+    expect(mid.max).toBe(100);
   });
 });
 

--- a/src/core/renderCoordinator/animation/animationHelpers.ts
+++ b/src/core/renderCoordinator/animation/animationHelpers.ts
@@ -190,6 +190,40 @@ export function lerpDomain(from: DomainBounds, to: DomainBounds, t: number): Dom
 }
 
 /**
+ * Interpolates domain bounds in **log space** (for log axes).
+ *
+ * When any endpoint is non-positive or non-finite, falls back to linear
+ * {@link lerpDomain} so callers can still sanitize afterward.
+ *
+ * @param from - Starting domain (data space)
+ * @param to - Ending domain (data space)
+ * @param t - Interpolation progress [0, 1]
+ * @returns Interpolated domain in data space
+ */
+export function lerpLogDomain(from: DomainBounds, to: DomainBounds, t: number): DomainBounds {
+  const t01 = clamp01(t);
+  if (t01 === 0) return { min: from.min, max: from.max };
+  if (t01 === 1) return { min: to.min, max: to.max };
+  if (
+    !(from.min > 0) ||
+    !(from.max > 0) ||
+    !(to.min > 0) ||
+    !(to.max > 0) ||
+    !Number.isFinite(from.min) ||
+    !Number.isFinite(from.max) ||
+    !Number.isFinite(to.min) ||
+    !Number.isFinite(to.max)
+  ) {
+    return lerpDomain(from, to, t01);
+  }
+  // Natural log is fine — base is an affine transform in log space.
+  return {
+    min: Math.exp(Math.log(from.min) + (Math.log(to.min) - Math.log(from.min)) * t01),
+    max: Math.exp(Math.log(from.max) + (Math.log(to.max) - Math.log(from.max)) * t01),
+  };
+}
+
+/**
  * Linearly interpolates between two numbers.
  *
  * @param from - Starting value

--- a/src/core/renderCoordinator/axis/computeAxisTicks.ts
+++ b/src/core/renderCoordinator/axis/computeAxisTicks.ts
@@ -1,11 +1,14 @@
 /**
  * Axis tick computation and formatting.
  *
- * Generates tick values and formatting for linear axes. Handles decimal precision
- * determination based on tick step size and provides number formatting utilities.
+ * Generates tick values and formatting for linear and logarithmic axes. Handles
+ * decimal precision determination based on tick step size and provides number
+ * formatting utilities.
  *
  * @module computeAxisTicks
  */
+
+import { DEFAULT_LOG_BASE, normalizeLogBase } from '../../../utils/scales';
 
 /**
  * Default maximum fraction digits for tick formatting (single source of truth).
@@ -30,6 +33,319 @@ export function generateLinearTicks(domainMin: number, domainMax: number, tickCo
     ticks[i] = v;
   }
   return ticks;
+}
+
+/**
+ * Generates major log tick values at integer powers of `base` inside [min, max].
+ *
+ * Domain endpoints that are non-positive are replaced with a safe fallback
+ * `[1, base]` before generation. If no integer power falls inside the domain
+ * (intra-decade window, e.g. `[2, 3]`), domain endpoints are returned so grid
+ * lines and labels stay inside the plot range.
+ *
+ * @param domainMin - Domain minimum (data space)
+ * @param domainMax - Domain maximum (data space)
+ * @param base - Logarithm base (default 10; invalid bases fall back to 10)
+ * @returns Sorted major tick values in data space
+ */
+export function generateLogTicks(domainMin: number, domainMax: number, base: number = DEFAULT_LOG_BASE): number[] {
+  const b = normalizeLogBase(base);
+  let lo = Math.min(domainMin, domainMax);
+  let hi = Math.max(domainMin, domainMax);
+
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || !(lo > 0) || !(hi > 0)) {
+    lo = 1;
+    hi = b > 1 ? b : 10;
+  }
+  if (lo === hi) {
+    hi = lo * b;
+  }
+
+  const logLo = Math.log(lo) / Math.log(b);
+  const logHi = Math.log(hi) / Math.log(b);
+  // Inclusive powers that land within the domain (with float tolerance).
+  const kStart = Math.ceil(logLo - 1e-12);
+  const kEnd = Math.floor(logHi + 1e-12);
+
+  if (kStart > kEnd) {
+    // Domain lies strictly between two consecutive powers — prefer endpoints
+    // so labels/grid stay inside the visible window (not surrounding powers).
+    return [lo, hi];
+  }
+
+  const ticks: number[] = [];
+  for (let k = kStart; k <= kEnd; k++) {
+    const v = b ** k;
+    // Keep powers that fall inside [lo, hi] with a tiny relative slack for float noise.
+    if (v >= lo * (1 - 1e-12) && v <= hi * (1 + 1e-12)) {
+      ticks.push(v);
+    }
+  }
+
+  // Deduplicate / sort (base**k can collide for pathological bases).
+  ticks.sort((a, c) => a - c);
+  const out: number[] = [];
+  for (let i = 0; i < ticks.length; i++) {
+    const v = ticks[i]!;
+    if (out.length === 0 || Math.abs(out[out.length - 1]! - v) > Math.abs(v) * 1e-12) {
+      out.push(v);
+    }
+  }
+
+  if (out.length === 0) {
+    return [lo, hi];
+  }
+  if (out.length === 1) {
+    const only = out[0]!;
+    return only > lo ? [lo, only] : [only, hi];
+  }
+  return out;
+}
+
+/**
+ * Generates log-axis ticks for the *visible* domain (e.g. after zoom/pan).
+ *
+ * Always places majors at integer powers of `base` that fall inside the window.
+ * When few majors are present (zoomed into one decade or an intra-decade band),
+ * densifies with intermediate mantissas (2×/5× then denser for base 10; log-spaced
+ * samples for other bases) so labels and grid stay useful inside the plot.
+ *
+ * Ticks are filtered to the visible domain. Callers should pass the scale's
+ * current domain (visible window), not the full explicit axis min/max.
+ *
+ * @param domainMin - Visible domain minimum (data space)
+ * @param domainMax - Visible domain maximum (data space)
+ * @param base - Logarithm base (default 10)
+ * @param options - Optional maxTicks cap (default 12)
+ * @returns Sorted tick values in data space, all within the visible domain
+ */
+export function generateLogTicksForVisibleDomain(
+  domainMin: number,
+  domainMax: number,
+  base: number = DEFAULT_LOG_BASE,
+  options?: { maxTicks?: number }
+): number[] {
+  const maxTicks = Math.max(2, Math.floor(options?.maxTicks ?? 12));
+  const b = normalizeLogBase(base);
+  let lo = Math.min(domainMin, domainMax);
+  let hi = Math.max(domainMin, domainMax);
+
+  if (!Number.isFinite(lo) || !Number.isFinite(hi) || !(lo > 0) || !(hi > 0)) {
+    lo = 1;
+    hi = b > 1 ? b : 10;
+  }
+  if (lo === hi) {
+    hi = lo * b;
+  }
+
+  const logLo = Math.log(lo) / Math.log(b);
+  const logHi = Math.log(hi) / Math.log(b);
+  const decadeSpan = logHi - logLo;
+
+  // Integer powers that land inside the visible window.
+  const kStart = Math.ceil(logLo - 1e-12);
+  const kEnd = Math.floor(logHi + 1e-12);
+  const majors: number[] = [];
+  for (let k = kStart; k <= kEnd; k++) {
+    const v = b ** k;
+    if (isInLogDomain(v, lo, hi)) {
+      majors.push(v);
+    }
+  }
+
+  // Enough majors for a multi-decade view: classic power-of-base labels only.
+  if (majors.length >= 3 || (majors.length >= 2 && decadeSpan >= 1.2)) {
+    return majors.length <= maxTicks ? majors : thinPreferringValues(majors, majors, maxTicks);
+  }
+
+  return densifyLogTicks(lo, hi, b, majors, maxTicks);
+}
+
+/** Relative float slack for domain membership checks. */
+function isInLogDomain(v: number, lo: number, hi: number): boolean {
+  return v >= lo * (1 - 1e-12) && v <= hi * (1 + 1e-12);
+}
+
+function dedupSortedTicks(ticks: number[]): number[] {
+  ticks.sort((a, c) => a - c);
+  const out: number[] = [];
+  for (let i = 0; i < ticks.length; i++) {
+    const v = ticks[i]!;
+    if (out.length === 0 || Math.abs(out[out.length - 1]! - v) > Math.abs(v) * 1e-12) {
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+/**
+ * Prefer keeping `preferred` values (e.g. major powers) when thinning to maxTicks.
+ * Fills remaining slots with evenly spaced picks from the full sorted list.
+ */
+function thinPreferringValues(all: number[], preferred: number[], maxTicks: number): number[] {
+  if (all.length <= maxTicks) return all;
+  const keep = new Set<number>();
+  for (const p of preferred) {
+    if (all.includes(p)) keep.add(p);
+  }
+  // Always try to keep endpoints of the candidate list.
+  if (all.length > 0) {
+    keep.add(all[0]!);
+    keep.add(all[all.length - 1]!);
+  }
+  if (keep.size >= maxTicks) {
+    const forced = dedupSortedTicks([...keep]);
+    if (forced.length <= maxTicks) return forced;
+    const out: number[] = [];
+    for (let i = 0; i < maxTicks; i++) {
+      const idx = maxTicks === 1 ? 0 : Math.round((i * (forced.length - 1)) / (maxTicks - 1));
+      out.push(forced[idx]!);
+    }
+    return dedupSortedTicks(out);
+  }
+  // Fill with evenly spaced non-preferred from `all`.
+  const remaining = maxTicks - keep.size;
+  const candidates = all.filter((v) => !keep.has(v));
+  if (candidates.length > 0 && remaining > 0) {
+    for (let i = 0; i < remaining; i++) {
+      const idx =
+        remaining === 1
+          ? Math.floor(candidates.length / 2)
+          : Math.round((i * (candidates.length - 1)) / (remaining - 1));
+      keep.add(candidates[Math.min(idx, candidates.length - 1)]!);
+    }
+  }
+  return dedupSortedTicks([...keep]).slice(0, maxTicks);
+}
+
+/**
+ * Densify when the visible window has few integer powers of `base`.
+ * Base 10: mantissa ladders 1/2/5 → denser 1–9. Other bases: log-spaced samples.
+ */
+function densifyLogTicks(lo: number, hi: number, base: number, majors: number[], maxTicks: number): number[] {
+  const isBase10 = Math.abs(base - 10) < 1e-9;
+
+  if (isBase10) {
+    const mantissaSets: readonly (readonly number[])[] = [
+      [1, 2, 5],
+      [1, 2, 3, 5, 7],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    ];
+    const logLo = Math.log10(lo);
+    const logHi = Math.log10(hi);
+    const expStart = Math.floor(logLo - 1e-12);
+    const expEnd = Math.ceil(logHi + 1e-12);
+
+    let best: number[] = majors.length > 0 ? [...majors] : [lo, hi];
+    for (let si = 0; si < mantissaSets.length; si++) {
+      const mantissas = mantissaSets[si]!;
+      const ticks: number[] = [];
+      for (let e = expStart; e <= expEnd; e++) {
+        const decade = 10 ** e;
+        for (let mi = 0; mi < mantissas.length; mi++) {
+          const v = mantissas[mi]! * decade;
+          if (isInLogDomain(v, lo, hi)) {
+            ticks.push(v);
+          }
+        }
+      }
+      const unique = dedupSortedTicks(ticks);
+      if (unique.length === 0) continue;
+      best = unique;
+      // Stop once we have a usable density (or last ladder).
+      if (unique.length >= 3 || si === mantissaSets.length - 1) {
+        break;
+      }
+    }
+
+    // Always merge visible domain endpoints before thinning (parity with non-base-10 path)
+    // so edge labels/grid stay at lo/hi even when the mantissa ladder omits them
+    // (e.g. [2e3, 8e3] → ladder has 2/3/5/7e3 but not 8e3).
+    best = dedupSortedTicks([...best, lo, hi]);
+    // Ensure in-range majors are present (mantissa 1 covers them for base 10).
+    for (const m of majors) {
+      if (!best.some((t) => Math.abs(t - m) <= Math.abs(m) * 1e-12)) {
+        best.push(m);
+      }
+    }
+    best = dedupSortedTicks(best);
+    if (best.length > maxTicks) {
+      return thinPreferringValues(best, majors, maxTicks);
+    }
+    return best;
+  }
+
+  // Non-base-10: evenly sample log space, always include majors.
+  const logLo = Math.log(lo) / Math.log(base);
+  const logHi = Math.log(hi) / Math.log(base);
+  // Aim for ~4 ticks per decade of log space; clamp to maxTicks.
+  const span = logHi - logLo;
+  const target = Math.min(maxTicks, Math.max(3, !Number.isFinite(span) || !(span > 0) ? 3 : Math.round(span * 4) + 1));
+  const ticks: number[] = [...majors];
+  for (let i = 0; i < target; i++) {
+    const t = target === 1 ? 0.5 : i / (target - 1);
+    const v = base ** (logLo + t * (logHi - logLo));
+    if (isInLogDomain(v, lo, hi)) {
+      ticks.push(v);
+    }
+  }
+  // Include endpoints so sparse windows still label the edges.
+  ticks.push(lo, hi);
+  const unique = dedupSortedTicks(ticks);
+  if (unique.length > maxTicks) {
+    return thinPreferringValues(unique, majors, maxTicks);
+  }
+  return unique.length > 0 ? unique : [lo, hi];
+}
+
+/**
+ * Formats a log-axis tick value for display (data-space value, not the log exponent).
+ *
+ * Policy (base 10):
+ * - Exact powers with |exp| ≥ 3 → scientific `1eN`
+ * - Exact powers with |exp| ≤ 2 → plain decimal (`0.01`, `0.1`, `1`, `10`, `100`)
+ * - Non-power / other bases → compact scientific or plain via Number formatting
+ *
+ * @param v - Data-space tick value
+ * @param base - Logarithm base used for power detection
+ */
+export function formatLogTickValue(v: number, base: number = DEFAULT_LOG_BASE): string | null {
+  if (!Number.isFinite(v) || v <= 0) return null;
+  const b = normalizeLogBase(base);
+
+  const exp = Math.log(v) / Math.log(b);
+  const nearest = Math.round(exp);
+  const isExactPower = Math.abs(exp - nearest) < 1e-9 * Math.max(1, Math.abs(nearest));
+
+  if (isExactPower && b === 10) {
+    if (Math.abs(nearest) >= 3) {
+      return `1e${nearest}`;
+    }
+    // Plain decimal for small powers of ten.
+    if (nearest >= 0) {
+      return String(10 ** nearest);
+    }
+    // 10^-1, 10^-2
+    const digits = -nearest;
+    return (10 ** nearest).toFixed(digits);
+  }
+
+  if (isExactPower && b !== 10) {
+    // e.g. base 2 → "2^10"
+    return `${formatCompactBase(b)}^${nearest}`;
+  }
+
+  // Non-power: prefer scientific for large/small magnitude.
+  const abs = Math.abs(v);
+  if (abs >= 1e3 || abs < 1e-2) {
+    return v.toExponential(2).replace(/\.?0+e/, 'e');
+  }
+  return String(Number(v.toPrecision(6)));
+}
+
+function formatCompactBase(b: number): string {
+  if (Number.isInteger(b)) return String(b);
+  return String(Number(b.toPrecision(6)));
 }
 
 /**

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -42,6 +42,7 @@ import {
   patchSeriesPresentationKeepingSampledData,
   didRawBoundsModeChange,
 } from './data/samplingDirty';
+import { syncCandlestickOwnedFromUserSeries } from './data/syncCandlestickRuntime';
 import { processAnnotations } from './annotations/processAnnotations';
 import {
   prepareSeries,
@@ -63,13 +64,18 @@ import { createTextureManager } from './gpu/textureManager';
 import { enqueueDeviceSubmit, flushDeviceSubmit } from '../gpu/submitBatcher';
 import {
   applyStickyAutoDomain,
+  applyStickyAutoLogDomain,
   DEFAULT_STICKY_DOMAIN_HEADROOM,
   DEFAULT_STICKY_X_DOMAIN_HEADROOM,
   resolveStickyOrDataDomain,
   shouldApplyStickyAutoDomain,
   shouldSkipStickyAutoXDomain,
 } from './zoom/stickyAutoDomain';
-import { isFullSpanZoomRange as isFullSpanZoomRangeHelper, scanCartesianVisibleYBounds } from './zoom/visibleYBounds';
+import {
+  isFullSpanZoomRange as isFullSpanZoomRangeHelper,
+  scanCartesianVisibleYBounds,
+  scanCartesianPositiveYBounds,
+} from './zoom/visibleYBounds';
 import { createCrosshairRenderer } from '../../renderers/createCrosshairRenderer';
 import { createHighlightRenderer } from '../../renderers/createHighlightRenderer';
 import { createReferenceLineRenderer } from '../../renderers/createReferenceLineRenderer';
@@ -84,8 +90,8 @@ import { findNearestPoint } from '../../interaction/findNearestPoint';
 import { findPointsAtX } from '../../interaction/findPointsAtX';
 import { computeCandlestickBodyWidthRange, findCandlestick } from '../../interaction/findCandlestick';
 import { findPieSlice } from '../../interaction/findPieSlice';
-import { createLinearScale } from '../../utils/scales';
-import type { LinearScale } from '../../utils/scales';
+import { createAxisScale } from '../../utils/scales';
+import type { ContinuousScale, LinearScale } from '../../utils/scales';
 import { parseCssColorToGPUColor } from '../../utils/colors';
 import { createTextOverlay } from '../../components/createTextOverlay';
 import type { TextOverlay } from '../../components/createTextOverlay';
@@ -114,7 +120,7 @@ import {
   clipXToCanvasCssPx,
   clipYToCanvasCssPx,
 } from './utils/axisUtils';
-import { extendBoundsWithOHLCDataPoints, normalizeDomain } from './utils/boundsComputation';
+import { extendBoundsWithOHLCDataPoints, normalizeDomain, sanitizeLogDomain } from './utils/boundsComputation';
 import {
   DEFAULT_TICK_COUNT as TIME_DEFAULT_TICK_COUNT,
   resolvePieCenterPlotCss,
@@ -122,6 +128,7 @@ import {
   generateLinearTicks,
   computeAdaptiveTimeXAxisTicks,
 } from './utils/timeAxisUtils';
+import { generateLogTicks, generateLogTicksForVisibleDomain } from './axis/computeAxisTicks';
 import {
   resolveAnimationConfig as resolveAnimationConfigHelper,
   isDomainEqual,
@@ -132,6 +139,7 @@ import {
   computeNextIntroPhase,
   applyBarIntroProgress,
   lerpDomain,
+  lerpLogDomain,
   type AnySeriesConfig,
 } from './animation/animationHelpers';
 import { computeCandlestickTooltipAnchorFromMatch } from './ui/tooltipLegendHelpers';
@@ -495,20 +503,164 @@ const computeGlobalYBoundsForAxis = (
   return { yMin, yMax };
 };
 
+/**
+ * Positive-only Y bounds for log axes. Ignores ≤0 values so auto domain stays
+ * strictly positive. Falls back to {1, 10} when no positive data exists.
+ *
+ * When `visibleBoundsOverride` is present but not both-positive (zeros/negatives
+ * in the visible window), re-scan **only** points inside `xWindow` (same window
+ * used for visible Y). Do not fall back to unwindowed full-series positives —
+ * that would contradict `autoBounds: 'visible'` under zoom.
+ */
+const computePositiveYBoundsForAxis = (
+  series: ResolvedChartGPUOptions['series'],
+  axisId: string,
+  runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null,
+  visibleBoundsOverride?: { yMin: number; yMax: number } | null,
+  xWindow?: { readonly min: number; readonly max: number } | null
+): { yMin: number; yMax: number } => {
+  // Prefer positive subset of a visible override when both ends are already positive.
+  if (
+    visibleBoundsOverride &&
+    visibleBoundsOverride.yMin > 0 &&
+    visibleBoundsOverride.yMax > 0 &&
+    Number.isFinite(visibleBoundsOverride.yMin) &&
+    Number.isFinite(visibleBoundsOverride.yMax)
+  ) {
+    return visibleBoundsOverride;
+  }
+
+  let yMin = Number.POSITIVE_INFINITY;
+  let yMax = Number.NEGATIVE_INFINITY;
+  const filterX = xWindow != null && Number.isFinite(xWindow.min) && Number.isFinite(xWindow.max);
+  const xMinW = filterX ? xWindow!.min : 0;
+  const xMaxW = filterX ? xWindow!.max : 0;
+  // Visible-mode override that still includes ≤0: restrict scan to xWindow only.
+  const inVisibleWindowMode = visibleBoundsOverride != null;
+
+  for (let s = 0; s < series.length; s++) {
+    const seriesConfig = series[s];
+    if (seriesConfig.type === 'pie') continue;
+    if (seriesConfig.yAxis !== axisId) continue;
+
+    if (seriesConfig.type === 'candlestick') {
+      const rawOHLC = (seriesConfig.rawData ?? seriesConfig.data) as ReadonlyArray<OHLCDataPoint>;
+      for (let i = 0; i < rawOHLC.length; i++) {
+        const p = rawOHLC[i]!;
+        const timestamp = isTupleOHLCDataPoint(p) ? p[0] : p.timestamp;
+        if (filterX && Number.isFinite(timestamp) && (timestamp < xMinW || timestamp > xMaxW)) {
+          continue;
+        }
+        const low = isTupleOHLCDataPoint(p) ? p[3] : p.low;
+        const high = isTupleOHLCDataPoint(p) ? p[4] : p.high;
+        if (!Number.isFinite(low) || !Number.isFinite(high)) continue;
+        const yLow = Math.min(low, high);
+        const yHigh = Math.max(low, high);
+        if (yLow > 0 && yLow < yMin) yMin = yLow;
+        if (yHigh > 0 && yHigh > yMax) yMax = yHigh;
+      }
+      continue;
+    }
+
+    const data = (seriesConfig.rawData ?? seriesConfig.data) as CartesianSeriesData;
+    const scanned = scanCartesianPositiveYBounds(data, filterX ? xWindow : null);
+    if (scanned) {
+      if (scanned.yMin < yMin) yMin = scanned.yMin;
+      if (scanned.yMax > yMax) yMax = scanned.yMax;
+    }
+  }
+
+  // Runtime bounds may still include non-positive; only accept when both positive.
+  // Skip unwindowed runtime extrema when a visible x-window is active — those are
+  // full-series and would reintroduce off-window positive peaks (log + zoom bug).
+  if (!(yMin > 0) || !(yMax > 0)) {
+    if (!(inVisibleWindowMode && filterX)) {
+      for (let s = 0; s < series.length; s++) {
+        const seriesConfig = series[s];
+        if (seriesConfig.type === 'pie') continue;
+        if (seriesConfig.yAxis !== axisId) continue;
+        const b = runtimeRawBoundsByIndex?.[s] ?? seriesConfig.rawBounds ?? null;
+        if (b && b.yMin > 0 && b.yMax > 0) {
+          if (b.yMin < yMin) yMin = b.yMin;
+          if (b.yMax > yMax) yMax = b.yMax;
+        }
+      }
+    }
+  }
+
+  if (!(yMin > 0) || !(yMax > 0) || !Number.isFinite(yMin) || !Number.isFinite(yMax)) {
+    return { yMin: 1, yMax: 10 };
+  }
+  if (yMin === yMax) yMax = yMin * 10;
+  return { yMin, yMax };
+};
+
+/** Smallest/largest strictly positive finite X across cartesian series (log clamp helper). */
+const computePositiveXBounds = (series: ResolvedChartGPUOptions['series']): { xMin: number; xMax: number } => {
+  let xMin = Number.POSITIVE_INFINITY;
+  let xMax = Number.NEGATIVE_INFINITY;
+  for (let s = 0; s < series.length; s++) {
+    const seriesConfig = series[s];
+    if (seriesConfig.type === 'pie' || seriesConfig.type === 'candlestick') continue;
+    const data = (seriesConfig.rawData ?? seriesConfig.data) as CartesianSeriesData;
+    const n = getPointCount(data);
+    for (let i = 0; i < n; i++) {
+      const x = getX(data, i);
+      if (!Number.isFinite(x) || !(x > 0)) continue;
+      if (x < xMin) xMin = x;
+      if (x > xMax) xMax = x;
+    }
+  }
+  if (!(xMin > 0) || !(xMax > 0) || !Number.isFinite(xMin) || !Number.isFinite(xMax)) {
+    return { xMin: Number.NaN, xMax: Number.NaN };
+  }
+  return { xMin, xMax };
+};
+
 const computeBaseXDomain = (
   options: ResolvedChartGPUOptions,
   runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null
 ): { readonly min: number; readonly max: number } => {
   // Short-circuit when both ends are explicit — avoids O(series) bounds aggregation
-  // on full rewrite frames with fixed axes.
+  // on full rewrite frames with fixed axes. Log still needs positive data extrema
+  // when either end is ≤0 so sanitize can clamp with positiveDataMin.
   const explicitMin = finiteOrUndefined(options.xAxis.min);
   const explicitMax = finiteOrUndefined(options.xAxis.max);
+  const isLog = options.xAxis.type === 'log';
+  const logBase = options.xAxis.logBase ?? 10;
+
   if (explicitMin !== undefined && explicitMax !== undefined) {
-    return normalizeDomain(explicitMin, explicitMax);
+    const raw = normalizeDomain(explicitMin, explicitMax);
+    if (!isLog) return raw;
+    // Always pass positive data extrema when available (docs: clamp via pd×0.5).
+    const pos = computePositiveXBounds(options.series);
+    return sanitizeLogDomain(raw.min, raw.max, {
+      base: logBase,
+      positiveDataMin: pos.xMin > 0 ? pos.xMin : undefined,
+      warn: true,
+      warnKey: 'x',
+    });
   }
   const bounds = computeGlobalXBounds(options.series, runtimeRawBoundsByIndex);
-  const baseMin = explicitMin ?? bounds.xMin;
-  const baseMax = explicitMax ?? bounds.xMax;
+  let baseMin = explicitMin ?? bounds.xMin;
+  let baseMax = explicitMax ?? bounds.xMax;
+  if (isLog) {
+    // Always compute positive extrema so non-positive explicit ends clamp to pd×0.5
+    // (not hard [1, base]) even when the other end is already positive.
+    const pos = computePositiveXBounds(options.series);
+    if (!(baseMin > 0) || !(baseMax > 0)) {
+      if (pos.xMin > 0 && pos.xMax > 0) {
+        baseMin = explicitMin ?? pos.xMin;
+        baseMax = explicitMax ?? pos.xMax;
+      }
+    }
+    return sanitizeLogDomain(baseMin, baseMax, {
+      base: logBase,
+      positiveDataMin: pos.xMin > 0 ? pos.xMin : undefined,
+      warn: true,
+      warnKey: 'x',
+    });
+  }
   return normalizeDomain(baseMin, baseMax);
 };
 
@@ -580,14 +732,33 @@ const computeBaseYDomainForAxis = (
   options: ResolvedChartGPUOptions,
   axisId: string,
   runtimeRawBoundsByIndex?: ReadonlyArray<Bounds | null> | null,
-  visibleBoundsOverride?: { yMin: number; yMax: number } | null
+  visibleBoundsOverride?: { yMin: number; yMax: number } | null,
+  /** Same X window used when computing visibleBoundsOverride (zoom + autoBounds visible). */
+  xWindow?: { readonly min: number; readonly max: number } | null
 ): { readonly min: number; readonly max: number } => {
   const yAxisConfig = options.yAxes.find((ax) => ax.id === axisId) || options.yAxes[0]!;
   const explicitMin = finiteOrUndefined(yAxisConfig.min);
   const explicitMax = finiteOrUndefined(yAxisConfig.max);
+  const isLog = yAxisConfig.type === 'log';
+  const logBase = yAxisConfig.logBase ?? 10;
 
   if (explicitMin !== undefined && explicitMax !== undefined) {
-    return normalizeDomain(explicitMin, explicitMax);
+    const raw = normalizeDomain(explicitMin, explicitMax);
+    if (!isLog) return raw;
+    // Always pass positive data extrema when available (docs: clamp via pd×0.5 / floor-to-power).
+    const pos = computePositiveYBoundsForAxis(
+      options.series,
+      axisId,
+      runtimeRawBoundsByIndex,
+      visibleBoundsOverride,
+      xWindow
+    );
+    return sanitizeLogDomain(raw.min, raw.max, {
+      base: logBase,
+      positiveDataMin: pos.yMin > 0 ? pos.yMin : undefined,
+      warn: true,
+      warnKey: `y:${axisId}`,
+    });
   }
 
   const autoBoundsMode = yAxisConfig.autoBounds ?? 'visible';
@@ -599,8 +770,31 @@ const computeBaseYDomainForAxis = (
     bounds = computeGlobalYBoundsForAxis(options.series, axisId, runtimeRawBoundsByIndex);
   }
 
-  const yMin = explicitMin ?? bounds.yMin;
-  const yMax = explicitMax ?? bounds.yMax;
+  // Log axes: only positive finite values contribute to auto domain.
+  let yMin = explicitMin ?? bounds.yMin;
+  let yMax = explicitMax ?? bounds.yMax;
+  if (isLog) {
+    // Always compute positive extrema so non-positive explicit ends clamp to pd×0.5
+    // even when the other end is already positive (or both explicit above).
+    // When override includes ≤0 under zoom, re-scan positives inside xWindow only.
+    const pos = computePositiveYBoundsForAxis(
+      options.series,
+      axisId,
+      runtimeRawBoundsByIndex,
+      visibleBoundsOverride,
+      xWindow
+    );
+    if (!(yMin > 0) || !(yMax > 0)) {
+      yMin = explicitMin ?? pos.yMin;
+      yMax = explicitMax ?? pos.yMax;
+    }
+    return sanitizeLogDomain(yMin, yMax, {
+      base: logBase,
+      positiveDataMin: pos.yMin > 0 ? pos.yMin : undefined,
+      warn: true,
+      warnKey: `y:${axisId}`,
+    });
+  }
   return normalizeDomain(yMin, yMax);
 };
 
@@ -646,10 +840,10 @@ type IntroPhase = 'pending' | 'running' | 'done';
  */
 
 const createAnimatedBarYScale = (
-  baseYScale: LinearScale,
+  baseYScale: ContinuousScale,
   plotClipRect: Readonly<{ top: number; bottom: number }>,
   progress01: number
-): LinearScale => {
+): ContinuousScale => {
   const p = clamp01(progress01);
   if (p >= 1) return baseYScale;
 
@@ -658,7 +852,9 @@ const createAnimatedBarYScale = (
   const yMin = Math.min(yDomainA, yDomainB);
   const yMax = Math.max(yDomainA, yDomainB);
 
-  const wrapper: LinearScale = {
+  const wrapper: ContinuousScale = {
+    kind: baseYScale.kind,
+    base: baseYScale.base,
     domain(min: number, max: number) {
       baseYScale.domain(min, max);
       return wrapper;
@@ -666,6 +862,12 @@ const createAnimatedBarYScale = (
     range(min: number, max: number) {
       baseYScale.range(min, max);
       return wrapper;
+    },
+    getDomain() {
+      return baseYScale.getDomain();
+    },
+    getRange() {
+      return baseYScale.getRange();
     },
     scale(value: number) {
       // Domain-space intro growth from zero-line (or domain min) via animationHelpers.
@@ -930,14 +1132,28 @@ export function createRenderCoordinator(
     t01: number,
     zoomRange: ZoomRange | null
   ): UpdateTransitionSnapshot => {
-    const xBase = lerpDomain(transition.from.xBaseDomain, transition.to.xBaseDomain, t01);
+    let xBase =
+      currentOptions.xAxis.type === 'log'
+        ? lerpLogDomain(transition.from.xBaseDomain, transition.to.xBaseDomain, t01)
+        : lerpDomain(transition.from.xBaseDomain, transition.to.xBaseDomain, t01);
+    if (currentOptions.xAxis.type === 'log') {
+      xBase = sanitizeLogDomain(xBase.min, xBase.max, {
+        base: currentOptions.xAxis.logBase ?? 10,
+        warn: false,
+      });
+    }
     const xVisible = computeVisibleXDomain(xBase, zoomRange);
     const yBaseDomains = new Map<string, { readonly min: number; readonly max: number }>();
     for (const ax of transition.from.series[0] ? currentOptions.yAxes : []) {
       const axId = ax.id!;
       const fromY = transition.from.yBaseDomains.get(axId) || { min: 0, max: 1 };
       const toY = transition.to.yBaseDomains.get(axId) || { min: 0, max: 1 };
-      yBaseDomains.set(axId, lerpDomain(fromY, toY, t01));
+      if (ax.type === 'log') {
+        const lerped = lerpLogDomain(fromY, toY, t01);
+        yBaseDomains.set(axId, sanitizeLogDomain(lerped.min, lerped.max, { base: ax.logBase ?? 10, warn: false }));
+      } else {
+        yBaseDomains.set(axId, lerpDomain(fromY, toY, t01));
+      }
     }
     const series = interpolateSeriesForUpdate(transition.from.series, transition.to.series, t01, null);
     return {
@@ -983,6 +1199,8 @@ export function createRenderCoordinator(
    */
   let stickyAutoXDomain: { min: number; max: number } | null = null;
   const stickyAutoYDomainByAxis = new Map<string, { min: number; max: number }>();
+  /** X window last used for cachedVisibleYBoundsByAxis (null = full span / no filter). */
+  let cachedVisibleYBoundsXWindow: { min: number; max: number } | null = null;
 
   /**
    * Base X domain used for zoom→visible window, sampling, and slice.
@@ -1019,6 +1237,17 @@ export function createRenderCoordinator(
         return dataXDomain;
       }
       // X headroom must be 0 — see DEFAULT_STICKY_X_DOMAIN_HEADROOM.
+      // Log X: sticky in log space so equal-span expand uses min*base, not min+1.
+      if (currentOptions.xAxis.type === 'log') {
+        const next = applyStickyAutoLogDomain(
+          dataXDomain,
+          stickyAutoXDomain,
+          currentOptions.xAxis.logBase ?? 10,
+          DEFAULT_STICKY_X_DOMAIN_HEADROOM
+        );
+        stickyAutoXDomain = next;
+        return next;
+      }
       const next = applyStickyAutoDomain(dataXDomain, stickyAutoXDomain, DEFAULT_STICKY_X_DOMAIN_HEADROOM);
       stickyAutoXDomain = next;
       return next;
@@ -1056,6 +1285,7 @@ export function createRenderCoordinator(
       const vis = computeVisibleXDomain(baseX, zoomRange);
       xWindow = { min: vis.min, max: vis.max };
     }
+    cachedVisibleYBoundsXWindow = xWindow;
 
     for (const ax of currentOptions.yAxes) {
       if (!shouldComputeVisibleYBoundsForAxis(currentOptions, ax.id!)) continue;
@@ -1506,10 +1736,13 @@ export function createRenderCoordinator(
     const plotSize = getPlotSizeCssPx(canvas, gridArea);
     if (!plotSize) return null;
 
-    const xScale = createLinearScale().domain(domains.xDomain.min, domains.xDomain.max).range(0, plotSize.plotWidthCss);
-    const yScales = new Map<string, LinearScale>();
+    const xScale = createAxisScale(currentOptions.xAxis)
+      .domain(domains.xDomain.min, domains.xDomain.max)
+      .range(0, plotSize.plotWidthCss);
+    const yScales = new Map<string, ContinuousScale>();
     for (const [id, dom] of domains.yDomains) {
-      yScales.set(id, createLinearScale().domain(dom.min, dom.max).range(plotSize.plotHeightCss, 0));
+      const yAxisCfg = currentOptions.yAxes.find((a) => a.id === id) ?? currentOptions.yAxes[0]!;
+      yScales.set(id, createAxisScale(yAxisCfg).domain(dom.min, dom.max).range(plotSize.plotHeightCss, 0));
     }
 
     return {
@@ -2121,7 +2354,8 @@ export function createRenderCoordinator(
             currentOptions,
             ax.id!,
             runtimeRawBoundsByIndex,
-            cachedVisibleYBoundsByAxis.get(ax.id!) ?? null
+            cachedVisibleYBoundsByAxis.get(ax.id!) ?? null,
+            cachedVisibleYBoundsXWindow
           )
         );
       }
@@ -2160,6 +2394,7 @@ export function createRenderCoordinator(
 
     // Always refresh: annotations, themes, tooltip config, etc. may have changed.
     cachedVisibleYBoundsByAxis.clear();
+    cachedVisibleYBoundsXWindow = null;
     // Drop sticky auto-range so setOption (axes-only y min/max, full rewrite)
     // does not keep a prior streaming headroom domain.
     stickyAutoXDomain = null;
@@ -2246,6 +2481,27 @@ export function createRenderCoordinator(
       recomputeCachedVisibleYBoundsIfNeeded();
     }
 
+    // Candlestick streaming: consumer may mutate a stable OHLC array (forming
+    // bar) and call setOption. Presentation-only dirty checks treat same-ref
+    // data as unchanged, while the coordinator keeps a sliced owned copy for
+    // appendData — copy user edits into owned so prepare/geometry see them.
+    {
+      const candleSync = syncCandlestickOwnedFromUserSeries({
+        series: resolvedOptions.series,
+        runtimeRawDataByIndex,
+        runtimeRawBoundsByIndex,
+        extendBounds: extendBoundsWithOHLCDataPoints,
+      });
+      if (candleSync.didReplaceRef) {
+        recomputeRuntimeBaseSeries();
+        recomputeRenderSeries();
+      } else if (candleSync.didMutate) {
+        // Owned array mutated in place (same ref as renderSeries.data). Refresh
+        // y-bounds so auto domain tracks the forming bar high/low.
+        recomputeCachedVisibleYBoundsIfNeeded();
+      }
+    }
+
     // Tooltip enablement may change at runtime.
     if (overlayContainer) {
       const shouldHaveTooltip = currentOptions.tooltip?.show !== false;
@@ -2304,7 +2560,8 @@ export function createRenderCoordinator(
           currentOptions,
           ax.id!,
           runtimeRawBoundsByIndex,
-          cachedVisibleYBoundsByAxis.get(ax.id!) ?? null
+          cachedVisibleYBoundsByAxis.get(ax.id!) ?? null,
+          cachedVisibleYBoundsXWindow
         )
       );
     }
@@ -2518,7 +2775,16 @@ export function createRenderCoordinator(
 
     const updateP = updateTransition ? clamp01(updateProgress01) : 1;
     const dataXDomain = updateTransition
-      ? lerpDomain(updateTransition.from.xBaseDomain, updateTransition.to.xBaseDomain, updateP)
+      ? (() => {
+          const fromX = updateTransition.from.xBaseDomain;
+          const toX = updateTransition.to.xBaseDomain;
+          if (currentOptions.xAxis.type === 'log') {
+            const base = currentOptions.xAxis.logBase ?? 10;
+            const lerped = lerpLogDomain(fromX, toX, updateP);
+            return sanitizeLogDomain(lerped.min, lerped.max, { base, warn: false });
+          }
+          return lerpDomain(fromX, toX, updateP);
+        })()
       : computeBaseXDomain(currentOptions, runtimeRawBoundsByIndex);
     // Sticky auto-range / autoScroll / mid-transition: shared with slice + resample
     // via resolveBaseXDomain so zoom-percent windows match GPU scales.
@@ -2531,12 +2797,12 @@ export function createRenderCoordinator(
     const plotClipRect = computePlotClipRect(gridArea);
     const plotScissor = computePlotScissorDevicePx(gridArea);
 
-    const xScale = createLinearScale()
+    const xScale = createAxisScale(currentOptions.xAxis)
       .domain(visibleXDomain.min, visibleXDomain.max)
       .range(plotClipRect.left, plotClipRect.right);
 
     // Compute per-axis y domains (with transition interpolation if active)
-    const currentYScales = new Map<string, LinearScale>();
+    const currentYScales = new Map<string, ContinuousScale>();
     const currentYDomains = new Map<string, { readonly min: number; readonly max: number }>();
     for (const ax of currentOptions.yAxes) {
       const axisId = ax.id!;
@@ -2544,14 +2810,21 @@ export function createRenderCoordinator(
       if (updateTransition && updateP < 1) {
         const fromY = updateTransition.from.yBaseDomains.get(axisId) ?? { min: 0, max: 1 };
         const toY = updateTransition.to.yBaseDomains.get(axisId) ?? { min: 0, max: 1 };
-        dom = lerpDomain(fromY, toY, updateP);
+        if (ax.type === 'log') {
+          const base = ax.logBase ?? 10;
+          const lerped = lerpLogDomain(fromY, toY, updateP);
+          dom = sanitizeLogDomain(lerped.min, lerped.max, { base, warn: false });
+        } else {
+          dom = lerpDomain(fromY, toY, updateP);
+        }
         stickyAutoYDomainByAxis.delete(axisId);
       } else {
         const dataDom = computeBaseYDomainForAxis(
           currentOptions,
           axisId,
           runtimeRawBoundsByIndex,
-          cachedVisibleYBoundsByAxis.get(axisId) ?? null
+          cachedVisibleYBoundsByAxis.get(axisId) ?? null,
+          cachedVisibleYBoundsXWindow
         );
         const yExplicitMin = finiteOrUndefined(ax.min);
         const yExplicitMax = finiteOrUndefined(ax.max);
@@ -2559,6 +2832,15 @@ export function createRenderCoordinator(
         if (!shouldApplyStickyAutoDomain(yExplicitMin, yExplicitMax)) {
           dom = dataDom;
           stickyAutoYDomainByAxis.delete(axisId);
+        } else if (ax.type === 'log') {
+          const next = applyStickyAutoLogDomain(
+            dataDom,
+            stickyAutoYDomainByAxis.get(axisId) ?? null,
+            ax.logBase ?? 10,
+            DEFAULT_STICKY_DOMAIN_HEADROOM
+          );
+          stickyAutoYDomainByAxis.set(axisId, next);
+          dom = next;
         } else {
           const next = applyStickyAutoDomain(
             dataDom,
@@ -2572,7 +2854,7 @@ export function createRenderCoordinator(
       currentYDomains.set(axisId, dom);
       currentYScales.set(
         axisId,
-        createLinearScale().domain(dom.min, dom.max).range(plotClipRect.bottom, plotClipRect.top)
+        createAxisScale(ax).domain(dom.min, dom.max).range(plotClipRect.bottom, plotClipRect.top)
       );
     }
     // Primary y scale (for bars, highlight, single-axis usage)
@@ -2652,10 +2934,21 @@ export function createRenderCoordinator(
       });
       xTickCount = computed.tickCount;
       xTickValues = computed.tickValues;
+    } else if (currentOptions.xAxis.type === 'log') {
+      // Always tick the *visible* scale domain (zoom/pan), not full explicit xAxis.min/max.
+      // Explicit min/max still define the base domain; only placement follows the window.
+      // densify when zoom leaves few decade majors; pure generateLogTicks is the major fallback.
+      const domainMin = visibleXDomain.min;
+      const domainMax = visibleXDomain.max;
+      const logBase = currentOptions.xAxis.logBase ?? 10;
+      const densified = generateLogTicksForVisibleDomain(domainMin, domainMax, logBase);
+      xTickValues = densified.length > 0 ? densified : generateLogTicks(domainMin, domainMax, logBase);
+      xTickCount = Math.max(1, xTickValues.length);
     } else {
-      // Keep existing behavior for non-time x axes.
-      const domainMin = finiteOrUndefined(currentOptions.xAxis.min) ?? xScale.invert(plotClipRect.left);
-      const domainMax = finiteOrUndefined(currentOptions.xAxis.max) ?? xScale.invert(plotClipRect.right);
+      // Value / category: tick the visible window so labels stay in-plot under zoom.
+      // Without zoom, visibleXDomain matches the base (incl. explicit min/max).
+      const domainMin = visibleXDomain.min;
+      const domainMax = visibleXDomain.max;
       xTickValues = generateLinearTicks(domainMin, domainMax, xTickCount);
     }
 
@@ -3360,16 +3653,24 @@ export function createRenderCoordinator(
       labelSig += `epoch:${axisLabelContentEpoch}|xr:${visibleXRangeMs}|xt:${currentOptions.xAxis.type ?? ''}|`;
       labelSig += `x:${currentOptions.xAxis.name ?? ''}|`;
       labelSig += `th:${tickHash >>> 0}|`;
-      labelSig += `xs:${xScale.scale(0)},${xScale.scale(1)}|`;
+      {
+        const xd = xScale.getDomain();
+        const xs0 = xScale.kind === 'log' ? xScale.scale(xd.min) : xScale.scale(0);
+        const xs1 = xScale.kind === 'log' ? xScale.scale(xd.max) : xScale.scale(1);
+        labelSig += `xs:${xs0},${xs1}|xk:${xScale.kind}|xb:${xScale.base ?? ''}|`;
+      }
       for (const yAxisConfig of currentOptions.yAxes) {
         const axisId = yAxisConfig.id!;
         const yScaleForAxis = currentYScales.get(axisId);
         if (!yScaleForAxis) continue;
         const yTickCount = (yAxisConfig as { tickCount?: number }).tickCount ?? 5;
+        const yd = yScaleForAxis.getDomain();
+        const ys0 = yScaleForAxis.kind === 'log' ? yScaleForAxis.scale(yd.min) : yScaleForAxis.scale(0);
+        const ys1 = yScaleForAxis.kind === 'log' ? yScaleForAxis.scale(yd.max) : yScaleForAxis.scale(1);
         labelSig += `y:${axisId}:${yAxisConfig.name ?? ''}:${yAxisConfig.position ?? 'left'}:`;
-        labelSig += `${yScaleForAxis.scale(0)},${yScaleForAxis.scale(1)}:${yTickCount}|`;
+        labelSig += `${ys0},${ys1}:${yTickCount}|`;
         // Y axis type can affect tick formatting when present.
-        labelSig += `yt:${(yAxisConfig as { type?: string }).type ?? ''};`;
+        labelSig += `yt:${yAxisConfig.type ?? ''};yb:${yAxisConfig.logBase ?? ''};`;
       }
       if (labelSig !== lastAxisLabelDomSignature) {
         lastAxisLabelDomSignature = labelSig;

--- a/src/core/renderCoordinator/data/__tests__/syncCandlestickRuntime.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/syncCandlestickRuntime.test.ts
@@ -1,0 +1,121 @@
+/**
+ * syncCandlestickOwnedFromUserSeries — forming-bar / length resync for setOption.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OHLCDataPoint } from '../../../../config/types';
+import { extendBoundsWithOHLCDataPoints } from '../../utils/boundsComputation';
+import { syncCandlestickOwnedFromUserSeries } from '../syncCandlestickRuntime';
+
+const candle = (t: number, o: number, c: number, l: number, h: number): OHLCDataPoint => [t, o, c, l, h];
+
+function seriesWithData(data: OHLCDataPoint[]) {
+  return [{ type: 'candlestick' as const, data, rawData: data }] as any;
+}
+
+describe('syncCandlestickOwnedFromUserSeries', () => {
+  it('no-ops when owned is the same array as user data', () => {
+    const data = [candle(0, 1, 2, 0.5, 2.5)];
+    const runtimeRawDataByIndex: unknown[] = [data];
+    const runtimeRawBoundsByIndex: any[] = [null];
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(data),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+    expect(result.didMutate).toBe(false);
+    expect(runtimeRawDataByIndex[0]).toBe(data);
+  });
+
+  it('copies last candle into owned when consumer mutates forming bar (same length)', () => {
+    const user = [candle(0, 10, 11, 9, 12), candle(1, 11, 11, 11, 11)];
+    const owned = [candle(0, 10, 11, 9, 12), candle(1, 11, 11, 11, 11)];
+    const runtimeRawDataByIndex: unknown[] = [owned];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    // Forming bar: close/high moved on consumer array only.
+    user[1] = candle(1, 11, 16, 10, 17);
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(result.didReplaceRef).toBe(false);
+    expect(runtimeRawDataByIndex[0]).toBe(owned); // same owned ref
+    expect(owned[1]).toEqual(candle(1, 11, 16, 10, 17));
+    expect(owned[0]).toEqual(candle(0, 10, 11, 9, 12));
+  });
+
+  it('appends onto owned when consumer array grew (stable owned ref)', () => {
+    const user = [candle(0, 10, 11, 9, 12), candle(1, 11, 12, 10, 13)];
+    const owned = [candle(0, 10, 11, 9, 12)];
+    const runtimeRawDataByIndex: unknown[] = [owned];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(runtimeRawDataByIndex[0]).toBe(owned);
+    expect(owned).toHaveLength(2);
+    expect(owned[1]).toEqual(candle(1, 11, 12, 10, 13));
+  });
+
+  it('truncates owned when consumer array shrank', () => {
+    const user = [candle(0, 10, 11, 9, 12)];
+    const owned = [candle(0, 10, 11, 9, 12), candle(1, 11, 12, 10, 13)];
+    const runtimeRawDataByIndex: unknown[] = [owned];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(owned).toHaveLength(1);
+    expect(owned[0]).toEqual(candle(0, 10, 11, 9, 12));
+  });
+
+  it('seeds owned with a slice when slot is empty', () => {
+    const user = [candle(0, 1, 2, 0.5, 2.5)];
+    const runtimeRawDataByIndex: unknown[] = [null];
+    const runtimeRawBoundsByIndex: any[] = [null];
+
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: seriesWithData(user),
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+
+    expect(result.didMutate).toBe(true);
+    expect(result.didReplaceRef).toBe(true);
+    expect(runtimeRawDataByIndex[0]).not.toBe(user);
+    expect(runtimeRawDataByIndex[0]).toEqual(user);
+  });
+
+  it('skips non-candlestick series', () => {
+    const runtimeRawDataByIndex: unknown[] = [null];
+    const runtimeRawBoundsByIndex: any[] = [null];
+    const result = syncCandlestickOwnedFromUserSeries({
+      series: [{ type: 'line', data: [[0, 1]] }] as any,
+      runtimeRawDataByIndex,
+      runtimeRawBoundsByIndex,
+      extendBounds: extendBoundsWithOHLCDataPoints,
+    });
+    expect(result.didMutate).toBe(false);
+    expect(runtimeRawDataByIndex[0]).toBeNull();
+  });
+});

--- a/src/core/renderCoordinator/data/syncCandlestickRuntime.ts
+++ b/src/core/renderCoordinator/data/syncCandlestickRuntime.ts
@@ -1,0 +1,140 @@
+/**
+ * Resync coordinator-owned OHLC from consumer series data on setOption.
+ *
+ * Streaming examples (e.g. candlestick-streaming) keep a stable OHLC array,
+ * mutate the forming bar in place, and call setOption. The coordinator stores a
+ * **sliced owned copy** for appendData, so presentation-only setOption (same
+ * data ref → didSeriesDataLikelyChange false) would never update what the
+ * candlestick renderer packs unless we copy user edits into the owned store.
+ *
+ * Prefers in-place mutation of the owned array so geometry identity can keep
+ * the same data ref while length / last-candle fingerprints force re-upload.
+ *
+ * @module syncCandlestickRuntime
+ * @internal
+ */
+
+import type { ResolvedSeriesConfig } from '../../../config/OptionResolver';
+import type { OHLCDataPoint } from '../../../config/types';
+import { isTupleOHLCDataPoint } from '../utils/dataPointUtils';
+
+type OhlcBounds = Readonly<{
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}>;
+
+type SyncCandlestickRuntimeResult = {
+  /** True when any owned OHLC slot was written. */
+  readonly didMutate: boolean;
+  /** True when an owned array was replaced (new ref) — caller should recompute baseline. */
+  readonly didReplaceRef: boolean;
+  /** Series indices that were mutated. */
+  readonly indices: readonly number[];
+};
+
+const ohlcEqual = (a: OHLCDataPoint, b: OHLCDataPoint): boolean => {
+  if (a === b) return true;
+  if (isTupleOHLCDataPoint(a) && isTupleOHLCDataPoint(b)) {
+    return a[0] === b[0] && a[1] === b[1] && a[2] === b[2] && a[3] === b[3] && a[4] === b[4];
+  }
+  if (!isTupleOHLCDataPoint(a) && !isTupleOHLCDataPoint(b)) {
+    return (
+      a.timestamp === b.timestamp && a.open === b.open && a.close === b.close && a.low === b.low && a.high === b.high
+    );
+  }
+  // Mixed shapes: normalize via tuple fields.
+  const at = isTupleOHLCDataPoint(a) ? a : ([a.timestamp, a.open, a.close, a.low, a.high] as const);
+  const bt = isTupleOHLCDataPoint(b) ? b : ([b.timestamp, b.open, b.close, b.low, b.high] as const);
+  return at[0] === bt[0] && at[1] === bt[1] && at[2] === bt[2] && at[3] === bt[3] && at[4] === bt[4];
+};
+
+/**
+ * Copy consumer candlestick OHLC into coordinator-owned runtime slots.
+ *
+ * @param extendBounds - Bounds helper (injected for testability)
+ */
+export function syncCandlestickOwnedFromUserSeries(input: {
+  readonly series: ReadonlyArray<ResolvedSeriesConfig>;
+  readonly runtimeRawDataByIndex: unknown[];
+  readonly runtimeRawBoundsByIndex: Array<OhlcBounds | null>;
+  readonly extendBounds: (bounds: OhlcBounds | null, points: ReadonlyArray<OHLCDataPoint>) => OhlcBounds | null;
+}): SyncCandlestickRuntimeResult {
+  const { series, runtimeRawDataByIndex, runtimeRawBoundsByIndex, extendBounds } = input;
+  const indices: number[] = [];
+  let didMutate = false;
+  let didReplaceRef = false;
+
+  for (let i = 0; i < series.length; i++) {
+    const s = series[i]!;
+    if (s.type !== 'candlestick') continue;
+
+    const user = ((s as { rawData?: unknown; data?: unknown }).rawData ?? (s as { data?: unknown }).data) as
+      | ReadonlyArray<OHLCDataPoint>
+      | null
+      | undefined;
+    if (user == null || !Array.isArray(user)) continue;
+
+    const existing = runtimeRawDataByIndex[i];
+
+    // Same array identity as the consumer: already shared; mutations are visible.
+    if (existing === user) {
+      continue;
+    }
+
+    // No owned slot yet — take a copy (matches initRuntimeSeriesFromOptions).
+    if (existing == null || !Array.isArray(existing)) {
+      runtimeRawDataByIndex[i] = user.slice();
+      runtimeRawBoundsByIndex[i] = extendBounds(null, user);
+      didMutate = true;
+      didReplaceRef = true;
+      indices.push(i);
+      continue;
+    }
+
+    const owned = existing as OHLCDataPoint[];
+
+    if (owned.length !== user.length) {
+      // Length mismatch: rewrite owned contents in place when possible to keep
+      // the array ref stable for geometry identity (length fingerprint re-packs).
+      if (user.length > owned.length) {
+        for (let j = 0; j < owned.length; j++) {
+          if (!ohlcEqual(owned[j]!, user[j]!)) {
+            owned[j] = user[j]!;
+          }
+        }
+        for (let j = owned.length; j < user.length; j++) {
+          owned.push(user[j]!);
+        }
+      } else {
+        // Truncate then copy.
+        owned.length = user.length;
+        for (let j = 0; j < user.length; j++) {
+          owned[j] = user[j]!;
+        }
+      }
+      runtimeRawBoundsByIndex[i] = extendBounds(null, owned);
+      didMutate = true;
+      indices.push(i);
+      continue;
+    }
+
+    // Same length, different refs (owned slice vs consumer array): streaming
+    // forming-bar path mutates only the last candle under a stable consumer ref.
+    // O(1) last-candle sync; mid-series in-place edits should pass a new array ref.
+    if (user.length === 0) continue;
+
+    const lastIdx = user.length - 1;
+    const userLast = user[lastIdx]!;
+    const ownedLast = owned[lastIdx]!;
+    if (!ohlcEqual(ownedLast, userLast)) {
+      owned[lastIdx] = userLast;
+      runtimeRawBoundsByIndex[i] = extendBounds(runtimeRawBoundsByIndex[i], [userLast]);
+      didMutate = true;
+      indices.push(i);
+    }
+  }
+
+  return { didMutate, didReplaceRef, indices };
+}

--- a/src/core/renderCoordinator/render/__tests__/renderAxisLabels.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/renderAxisLabels.test.ts
@@ -82,6 +82,7 @@ function createMinimalContext(overrides: Partial<AxisLabelRenderContext> = {}): 
     xScale: {
       scale: (v: number) => -1 + (v / 100) * 2, // maps 0-100 to -1..+1
       invert: (c: number) => ((c + 1) / 2) * 100,
+      getDomain: () => ({ min: 0, max: 100 }),
     } as any,
     yScales: new Map([
       [
@@ -89,6 +90,7 @@ function createMinimalContext(overrides: Partial<AxisLabelRenderContext> = {}): 
         {
           scale: (v: number) => -1 + (v / 100) * 2,
           invert: (c: number) => ((c + 1) / 2) * 100,
+          getDomain: () => ({ min: 0, max: 100 }),
         } as any,
       ],
     ]),

--- a/src/core/renderCoordinator/render/overlayPrepareMemo.ts
+++ b/src/core/renderCoordinator/render/overlayPrepareMemo.ts
@@ -10,7 +10,7 @@
  */
 
 import type { AxisConfig } from '../../../config/types';
-import type { LinearScale } from '../../../utils/scales';
+import type { ContinuousScale, LinearScale } from '../../../utils/scales';
 import type { GridArea } from '../../../renderers/createGridRenderer';
 
 /** Compact layout + grid line inputs that affect grid vertex/color uploads. */
@@ -27,6 +27,13 @@ interface GridPrepareSignature {
   readonly horizontalColor: string;
   readonly verticalColor: string;
   readonly show: boolean;
+  /** Tick-aligned clip Y positions (log grid); empty when even-count. */
+  readonly horizontalClipYs: readonly number[];
+  /** Tick-aligned clip X positions (log grid); empty when even-count. */
+  readonly verticalClipXs: readonly number[];
+  readonly xScaleKind: 'linear' | 'log';
+  readonly yScaleKind: 'linear' | 'log';
+  readonly logBase: number;
 }
 
 /** Compact axis inputs that affect axis vertex/color uploads. */
@@ -40,10 +47,14 @@ interface AxisPrepareSignature {
   readonly canvasWidth: number;
   readonly canvasHeight: number;
   readonly devicePixelRatio: number;
-  /** Affine sample: scale.scale(0) */
+  /** Affine sample: scale.scale(0) — linear; log uses domain endpoints via scaleKind. */
   readonly scaleAt0: number;
   /** Affine sample: scale.scale(1) */
   readonly scaleAt1: number;
+  readonly scaleKind: 'linear' | 'log';
+  readonly scaleBase: number;
+  readonly domainMin: number;
+  readonly domainMax: number;
   readonly tickCount: number;
   /**
    * Explicit tick domain values (e.g. nice time ticks). Empty when using linear-from-count only.
@@ -84,6 +95,14 @@ export function clearOverlayPrepareMemo(memo: OverlayPrepareMemo): void {
   memo.yAxes.clear();
 }
 
+const clipPosEqual = (a: readonly number[], b: readonly number[]): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
 export function buildGridPrepareSignature(input: {
   readonly gridArea: GridArea;
   readonly show: boolean;
@@ -91,6 +110,11 @@ export function buildGridPrepareSignature(input: {
   readonly verticalCount: number;
   readonly horizontalColor: string;
   readonly verticalColor: string;
+  readonly horizontalClipYs?: readonly number[];
+  readonly verticalClipXs?: readonly number[];
+  readonly xScaleKind?: 'linear' | 'log';
+  readonly yScaleKind?: 'linear' | 'log';
+  readonly logBase?: number;
 }): GridPrepareSignature {
   const { gridArea } = input;
   return {
@@ -106,6 +130,11 @@ export function buildGridPrepareSignature(input: {
     horizontalColor: input.horizontalColor,
     verticalColor: input.verticalColor,
     show: input.show,
+    horizontalClipYs: input.horizontalClipYs != null ? input.horizontalClipYs.slice() : [],
+    verticalClipXs: input.verticalClipXs != null ? input.verticalClipXs.slice() : [],
+    xScaleKind: input.xScaleKind ?? 'linear',
+    yScaleKind: input.yScaleKind ?? 'linear',
+    logBase: input.logBase ?? 10,
   };
 }
 
@@ -123,7 +152,12 @@ export function gridPrepareSignaturesEqual(a: GridPrepareSignature | null, b: Gr
     a.verticalCount === b.verticalCount &&
     a.horizontalColor === b.horizontalColor &&
     a.verticalColor === b.verticalColor &&
-    a.show === b.show
+    a.show === b.show &&
+    clipPosEqual(a.horizontalClipYs, b.horizontalClipYs) &&
+    clipPosEqual(a.verticalClipXs, b.verticalClipXs) &&
+    a.xScaleKind === b.xScaleKind &&
+    a.yScaleKind === b.yScaleKind &&
+    a.logBase === b.logBase
   );
 }
 
@@ -137,7 +171,7 @@ const tickValuesEqual = (a: readonly number[], b: readonly number[]): boolean =>
 
 export function buildAxisPrepareSignature(input: {
   readonly axisConfig: AxisConfig;
-  readonly scale: LinearScale;
+  readonly scale: ContinuousScale | LinearScale;
   readonly orientation: 'x' | 'y';
   readonly axisId: string;
   readonly gridArea: GridArea;
@@ -149,6 +183,10 @@ export function buildAxisPrepareSignature(input: {
 }): AxisPrepareSignature {
   const { gridArea, scale, axisConfig } = input;
   const tickValues = input.tickValues != null && input.tickValues.length > 0 ? input.tickValues.slice() : [];
+  const domain = typeof scale.getDomain === 'function' ? scale.getDomain() : { min: Number.NaN, max: Number.NaN };
+  // Linear: sample 0/1 for affine identity. Log: 0 is invalid — sample domain endpoints.
+  const scaleAt0 = scale.kind === 'log' ? scale.scale(domain.min) : scale.scale(0);
+  const scaleAt1 = scale.kind === 'log' ? scale.scale(domain.max) : scale.scale(1);
   return {
     orientation: input.orientation,
     axisId: input.axisId,
@@ -159,8 +197,12 @@ export function buildAxisPrepareSignature(input: {
     canvasWidth: gridArea.canvasWidth,
     canvasHeight: gridArea.canvasHeight,
     devicePixelRatio: gridArea.devicePixelRatio,
-    scaleAt0: scale.scale(0),
-    scaleAt1: scale.scale(1),
+    scaleAt0,
+    scaleAt1,
+    scaleKind: scale.kind ?? 'linear',
+    scaleBase: scale.base ?? 10,
+    domainMin: domain.min,
+    domainMax: domain.max,
     tickCount: input.tickCount,
     tickValues,
     tickLength: axisConfig.tickLength,
@@ -189,6 +231,10 @@ export function axisPrepareSignaturesEqual(
     a.devicePixelRatio === b.devicePixelRatio &&
     a.scaleAt0 === b.scaleAt0 &&
     a.scaleAt1 === b.scaleAt1 &&
+    a.scaleKind === b.scaleKind &&
+    a.scaleBase === b.scaleBase &&
+    a.domainMin === b.domainMin &&
+    a.domainMax === b.domainMax &&
     a.tickCount === b.tickCount &&
     tickValuesEqual(a.tickValues, b.tickValues) &&
     a.tickLength === b.tickLength &&

--- a/src/core/renderCoordinator/render/renderAxisLabels.ts
+++ b/src/core/renderCoordinator/render/renderAxisLabels.ts
@@ -10,12 +10,17 @@
 
 import type { ResolvedChartGPUOptions } from '../../../config/OptionResolver';
 import type { AxisConfig } from '../../../config/types';
-import type { LinearScale } from '../../../utils/scales';
+import type { ContinuousScale, LinearScale } from '../../../utils/scales';
 import type { TextOverlay, TextOverlayAnchor } from '../../../components/createTextOverlay';
 import { getCanvasCssWidth, getCanvasCssHeight } from '../utils/canvasUtils';
 import { formatTimeTickValue } from '../utils/timeAxisUtils';
-import { formatTickValue, createTickFormatter } from '../axis/computeAxisTicks';
-import { finiteOrUndefined } from '../utils/dataPointUtils';
+import {
+  formatTickValue,
+  createTickFormatter,
+  formatLogTickValue,
+  generateLogTicksForVisibleDomain,
+  generateLinearTicks,
+} from '../axis/computeAxisTicks';
 import { getAxisTitleFontSize } from '../../../utils/axisLabelStyling';
 import { getRightYAxisLabelX, getYAxisLabelX, getRightYAxisTitleX, getYAxisTitleX } from '../axis/axisLabelHelpers';
 
@@ -27,7 +32,7 @@ const DEFAULT_TICK_COUNT = 5;
 interface AxisLabelRenderContext {
   readonly gpuContext: { readonly canvas: HTMLCanvasElement | null };
   readonly currentOptions: ResolvedChartGPUOptions;
-  readonly xScale: LinearScale;
+  readonly xScale: ContinuousScale | LinearScale;
   readonly xTickValues: readonly number[];
   readonly plotClipRect: { left: number; right: number; top: number; bottom: number };
   readonly visibleXRangeMs: number;
@@ -38,13 +43,15 @@ interface YAxisLabelRenderContext {
   readonly axisLabelOverlay: TextOverlay | null;
   readonly overlayContainer: HTMLElement | null;
   readonly yAxisConfig: AxisConfig;
-  readonly yScale: LinearScale;
+  readonly yScale: ContinuousScale | LinearScale;
   readonly plotClipRect: { left: number; right: number; top: number; bottom: number };
   readonly canvasCssWidth: number;
   readonly canvasCssHeight: number;
   readonly offsetX: number;
   readonly offsetY: number;
   readonly theme: ResolvedChartGPUOptions['theme'];
+  /** Optional precomputed tick domain values (log majors). */
+  readonly yTickValues?: readonly number[];
 }
 
 function clipXToCanvasCssPx(xClip: number, canvasCssWidth: number): number {
@@ -102,12 +109,19 @@ export function renderAxisLabels(
   const xTickLengthCssPx = currentOptions.xAxis.tickLength ?? DEFAULT_TICK_LENGTH_CSS_PX;
   const xLabelY = plotBottomCss + xTickLengthCssPx + LABEL_PADDING_CSS_PX + currentOptions.theme.fontSize * 0.5;
   const isTimeXAxis = currentOptions.xAxis.type === 'time';
+  const isLogXAxis = currentOptions.xAxis.type === 'log';
+  const xLogBase = currentOptions.xAxis.logBase ?? 10;
   const xFormatter = (() => {
-    if (isTimeXAxis) return null;
-    const xDomainMin = finiteOrUndefined(currentOptions.xAxis.min) ?? xScale.invert(plotClipRect.left);
-    const xDomainMax = finiteOrUndefined(currentOptions.xAxis.max) ?? xScale.invert(plotClipRect.right);
+    if (isTimeXAxis || isLogXAxis) return null;
+    // Step from visible ticks / scale domain so decimal precision tracks zoom.
     const xTickCount = xTickValues.length;
-    const xTickStep = xTickCount === 1 ? 0 : (xDomainMax - xDomainMin) / (xTickCount - 1);
+    let xTickStep = 0;
+    if (xTickCount >= 2) {
+      xTickStep = Math.abs(xTickValues[1]! - xTickValues[0]!);
+    } else {
+      const xd = xScale.getDomain();
+      xTickStep = Math.abs(xd.max - xd.min);
+    }
     return createTickFormatter(xTickStep);
   })();
 
@@ -123,7 +137,9 @@ export function renderAxisLabels(
       ? xTickFormatter(v)
       : isTimeXAxis
         ? formatTimeTickValue(v, visibleXRangeMs)
-        : formatTickValue(xFormatter!, v);
+        : isLogXAxis
+          ? formatLogTickValue(v, xLogBase)
+          : formatTickValue(xFormatter!, v);
     if (label == null) continue;
 
     const span = axisLabelOverlay.addLabel(label, offsetX + xCss, offsetY + xLabelY, {
@@ -173,6 +189,7 @@ export function renderYAxisLabels(ctx: YAxisLabelRenderContext): void {
     offsetX,
     offsetY,
     theme,
+    yTickValues: yTickValuesOpt,
   } = ctx;
   if (!axisLabelOverlay || !overlayContainer) return;
   if (canvasCssWidth <= 0 || canvasCssHeight <= 0) return;
@@ -185,11 +202,26 @@ export function renderYAxisLabels(ctx: YAxisLabelRenderContext): void {
   const isRight = yAxisConfig.position === 'right';
   const yTickLengthCssPx = yAxisConfig.tickLength ?? DEFAULT_TICK_LENGTH_CSS_PX;
 
-  const yTickCount = (yAxisConfig as any).tickCount ?? DEFAULT_TICK_COUNT;
-  const yDomainMin = finiteOrUndefined(yAxisConfig.min) ?? yScale.invert(plotClipRect.bottom);
-  const yDomainMax = finiteOrUndefined(yAxisConfig.max) ?? yScale.invert(plotClipRect.top);
+  // Prefer the live scale domain so ticks track any visible window (same as X zoom path).
+  // Explicit axis min/max still feed the scale via base-domain computation upstream.
+  const scaleDomain = yScale.getDomain();
+  const yDomainMin = scaleDomain.min;
+  const yDomainMax = scaleDomain.max;
+  const isLogY = yAxisConfig.type === 'log';
+  const logBase = yAxisConfig.logBase ?? 10;
+  const yTickValues =
+    yTickValuesOpt != null && yTickValuesOpt.length > 0
+      ? yTickValuesOpt
+      : isLogY
+        ? generateLogTicksForVisibleDomain(yDomainMin, yDomainMax, logBase)
+        : generateLinearTicks(
+            yDomainMin,
+            yDomainMax,
+            (yAxisConfig as { tickCount?: number }).tickCount ?? DEFAULT_TICK_COUNT
+          );
+  const yTickCount = yTickValues.length;
   const yTickStep = yTickCount <= 1 ? 0 : (yDomainMax - yDomainMin) / (yTickCount - 1);
-  const yFormatter = createTickFormatter(yTickStep);
+  const yFormatter = isLogY ? null : createTickFormatter(yTickStep);
 
   const yLabelX = isRight
     ? getRightYAxisLabelX(plotRightCss, yTickLengthCssPx)
@@ -211,12 +243,15 @@ export function renderYAxisLabels(ctx: YAxisLabelRenderContext): void {
   let maxTickLabelWidth = 0;
 
   for (let i = 0; i < yTickCount; i++) {
-    const t = yTickCount <= 1 ? 0.5 : i / (yTickCount - 1);
-    const v = yDomainMin + t * (yDomainMax - yDomainMin);
+    const v = yTickValues[i]!;
     const yClip = yScale.scale(v);
     const yCss = clipYToCanvasCssPx(yClip, canvasCssHeight);
 
-    const label = yTickFormatter ? yTickFormatter(v) : formatTickValue(yFormatter, v);
+    const label = yTickFormatter
+      ? yTickFormatter(v)
+      : isLogY
+        ? formatLogTickValue(v, logBase)
+        : formatTickValue(yFormatter!, v);
     if (label == null) continue;
 
     if (measureCtx) {

--- a/src/core/renderCoordinator/render/renderOverlays.ts
+++ b/src/core/renderCoordinator/render/renderOverlays.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ResolvedChartGPUOptions } from '../../../config/OptionResolver';
-import type { LinearScale } from '../../../utils/scales';
+import type { ContinuousScale } from '../../../utils/scales';
 import type { GridRenderer } from '../../../renderers/createGridRenderer';
 import type { AxisRenderer } from '../../../renderers/createAxisRenderer';
 import type { CrosshairRenderer, CrosshairRenderOptions } from '../../../renderers/createCrosshairRenderer';
@@ -24,6 +24,7 @@ import {
   buildAxisPrepareSignature,
   axisPrepareSignaturesEqual,
 } from './overlayPrepareMemo';
+import { generateLinearTicks, generateLogTicksForVisibleDomain } from '../axis/computeAxisTicks';
 
 const DEFAULT_TICK_COUNT = 5;
 const DEFAULT_CROSSHAIR_LINE_WIDTH_CSS_PX = 1;
@@ -45,15 +46,20 @@ type SharedNearestMatch = NearestPointMatch | null;
 
 interface OverlayPrepareContext {
   currentOptions: ResolvedChartGPUOptions;
-  xScale: LinearScale;
-  yScales: Map<string, LinearScale>;
+  xScale: ContinuousScale;
+  yScales: Map<string, ContinuousScale>;
   gridArea: GridArea;
   xTickCount: number;
   /**
-   * Explicit x-axis tick domain values (nice time ticks or linear).
+   * Explicit x-axis tick domain values (nice time ticks, log majors, or linear).
    * When non-empty, GPU axis marks use these values so they align with DOM labels.
    */
   xTickValues?: readonly number[];
+  /**
+   * Optional per-axis Y tick domain values (log majors). Keyed by y-axis id.
+   * When omitted, log Y axes compute ticks here; linear Y uses even count.
+   */
+  yTickValuesByAxis?: ReadonlyMap<string, readonly number[]>;
   hasCartesianSeries: boolean;
   effectivePointer: {
     hasPointer: boolean;
@@ -65,8 +71,8 @@ interface OverlayPrepareContext {
     gridY: number;
   };
   interactionScales: {
-    xScale: LinearScale;
-    yScales: Map<string, LinearScale>;
+    xScale: ContinuousScale;
+    yScales: Map<string, ContinuousScale>;
   } | null;
   seriesForRender: ReadonlyArray<any>;
   withAlpha: (color: string, alpha: number) => string;
@@ -101,6 +107,7 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
     gridArea,
     xTickCount,
     xTickValues,
+    yTickValuesByAxis,
     hasCartesianSeries,
     effectivePointer,
     interactionScales,
@@ -109,12 +116,67 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
     overlayPrepareMemo: memo,
   } = context;
 
+  // Resolve Y tick values (log majors or linear even splits) for primary + multi axes.
+  const resolvedYTickValuesByAxis = new Map<string, readonly number[]>();
+  for (const yAxisConfig of currentOptions.yAxes) {
+    const axisId = yAxisConfig.id!;
+    const axisYScale = yScales.get(axisId) ?? yScales.values().next().value;
+    if (!axisYScale) continue;
+    const provided = yTickValuesByAxis?.get(axisId);
+    if (provided != null && provided.length > 0) {
+      resolvedYTickValuesByAxis.set(axisId, provided);
+      continue;
+    }
+    // Use the scale's current domain (visible window), not explicit axis min/max alone.
+    const { min: dMin, max: dMax } = axisYScale.getDomain();
+    if (yAxisConfig.type === 'log') {
+      resolvedYTickValuesByAxis.set(axisId, generateLogTicksForVisibleDomain(dMin, dMax, yAxisConfig.logBase ?? 10));
+    } else {
+      const yTickCount = (yAxisConfig as { tickCount?: number }).tickCount ?? DEFAULT_TICK_COUNT;
+      resolvedYTickValuesByAxis.set(axisId, generateLinearTicks(dMin, dMax, yTickCount));
+    }
+  }
+  // Primary Y axis drives horizontal grid (log or linear tick-aligned when we have values).
+  const primaryYId = currentOptions.yAxes[0]?.id ?? 'y';
+  const primaryYTicks = resolvedYTickValuesByAxis.get(primaryYId) ?? [];
+  const primaryYScale = yScales.get(primaryYId) ?? yScales.values().next().value;
+
   // Grid preparation - always prepare so hidden grids don't render stale geometry,
   // unless the memo signature matches (geometry/colors unchanged).
   const gridLinesConfig = currentOptions.gridLines;
-  const horizontalCount =
-    gridLinesConfig.show && gridLinesConfig.horizontal.show ? gridLinesConfig.horizontal.count : 0;
-  const verticalCount = gridLinesConfig.show && gridLinesConfig.vertical.show ? gridLinesConfig.vertical.count : 0;
+  const wantHorizontal = gridLinesConfig.show && gridLinesConfig.horizontal.show;
+  const wantVertical = gridLinesConfig.show && gridLinesConfig.vertical.show;
+
+  // Tick-aligned positions for log axes (and any axis with explicit tick values).
+  const horizontalClipYs: number[] = [];
+  if (wantHorizontal && primaryYScale && primaryYTicks.length > 0) {
+    // Prefer tick-aligned for log primary; for linear keep even count unless log X/Y needs co-location.
+    const primaryIsLog = currentOptions.yAxes[0]?.type === 'log';
+    if (primaryIsLog) {
+      for (let i = 0; i < primaryYTicks.length; i++) {
+        const clip = primaryYScale.scale(primaryYTicks[i]!);
+        if (Number.isFinite(clip)) horizontalClipYs.push(clip);
+      }
+    }
+  }
+  const verticalClipXs: number[] = [];
+  if (wantVertical && xTickValues != null && xTickValues.length > 0 && currentOptions.xAxis.type === 'log') {
+    for (let i = 0; i < xTickValues.length; i++) {
+      const clip = xScale.scale(xTickValues[i]!);
+      if (Number.isFinite(clip)) verticalClipXs.push(clip);
+    }
+  }
+
+  const horizontalCount = !wantHorizontal
+    ? 0
+    : horizontalClipYs.length > 0
+      ? horizontalClipYs.length
+      : gridLinesConfig.horizontal.count;
+  const verticalCount = !wantVertical
+    ? 0
+    : verticalClipXs.length > 0
+      ? verticalClipXs.length
+      : gridLinesConfig.vertical.count;
 
   const gridSig = buildGridPrepareSignature({
     gridArea,
@@ -123,6 +185,12 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
     verticalCount,
     horizontalColor: gridLinesConfig.horizontal.color,
     verticalColor: gridLinesConfig.vertical.color,
+    horizontalClipYs,
+    verticalClipXs,
+    xScaleKind: xScale.kind,
+    yScaleKind: primaryYScale?.kind ?? 'linear',
+    logBase:
+      primaryYScale?.kind === 'log' ? (primaryYScale.base ?? 10) : xScale.kind === 'log' ? (xScale.base ?? 10) : 10,
   });
 
   const gridUnchanged = memo != null && gridPrepareSignaturesEqual(memo.grid, gridSig);
@@ -142,10 +210,12 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
       renderers.gridRenderer.prepare(gridArea, {
         lineCount: { horizontal: horizontalCount, vertical: 0 },
         color: gridLinesConfig.horizontal.color,
+        horizontalClipYs: horizontalClipYs.length > 0 ? horizontalClipYs : undefined,
       });
       renderers.gridRenderer.prepare(gridArea, {
         lineCount: { horizontal: 0, vertical: verticalCount },
         color: gridLinesConfig.vertical.color,
+        verticalClipXs: verticalClipXs.length > 0 ? verticalClipXs : undefined,
         append: true,
       });
     } else {
@@ -154,6 +224,8 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
       renderers.gridRenderer.prepare(gridArea, {
         lineCount: { horizontal: horizontalCount, vertical: verticalCount },
         color,
+        horizontalClipYs: horizontalClipYs.length > 0 ? horizontalClipYs : undefined,
+        verticalClipXs: verticalClipXs.length > 0 ? verticalClipXs : undefined,
       });
     }
     if (memo) memo.grid = gridSig;
@@ -197,7 +269,9 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
       const yAxisRenderer = renderers.yAxisRenderers.get(axisId);
       if (!yAxisRenderer) continue;
       const axisYScale = yScales.get(axisId) ?? yScales.values().next().value!;
-      const yTickCount = (yAxisConfig as { tickCount?: number }).tickCount ?? DEFAULT_TICK_COUNT;
+      const yTicks = resolvedYTickValuesByAxis.get(axisId) ?? [];
+      const yTickCount =
+        yTicks.length > 0 ? yTicks.length : ((yAxisConfig as { tickCount?: number }).tickCount ?? DEFAULT_TICK_COUNT);
       const ySig = buildAxisPrepareSignature({
         axisConfig: yAxisConfig,
         scale: axisYScale,
@@ -207,10 +281,11 @@ export function prepareOverlays(renderers: OverlayRenderers, context: OverlayPre
         axisLineColor,
         axisTickColor,
         tickCount: yTickCount,
+        tickValues: yTicks,
       });
       const yUnchanged = memo != null && axisPrepareSignaturesEqual(memo.yAxes.get(axisId), ySig);
       if (!yUnchanged) {
-        yAxisRenderer.prepare(yAxisConfig, axisYScale, 'y', gridArea, axisLineColor, axisTickColor, yTickCount);
+        yAxisRenderer.prepare(yAxisConfig, axisYScale, 'y', gridArea, axisLineColor, axisTickColor, yTickCount, yTicks);
         if (memo) memo.yAxes.set(axisId, ySig);
       }
     }

--- a/src/core/renderCoordinator/render/renderSeries.ts
+++ b/src/core/renderCoordinator/render/renderSeries.ts
@@ -235,7 +235,27 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
     lastSetSeriesCache.set(seriesIndex, { data, xOffset });
   };
 
-  const defaultBaseline = currentOptions.yAxes[0]?.min ?? 0;
+  /**
+   * Area baseline for fill-to floor.
+   * Linear: series/axis min, else 0. Log Y: never force 0 (VS discards non-positive);
+   * omit so AreaRenderer uses the positive scale domain min.
+   */
+  const resolveAreaBaseline = (series: ResolvedSeriesConfig, yScale: LinearScale): number | undefined => {
+    const seriesBaseline = (series as { readonly baseline?: number }).baseline;
+    if (seriesBaseline !== undefined && Number.isFinite(seriesBaseline)) {
+      return seriesBaseline;
+    }
+    const axisId = (series as { readonly yAxis?: string }).yAxis || 'y';
+    const axis = currentOptions.yAxes.find((ax) => ax.id === axisId) ?? currentOptions.yAxes[0];
+    const axisMin = axis?.min;
+    if (axisMin !== undefined && Number.isFinite(axisMin)) {
+      return axisMin;
+    }
+    if (yScale.kind === 'log') {
+      return undefined;
+    }
+    return 0;
+  };
   const barSeriesConfigs: ResolvedBarSeriesConfig[] = [];
 
   const introP = introPhase === 'running' ? clamp01(introProgress01) : 1;
@@ -263,7 +283,7 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
         // that buffer. Private pack alone identity-caches on data ref and misses
         // in-place column growth from appendData (empty until a zoom creates a new
         // sliced array ref).
-        const baseline = s.baseline ?? defaultBaseline;
+        const baseline = resolveAreaBaseline(s, getYScale(s));
         // When connectNulls is true, strip null/NaN gap entries so the area draws through gaps.
         // Cached by data ref identity (P2-12) so static frames do not re-allocate.
         // sampling:'none' uploads full raw (same fullRawLine contract as line).
@@ -457,6 +477,8 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
           // wrap raw GPU order is not chronological — area.wgsl reads linearly
           // and would connect physical neighbors (issue 1 review fix).
           if (s.areaStyle) {
+            const yScaleForArea = getYScale(s);
+            const areaBaseline = resolveAreaBaseline(s, yScaleForArea);
             const areaLike: ResolvedAreaSeriesConfig = {
               type: 'area',
               name: s.name,
@@ -478,15 +500,15 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
                 areaLike,
                 areaLike.data,
                 xScale,
-                getYScale(s),
-                defaultBaseline,
+                yScaleForArea,
+                areaBaseline,
                 strokeBuffer,
                 strokePointCount,
                 xOffset
               );
             } else {
               // Modular ring wrap: private chronological pack from runtime raw.
-              renderers.areaRenderers[i].prepare(areaLike, areaLike.data, xScale, getYScale(s), defaultBaseline);
+              renderers.areaRenderers[i].prepare(areaLike, areaLike.data, xScale, yScaleForArea, areaBaseline);
             }
           }
 
@@ -551,6 +573,8 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
         // Line+areaStyle on CPU path: share DataStore only when linear (capacity 0).
         // After modular wrap, private-pack chronological uploadData (issue 1 review).
         if (s.areaStyle) {
+          const yScaleForArea = getYScale(s);
+          const areaBaseline = resolveAreaBaseline(s, yScaleForArea);
           const areaLike: ResolvedAreaSeriesConfig = {
             type: 'area',
             name: s.name,
@@ -572,14 +596,14 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
               areaLike,
               areaLike.data,
               xScale,
-              getYScale(s),
-              defaultBaseline,
+              yScaleForArea,
+              areaBaseline,
               buffer,
               dataStore.getSeriesPointCount(i),
               xOffset
             );
           } else {
-            renderers.areaRenderers[i].prepare(areaLike, areaLike.data, xScale, getYScale(s), defaultBaseline);
+            renderers.areaRenderers[i].prepare(areaLike, areaLike.data, xScale, yScaleForArea, areaBaseline);
           }
         }
 

--- a/src/core/renderCoordinator/utils/boundsComputation.ts
+++ b/src/core/renderCoordinator/utils/boundsComputation.ts
@@ -94,3 +94,88 @@ export const normalizeDomain = (
 
   return { min, max };
 };
+
+/** Last sanitized result warned per axis key — suppress streaming spam. */
+const lastLogDomainWarnByKey = new Map<string, string>();
+
+/**
+ * Sanitize a domain for logarithmic axes.
+ *
+ * - Both ends must be finite and strictly positive.
+ * - Explicit min/max ≤ 0 are clamped using `positiveDataMin` when available
+ *   (prefer `positiveDataMin * 0.5`, floored at a power of `base`), else fallback.
+ * - Empty / all-non-positive data → `[1, 10]` (or `[1, base]` when base > 1).
+ *
+ * @returns Sanitized domain plus whether a clamp/fallback warning was applied
+ */
+export function sanitizeLogDomain(
+  minCandidate: number,
+  maxCandidate: number,
+  options?: Readonly<{
+    base?: number;
+    /** Smallest positive finite data value on this axis (for clamping explicit ≤0). */
+    positiveDataMin?: number;
+    /** When true, emit a console warning on clamp/fallback (dev). */
+    warn?: boolean;
+    /**
+     * Stable key for de-duplicating warnings (e.g. `'x'`, `'y:0'`).
+     * Warns once per key, or again when the sanitized `[min, max]` changes.
+     */
+    warnKey?: string;
+  }>
+): { readonly min: number; readonly max: number; readonly warned: boolean } {
+  const base =
+    options?.base != null && Number.isFinite(options.base) && options.base > 0 && options.base !== 1
+      ? options.base
+      : 10;
+  const fallbackMax = base > 1 ? base : 10;
+  let warned = false;
+
+  let min = minCandidate;
+  let max = maxCandidate;
+
+  const clampPositive = (v: number, role: 'min' | 'max'): number => {
+    if (Number.isFinite(v) && v > 0) return v;
+    warned = true;
+    const pd = options?.positiveDataMin;
+    if (pd != null && Number.isFinite(pd) && pd > 0) {
+      const half = pd * 0.5;
+      // Floor at a power of base near half (or EPSILON-scale positive).
+      const logHalf = Math.log(Math.max(half, Number.MIN_VALUE)) / Math.log(base);
+      const floored = base ** Math.floor(logHalf);
+      return Math.max(floored, Number.MIN_VALUE);
+    }
+    return role === 'min' ? 1 : fallbackMax;
+  };
+
+  min = clampPositive(min, 'min');
+  max = clampPositive(max, 'max');
+
+  if (min === max) {
+    max = min * base;
+  } else if (min > max) {
+    const t = min;
+    min = max;
+    max = t;
+  }
+
+  if (!Number.isFinite(min) || !Number.isFinite(max) || !(min > 0) || !(max > 0)) {
+    warned = true;
+    min = 1;
+    max = fallbackMax;
+  }
+
+  if (warned && options?.warn !== false) {
+    const key = options?.warnKey ?? 'default';
+    const resultKey = `${min}|${max}|${base}`;
+    if (lastLogDomainWarnByKey.get(key) !== resultKey) {
+      lastLogDomainWarnByKey.set(key, resultKey);
+      console.warn(
+        `[ChartGPU] Log axis domain was non-positive or invalid; using [${min}, ${max}]. ` +
+          `Log axes require strictly positive min/max.`
+      );
+    }
+  }
+
+  return { min, max, warned };
+}

--- a/src/core/renderCoordinator/zoom/__tests__/stickyAutoDomain.test.ts
+++ b/src/core/renderCoordinator/zoom/__tests__/stickyAutoDomain.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   applyStickyAutoDomain,
+  applyStickyAutoLogDomain,
   resolveStickyOrDataDomain,
   shouldApplyStickyAutoDomain,
   shouldSkipStickyAutoXDomain,
@@ -115,6 +116,28 @@ describe('applyStickyAutoDomain', () => {
     const next = applyStickyAutoDomain({ min: 5, max: 5 }, null, 0.1);
     expect(next.min).toBe(5);
     expect(next.max).toBe(6);
+  });
+});
+
+describe('applyStickyAutoLogDomain', () => {
+  it('establishes exact positive domain (no pad) on cold start', () => {
+    const next = applyStickyAutoLogDomain({ min: 1, max: 1000 }, null, 10, 0);
+    expect(next.min).toBeCloseTo(1, 10);
+    expect(next.max).toBeCloseTo(1000, 10);
+  });
+
+  it('expands equal-span domains by base factor (not linear +1)', () => {
+    // Linear sticky with headroom 0 expands min===max to min+1; log uses min*base.
+    const next = applyStickyAutoLogDomain({ min: 5, max: 5 }, null, 10, 0);
+    expect(next.min).toBeCloseTo(5, 10);
+    expect(next.max).toBeCloseTo(50, 10);
+  });
+
+  it('with headroom 0 tracks data max tightly (log-X sticky policy)', () => {
+    let sticky = applyStickyAutoLogDomain({ min: 1, max: 100 }, null, 10, 0);
+    sticky = applyStickyAutoLogDomain({ min: 1, max: 200 }, sticky, 10, 0);
+    expect(sticky.min).toBeCloseTo(1, 10);
+    expect(sticky.max).toBeCloseTo(200, 10);
   });
 });
 

--- a/src/core/renderCoordinator/zoom/__tests__/visibleYBounds.test.ts
+++ b/src/core/renderCoordinator/zoom/__tests__/visibleYBounds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isFullSpanZoomRange, scanCartesianVisibleYBounds } from '../visibleYBounds';
+import { isFullSpanZoomRange, scanCartesianVisibleYBounds, scanCartesianPositiveYBounds } from '../visibleYBounds';
 
 describe('isFullSpanZoomRange', () => {
   it('treats null/undefined as full span', () => {
@@ -45,5 +45,33 @@ describe('scanCartesianVisibleYBounds', () => {
   it('expands equal y to unit span', () => {
     const flat = { x: new Float64Array([0, 1]), y: new Float64Array([7, 7]) };
     expect(scanCartesianVisibleYBounds(flat)).toEqual({ yMin: 7, yMax: 8 });
+  });
+});
+
+describe('scanCartesianPositiveYBounds', () => {
+  // Global positives: 100,1,50,2,200. Window [10,30] has 1,50,2 and also 0/-5 noise.
+  const data = {
+    x: new Float64Array([0, 10, 20, 30, 40, 25]),
+    y: new Float64Array([100, 1, 0, 2, 200, -5]),
+  };
+
+  it('ignores ≤0 globally', () => {
+    const b = scanCartesianPositiveYBounds(data);
+    expect(b).toEqual({ yMin: 1, yMax: 200 });
+  });
+
+  it('x-window restricts positives (does not use off-window peaks)', () => {
+    // Window [10, 30]: positives 1, 2 (0 and -5 ignored; 100/200 off-window)
+    const b = scanCartesianPositiveYBounds(data, { min: 10, max: 30 });
+    expect(b).toEqual({ yMin: 1, yMax: 2 });
+  });
+
+  it('returns null when window has no positive y', () => {
+    const onlyNonPos = {
+      x: new Float64Array([0, 1]),
+      y: new Float64Array([0, -3]),
+    };
+    expect(scanCartesianPositiveYBounds(onlyNonPos)).toBeNull();
+    expect(scanCartesianPositiveYBounds(data, { min: 100, max: 200 })).toBeNull();
   });
 });

--- a/src/core/renderCoordinator/zoom/stickyAutoDomain.ts
+++ b/src/core/renderCoordinator/zoom/stickyAutoDomain.ts
@@ -145,3 +145,40 @@ export function applyStickyAutoDomain(
 
   return normalize(nextMin, nextMax);
 }
+
+/**
+ * Sticky auto-domain with headroom applied in **log space** (for log axes).
+ *
+ * Same breach / cold-start / window-slide semantics as {@link applyStickyAutoDomain},
+ * but pad is a fraction of `log_b(max) - log_b(min)` so multi-decade ranges grow
+ * symmetrically in decades rather than linear units.
+ *
+ * Requires strictly positive finite domain endpoints; non-positive inputs fall through
+ * to a trivial `{ min, max }` copy (caller should sanitize first).
+ */
+export function applyStickyAutoLogDomain(
+  dataDomain: { readonly min: number; readonly max: number },
+  sticky: StickyDomain | null,
+  base: number = 10,
+  headroom: number = DEFAULT_STICKY_DOMAIN_HEADROOM
+): StickyDomain {
+  const { min: dMin, max: dMax } = dataDomain;
+  if (!Number.isFinite(dMin) || !Number.isFinite(dMax) || !(dMin > 0) || !(dMax > 0)) {
+    return { min: dMin, max: dMax };
+  }
+  const b = Number.isFinite(base) && base > 0 && base !== 1 ? base : 10;
+  const lnB = Math.log(b);
+  const logDMin = Math.log(dMin) / lnB;
+  const logDMax = Math.log(dMax) / lnB;
+
+  const logSticky: StickyDomain | null =
+    sticky != null && sticky.min > 0 && sticky.max > 0 && Number.isFinite(sticky.min) && Number.isFinite(sticky.max)
+      ? { min: Math.log(sticky.min) / lnB, max: Math.log(sticky.max) / lnB }
+      : null;
+
+  const logResult = applyStickyAutoDomain({ min: logDMin, max: logDMax }, logSticky, headroom);
+  return {
+    min: b ** logResult.min,
+    max: b ** logResult.max,
+  };
+}

--- a/src/core/renderCoordinator/zoom/visibleYBounds.ts
+++ b/src/core/renderCoordinator/zoom/visibleYBounds.ts
@@ -51,3 +51,35 @@ export function scanCartesianVisibleYBounds(
   if (yMin === yMax) yMax = yMin + 1;
   return { yMin, yMax };
 }
+
+/**
+ * Scan cartesian points for **strictly positive** y min/max (log-axis auto domain).
+ * Optionally restricted to an X window — same window used for visible Y under zoom
+ * so positives outside the view do not pull the log domain.
+ * Returns null when no positive finite y contributes (caller falls back).
+ */
+export function scanCartesianPositiveYBounds(
+  data: CartesianSeriesData,
+  xWindow?: { readonly min: number; readonly max: number } | null
+): { yMin: number; yMax: number } | null {
+  let yMin = Number.POSITIVE_INFINITY;
+  let yMax = Number.NEGATIVE_INFINITY;
+  const filterX = xWindow != null && Number.isFinite(xWindow.min) && Number.isFinite(xWindow.max);
+  const xMinW = filterX ? xWindow!.min : 0;
+  const xMaxW = filterX ? xWindow!.max : 0;
+  const n = getPointCount(data);
+  for (let i = 0; i < n; i++) {
+    if (filterX) {
+      const x = getX(data, i);
+      if (!Number.isFinite(x) || x < xMinW || x > xMaxW) continue;
+    }
+    const y = getY(data, i);
+    if (!Number.isFinite(y) || !(y > 0)) continue;
+    if (y < yMin) yMin = y;
+    if (y > yMax) yMax = y;
+  }
+  if (!Number.isFinite(yMin) || !Number.isFinite(yMax) || !(yMin > 0) || !(yMax > 0)) {
+    return null;
+  }
+  return { yMin, yMax };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,23 @@ export { darkTheme, lightTheme, getTheme } from './themes';
 export type { ThemeName } from './themes';
 
 // Scales - Pure utilities
-export { createLinearScale, createCategoryScale } from './utils/scales';
-export type { LinearScale, CategoryScale } from './utils/scales';
+export {
+  createLinearScale,
+  createLogScale,
+  createAxisScale,
+  createCategoryScale,
+  normalizeLogBase,
+  DEFAULT_LOG_BASE,
+} from './utils/scales';
+export type { LinearScale, ContinuousScale, CategoryScale } from './utils/scales';
+export {
+  generateLinearTicks,
+  generateLogTicks,
+  generateLogTicksForVisibleDomain,
+  formatLogTickValue,
+  createTickFormatter,
+  formatTickValue,
+} from './core/renderCoordinator/axis/computeAxisTicks';
 
 // Chart sync (interaction)
 export { connectCharts } from './interaction/createChartSync';

--- a/src/renderers/__tests__/areaRendererGeometryCache.test.ts
+++ b/src/renderers/__tests__/areaRendererGeometryCache.test.ts
@@ -271,10 +271,10 @@ describe('createAreaRenderer geometry cache', () => {
     // External storage path uses packing-origin X affine (same as LineRenderer).
     renderer.prepare(areaConfig(data), data, xScale, yScale, 0, external, 2, origin);
 
-    // Area VS uniforms: mat4 + baseline padding = 96 bytes.
+    // Area VS uniforms: mat4 + baseline/log (80 bytes).
     const vsWrites = writeUniformBufferMock.mock.calls.filter((c) => {
       const dataArg = c[2];
-      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 80;
     });
     expect(vsWrites.length).toBeGreaterThan(0);
     const f32 = new Float32Array(vsWrites[0]![2] as ArrayBuffer);

--- a/src/renderers/__tests__/candlestickGeometryCache.test.ts
+++ b/src/renderers/__tests__/candlestickGeometryCache.test.ts
@@ -154,6 +154,54 @@ describe('candlestick geometry cache (issue 1.3)', () => {
     renderer.dispose();
   });
 
+  it('re-uploads when same data ref grows in length (streaming append)', () => {
+    // appendData mutates the coordinator-owned OHLC array in place; identity skip
+    // must miss when length changes or new candles never reach the GPU buffer.
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createCandlestickRenderer(device, { sampleCount: 1 });
+    const ga = gridArea();
+    const x = createLinearScale().domain(0, 5).range(-1, 1);
+    const y = createLinearScale().domain(0, 20).range(-1, 1);
+
+    const growing = [
+      [0, 10, 12, 9, 13],
+      [1, 12, 11, 10, 14],
+    ] as Array<[number, number, number, number, number]>;
+
+    renderer.prepare(candleSeries(growing as never), growing as never, x, y, ga);
+    writeBuffer.mockClear();
+
+    growing.push([2, 11, 15, 10, 16]);
+    renderer.prepare(candleSeries(growing as never), growing as never, x, y, ga);
+    expect(writeBuffer.mock.calls.length).toBeGreaterThan(0);
+    renderer.dispose();
+  });
+
+  it('re-uploads when last candle mutates under same data ref (forming candle)', () => {
+    // Streaming examples update the open candle via setOption with a stable array
+    // and an in-place last-element replace — must not hit axes-only identity skip.
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createCandlestickRenderer(device, { sampleCount: 1 });
+    const ga = gridArea();
+    const x = createLinearScale().domain(0, 2).range(-1, 1);
+    const y = createLinearScale().domain(0, 20).range(-1, 1);
+
+    const forming = [
+      [0, 10, 12, 9, 13],
+      [1, 12, 11, 10, 14],
+    ] as Array<[number, number, number, number, number]>;
+
+    renderer.prepare(candleSeries(forming as never), forming as never, x, y, ga);
+    writeBuffer.mockClear();
+
+    forming[1] = [1, 12, 16, 10, 17]; // close/high moved
+    renderer.prepare(candleSeries(forming as never), forming as never, x, y, ga);
+    expect(writeBuffer.mock.calls.length).toBeGreaterThan(0);
+    renderer.dispose();
+  });
+
   it('re-uploads after invalidateGeometry with same data ref', () => {
     const device = createMockDevice();
     const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;

--- a/src/renderers/__tests__/lineRendererBounds.test.ts
+++ b/src/renderers/__tests__/lineRendererBounds.test.ts
@@ -225,7 +225,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
 
     const vsWrites = writeUniform.mock.calls.filter((c) => {
       const dataArg = c[2];
-      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 112;
     });
     expect(vsWrites.length).toBeGreaterThan(0);
     const f32 = new Float32Array(vsWrites[0]![2] as ArrayBuffer);
@@ -250,7 +250,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
     const src = fs.readFileSync(path.resolve(__dirname, '../createLineRenderer.ts'), 'utf8');
     expect(src).not.toMatch(/computeRawBoundsFromCartesianData/);
     expect(src).toMatch(/computePackedXAffineFromScale\(xScale, xOffset\)/);
-    expect(src).toMatch(/computeClipAffineFromScale\(yScale, 0, 1\)/);
+    expect(src).toMatch(/computeClipAffineFromContinuousScale\(yScale\)/);
     expect(src).not.toMatch(/bx \+ ax \* xOffset/);
   });
 
@@ -274,7 +274,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
 
     const vsWrites = writeUniform.mock.calls.filter((c) => {
       const dataArg = c[2];
-      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 112;
     });
     expect(vsWrites.length).toBeGreaterThan(0);
     const f32 = new Float32Array(vsWrites[vsWrites.length - 1]![2] as ArrayBuffer);
@@ -392,7 +392,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
     const vsWrites = () =>
       writeUniform.mock.calls.filter((c) => {
         const dataArg = c[2];
-        return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+        return dataArg instanceof ArrayBuffer && dataArg.byteLength === 112;
       }).length;
 
     a.prepare(series, bufA, xScale, yScale, 0, 1, 800, 600, 10);
@@ -433,7 +433,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
     const vsCount = () =>
       writeUniform.mock.calls.filter((c) => {
         const dataArg = c[2];
-        return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+        return dataArg instanceof ArrayBuffer && dataArg.byteLength === 112;
       }).length;
 
     a.prepare(thin, bufA, xScale, yScale, 0, 1, 800, 600, 10);
@@ -621,7 +621,7 @@ describe('createLineRenderer bounds (P2-5)', () => {
 
     const vsWrites = writeUniform.mock.calls.filter((c) => {
       const dataArg = c[2];
-      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 96;
+      return dataArg instanceof ArrayBuffer && dataArg.byteLength === 112;
     });
     const f32 = new Float32Array(vsWrites[vsWrites.length - 1]![2] as ArrayBuffer);
     expect(f32[19]).toBe(2);
@@ -641,7 +641,8 @@ describe('line.wgsl hairline gap contract (Issue 1 review)', () => {
     // Endpoints via pointAt (modular ring remap) or legacy points[iid].
     expect(hairBody).toMatch(/pointAt\(iid\)|points\[iid\]/);
     expect(hairBody).toMatch(/pointAt\(iid \+ 1u\)|points\[iid \+ 1u\]/);
-    expect(hairBody).toMatch(/pA\.x != pA\.x/);
-    expect(hairBody).toMatch(/pB\.x != pB\.x/);
+    // Endpoints may be named pA/pB or pA_raw/pB_raw (log-projection path).
+    expect(hairBody).toMatch(/pA(_raw)?\.x != pA(_raw)?\.x/);
+    expect(hairBody).toMatch(/pB(_raw)?\.x != pB(_raw)?\.x/);
   });
 });

--- a/src/renderers/__tests__/lineRingRemap.test.ts
+++ b/src/renderers/__tests__/lineRingRemap.test.ts
@@ -104,10 +104,10 @@ describe('LineRenderer modular ring remap (issue 0.1)', () => {
       { start: 1, capacity: 4 } // writes ring layout uniforms; segment order is shader pointAt contract
     );
 
-    // First writeUniformBuffer call is VS (96-byte buffer with ring u32s).
+    // First writeUniformBuffer call is VS (112-byte buffer with ring u32s).
     const vsCall = vi.mocked(writeUniformBuffer).mock.calls.find((c) => {
       const payload = c[2];
-      return payload instanceof ArrayBuffer && payload.byteLength === 96;
+      return payload instanceof ArrayBuffer && payload.byteLength === 112;
     });
     expect(vsCall).toBeDefined();
     const u32 = new Uint32Array(vsCall![2] as ArrayBuffer);
@@ -136,7 +136,7 @@ describe('LineRenderer modular ring remap (issue 0.1)', () => {
 
     const vsCall = vi.mocked(writeUniformBuffer).mock.calls.find((c) => {
       const payload = c[2];
-      return payload instanceof ArrayBuffer && payload.byteLength === 96;
+      return payload instanceof ArrayBuffer && payload.byteLength === 112;
     });
     expect(vsCall).toBeDefined();
     const u32 = new Uint32Array(vsCall![2] as ArrayBuffer);

--- a/src/renderers/__tests__/scatterConstRadius.test.ts
+++ b/src/renderers/__tests__/scatterConstRadius.test.ts
@@ -55,8 +55,13 @@ function createMockDevice() {
 }
 
 const identityScale = {
+  kind: 'linear' as const,
   scale: (v: number) => v,
   invert: (v: number) => v,
+  getDomain: () => ({ min: 0, max: 1 }),
+  getRange: () => ({ min: 0, max: 1 }),
+  domain: () => identityScale,
+  range: () => identityScale,
 } as unknown as LinearScale;
 
 const gridArea = {
@@ -227,8 +232,13 @@ describe('scatter geometry identity cache (issue 1.2)', () => {
     // Axes-only / pan: same data ref — uniforms may rewrite; instances must not.
     writeBuffer.mockClear();
     const zoomedScale = {
+      kind: 'linear' as const,
       scale: (v: number) => v * 2,
       invert: (v: number) => v / 2,
+      getDomain: () => ({ min: 0, max: 1 }),
+      getRange: () => ({ min: 0, max: 2 }),
+      domain: () => zoomedScale,
+      range: () => zoomedScale,
     } as unknown as LinearScale;
     renderer.prepare(baseSeries(5), data as unknown as never, zoomedScale, identityScale, gridArea);
     // No instance writeBuffer (byteLength payload via 5th arg); uniforms use writeUniformBuffer mock.

--- a/src/renderers/__tests__/scatterYOnlyRewrite.test.ts
+++ b/src/renderers/__tests__/scatterYOnlyRewrite.test.ts
@@ -58,8 +58,13 @@ function createMockDevice() {
 }
 
 const identityScale = {
+  kind: 'linear' as const,
   scale: (v: number) => v,
   invert: (v: number) => v,
+  getDomain: () => ({ min: 0, max: 1 }),
+  getRange: () => ({ min: 0, max: 1 }),
+  domain: () => identityScale,
+  range: () => identityScale,
 } as unknown as LinearScale;
 
 const gridArea = {
@@ -172,8 +177,13 @@ describe('scatter equal-N y-only dual-buffer (issue 1.2 Option A)', () => {
     renderer.prepare(baseSeries(5), data as unknown as never, identityScale, identityScale, gridArea);
     writeBuffer.mockClear();
     const zoomedScale = {
+      kind: 'linear' as const,
       scale: (v: number) => v * 2,
       invert: (v: number) => v / 2,
+      getDomain: () => ({ min: 0, max: 1 }),
+      getRange: () => ({ min: 0, max: 2 }),
+      domain: () => zoomedScale,
+      range: () => zoomedScale,
     } as unknown as LinearScale;
     renderer.prepare(baseSeries(5), data as unknown as never, zoomedScale, identityScale, gridArea);
     expect(instanceWriteSizes(writeBuffer)).toHaveLength(0);
@@ -192,8 +202,13 @@ describe('scatter equal-N y-only dual-buffer (issue 1.2 Option A)', () => {
     renderer.prepare(baseSeries(5), dataB as unknown as never, identityScale, identityScale, gridArea);
     writeBuffer.mockClear();
     const zoomedScale = {
+      kind: 'linear' as const,
       scale: (v: number) => v * 2,
       invert: (v: number) => v / 2,
+      getDomain: () => ({ min: 0, max: 1 }),
+      getRange: () => ({ min: 0, max: 2 }),
+      domain: () => zoomedScale,
+      range: () => zoomedScale,
     } as unknown as LinearScale;
     renderer.prepare(baseSeries(5), dataB as unknown as never, zoomedScale, identityScale, gridArea);
     expect(instanceWriteSizes(writeBuffer)).toHaveLength(0);
@@ -309,7 +324,7 @@ describe('scatter equal-N y-only dual-buffer (issue 1.2 Option A)', () => {
     // writeUniformBuffer(device, buffer, data) — VS uniform is ArrayBuffer 80 bytes
     const vsWrites = writeUniform.mock.calls.filter((c) => {
       const data = c[2];
-      return data instanceof ArrayBuffer && data.byteLength === 80;
+      return data instanceof ArrayBuffer && data.byteLength === 96;
     });
     expect(vsWrites.length).toBeGreaterThan(0);
     const f32 = new Float32Array(vsWrites[vsWrites.length - 1]![2] as ArrayBuffer);
@@ -328,7 +343,7 @@ describe('scatter equal-N y-only dual-buffer (issue 1.2 Option A)', () => {
     renderer.prepare(baseSeries(5), data as unknown as never, identityScale, identityScale, gridArea);
     const vsWrites = writeUniform.mock.calls.filter((c) => {
       const data = c[2];
-      return data instanceof ArrayBuffer && data.byteLength === 80;
+      return data instanceof ArrayBuffer && data.byteLength === 96;
     });
     const f32 = new Float32Array(vsWrites[vsWrites.length - 1]![2] as ArrayBuffer);
     expect(f32[18]).toBe(5); // symbolSize 5 × dpr 1

--- a/src/renderers/createAreaRenderer.ts
+++ b/src/renderers/createAreaRenderer.ts
@@ -1,7 +1,7 @@
 import areaWgsl from '../shaders/area.wgsl?raw';
 import type { ResolvedAreaSeriesConfig } from '../config/OptionResolver';
 import type { CartesianSeriesData } from '../config/types';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
 import {
@@ -13,14 +13,19 @@ import {
   isRingXYColumns,
 } from '../data/cartesianData';
 import type { PipelineCache } from '../core/PipelineCache';
-import { computePackedXAffineFromScale } from './packedXAffine';
+import {
+  computeClipAffineFromContinuousScale,
+  computeClipAffineFromScale,
+  computePackedXAffineFromScale,
+  resolveLogProjection,
+} from './packedXAffine';
 
 export interface AreaRenderer {
   prepare(
     seriesConfig: ResolvedAreaSeriesConfig,
     data: CartesianSeriesData,
-    xScale: LinearScale,
-    yScale: LinearScale,
+    xScale: ContinuousScale,
+    yScale: ContinuousScale,
     baseline?: number,
     /**
      * Optional shared storage buffer (line / GPU decimation output). When set,
@@ -82,23 +87,6 @@ const nextPow2 = (v: number): number => {
   if (!Number.isFinite(v) || v <= 0) return 1;
   const n = Math.ceil(v);
   return 2 ** Math.ceil(Math.log2(n));
-};
-
-const computeClipAffineFromScale = (
-  scale: LinearScale,
-  v0: number,
-  v1: number
-): { readonly a: number; readonly b: number } => {
-  const p0 = scale.scale(v0);
-  const p1 = scale.scale(v1);
-
-  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
-    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
-  }
-
-  const a = (p1 - p0) / (v1 - v0);
-  const b = p0 - a * v0;
-  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
 };
 
 const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: number, by: number): void => {
@@ -168,14 +156,15 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
     ],
   });
 
-  const vsUniformBuffer = createUniformBuffer(device, 96, {
+  // VSUniforms: mat4 (64) + baseline/logBaseX/logBaseY/logFlags (16) = 80.
+  const vsUniformBuffer = createUniformBuffer(device, 80, {
     label: 'areaRenderer/vsUniforms',
   });
   const fsUniformBuffer = createUniformBuffer(device, 16, {
     label: 'areaRenderer/fsUniforms',
   });
 
-  const vsUniformScratchBuffer = new ArrayBuffer(96);
+  const vsUniformScratchBuffer = new ArrayBuffer(80);
   const vsUniformScratchF32 = new Float32Array(vsUniformScratchBuffer);
   const fsUniformScratchF32 = new Float32Array(4);
 
@@ -274,35 +263,55 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
     boundDataBuffer = buffer;
   };
 
-  // Issue 2.5: skip uniform writes when affine/color/baseline unchanged.
+  // Issue 2.5: skip uniform writes when affine/color/baseline/log unchanged.
   let lastAx = Number.NaN;
   let lastBx = Number.NaN;
   let lastAy = Number.NaN;
   let lastBy = Number.NaN;
   let lastBaseline = Number.NaN;
+  let lastLogFlags = 0;
+  let lastLogBaseX = Number.NaN;
+  let lastLogBaseY = Number.NaN;
   let lastFsR = Number.NaN;
   let lastFsG = Number.NaN;
   let lastFsB = Number.NaN;
   let lastFsA = Number.NaN;
+  const vsUniformScratchU32 = new Uint32Array(vsUniformScratchBuffer);
 
-  const writeVsUniforms = (ax: number, bx: number, ay: number, by: number, baseline: number): void => {
-    const dirty = lastAx !== ax || lastBx !== bx || lastAy !== ay || lastBy !== by || lastBaseline !== baseline;
+  const writeVsUniforms = (
+    ax: number,
+    bx: number,
+    ay: number,
+    by: number,
+    baseline: number,
+    logFlags: number,
+    logBaseX: number,
+    logBaseY: number
+  ): void => {
+    const dirty =
+      lastAx !== ax ||
+      lastBx !== bx ||
+      lastAy !== ay ||
+      lastBy !== by ||
+      lastBaseline !== baseline ||
+      lastLogFlags !== logFlags ||
+      lastLogBaseX !== logBaseX ||
+      lastLogBaseY !== logBaseY;
     if (!dirty) return;
     writeTransformMat4F32(vsUniformScratchF32, ax, bx, ay, by);
     vsUniformScratchF32[16] = baseline;
-    vsUniformScratchF32[17] = 0;
-    vsUniformScratchF32[18] = 0;
-    vsUniformScratchF32[19] = 0;
-    vsUniformScratchF32[20] = 0;
-    vsUniformScratchF32[21] = 0;
-    vsUniformScratchF32[22] = 0;
-    vsUniformScratchF32[23] = 0;
+    vsUniformScratchF32[17] = logBaseX;
+    vsUniformScratchF32[18] = logBaseY;
+    vsUniformScratchU32[19] = logFlags >>> 0;
     writeUniformBuffer(device, vsUniformBuffer, vsUniformScratchBuffer);
     lastAx = ax;
     lastBx = bx;
     lastAy = ay;
     lastBy = by;
     lastBaseline = baseline;
+    lastLogFlags = logFlags;
+    lastLogBaseX = logBaseX;
+    lastLogBaseY = logBaseY;
   };
 
   const prepare: AreaRenderer['prepare'] = (
@@ -330,11 +339,22 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
       boundDataRef = null; // external ownership
       bindStorage(storageBuffer);
 
-      // Packed-origin X affine (stable for epoch-ms); Y samples (0,1).
+      // Packed-origin X affine (stable for epoch-ms); Y continuous (log-aware).
       const { a: ax, b: bxPacked } = computePackedXAffineFromScale(xScale, xOffset);
-      const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
-      const baselineValue = Number.isFinite(baseline ?? Number.NaN) ? (baseline as number) : 0;
-      writeVsUniforms(ax, bxPacked, ay, by, baselineValue);
+      const { a: ay, b: by } = computeClipAffineFromContinuousScale(yScale);
+      const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
+      // Log Y: default baseline is domain min (positive), not 0.
+      // Non-positive caller baselines are treated as unset on log (fill-to-zero invalid).
+      const defaultBaseline = yScale.kind === 'log' ? yScale.getDomain().min : 0;
+      const baselineValue =
+        yScale.kind === 'log'
+          ? Number.isFinite(baseline ?? Number.NaN) && (baseline as number) > 0
+            ? (baseline as number)
+            : defaultBaseline
+          : Number.isFinite(baseline ?? Number.NaN)
+            ? (baseline as number)
+            : defaultBaseline;
+      writeVsUniforms(ax, bxPacked, ay, by, baselineValue, logFlags, logBaseX, logBaseY);
     } else {
       // Private pack path with identity cache + pow2 growth.
       // Also re-pack when length changes under a stable ref (streaming append grows
@@ -368,14 +388,27 @@ export function createAreaRenderer(device: GPUDevice, options?: AreaRendererOpti
         yMin: 0,
         yMax: 1,
       };
-      const { a: ax, b: bx } = computeClipAffineFromScale(xScale, xMin, xMax);
-      const { a: ay, b: by } = computeClipAffineFromScale(yScale, yMin, yMax);
-      const baselineValue = Number.isFinite(baseline ?? Number.NaN)
-        ? (baseline as number)
-        : Number.isFinite(yMin)
-          ? yMin
-          : 0;
-      writeVsUniforms(ax, bx, ay, by, baselineValue);
+      // Log axes: affine in transformed space. Linear: sample domain endpoints (parity).
+      const { a: ax, b: bx } =
+        xScale.kind === 'log'
+          ? computeClipAffineFromContinuousScale(xScale)
+          : computeClipAffineFromScale(xScale, xMin, xMax);
+      const { a: ay, b: by } =
+        yScale.kind === 'log'
+          ? computeClipAffineFromContinuousScale(yScale)
+          : computeClipAffineFromScale(yScale, yMin, yMax);
+      const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
+      const fallbackBaseline = yScale.kind === 'log' ? yScale.getDomain().min : Number.isFinite(yMin) ? yMin : 0;
+      // Log Y: non-positive baseline is unset (same guard as storageBuffer path).
+      const baselineValue =
+        yScale.kind === 'log'
+          ? Number.isFinite(baseline ?? Number.NaN) && (baseline as number) > 0
+            ? (baseline as number)
+            : fallbackBaseline
+          : Number.isFinite(baseline ?? Number.NaN)
+            ? (baseline as number)
+            : fallbackBaseline;
+      writeVsUniforms(ax, bx, ay, by, baselineValue, logFlags, logBaseX, logBaseY);
     }
 
     const [r, g, b, a] = parseSeriesColorToRgba01(seriesConfig.areaStyle.color);

--- a/src/renderers/createAxisRenderer.ts
+++ b/src/renderers/createAxisRenderer.ts
@@ -1,6 +1,6 @@
 import gridWgsl from '../shaders/grid.wgsl?raw';
 import type { AxisConfig } from '../config/types';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
 import type { GridArea } from './createGridRenderer';
 import { parseCssColorToRgba01 } from '../utils/colors';
@@ -9,7 +9,7 @@ import type { PipelineCache } from '../core/PipelineCache';
 export interface AxisRenderer {
   prepare(
     axisConfig: AxisConfig,
-    scale: LinearScale,
+    scale: ContinuousScale,
     orientation: 'x' | 'y',
     gridArea: GridArea,
     axisLineColor?: string,
@@ -128,7 +128,7 @@ const resolveTickDomainValues = (
 
 const generateAxisVertices = (
   axisConfig: AxisConfig,
-  scale: LinearScale,
+  scale: ContinuousScale,
   orientation: 'x' | 'y',
   gridArea: GridArea,
   tickCountOverride?: number,

--- a/src/renderers/createBarRenderer.ts
+++ b/src/renderers/createBarRenderer.ts
@@ -1,6 +1,7 @@
 import barWgsl from '../shaders/bar.wgsl?raw';
 import type { ResolvedBarSeriesConfig } from '../config/OptionResolver';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
+import { computeClipAffineFromContinuousScale, resolveLogProjection } from './packedXAffine';
 import type { GridArea } from './createGridRenderer';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
@@ -11,8 +12,8 @@ import type { PipelineCache } from '../core/PipelineCache';
 export interface BarRenderer {
   prepare(
     seriesConfigs: ReadonlyArray<ResolvedBarSeriesConfig>,
-    xScale: LinearScale,
-    yScale: LinearScale,
+    xScale: ContinuousScale,
+    yScale: ContinuousScale,
     gridArea: GridArea
   ): void;
   /**
@@ -63,24 +64,6 @@ const nextPow2 = (v: number): number => {
   if (!Number.isFinite(v) || v <= 0) return 1;
   const n = Math.ceil(v);
   return 2 ** Math.ceil(Math.log2(n));
-};
-
-/** Linear scale → clip affine: clip = a * domain + b (sample at v0, v1). */
-const computeClipAffineFromScale = (
-  scale: LinearScale,
-  v0: number,
-  v1: number
-): { readonly a: number; readonly b: number } => {
-  const p0 = scale.scale(v0);
-  const p1 = scale.scale(v1);
-
-  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
-    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
-  }
-
-  const a = (p1 - p0) / (v1 - v0);
-  const b = p0 - a * v0;
-  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
 };
 
 const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: number, by: number): void => {
@@ -217,12 +200,14 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
     ],
   });
 
-  const vsUniformBuffer = createUniformBuffer(device, 64, {
+  // mat4 (64) + logBaseX/logBaseY/logFlags/pad (16) = 80
+  const vsUniformBuffer = createUniformBuffer(device, 80, {
     label: 'barRenderer/vsUniforms',
   });
   // Domain → clip affine written every prepare (not identity).
-  const vsUniformScratchBuffer = new ArrayBuffer(64);
+  const vsUniformScratchBuffer = new ArrayBuffer(80);
   const vsUniformScratchF32 = new Float32Array(vsUniformScratchBuffer);
+  const vsUniformScratchU32 = new Uint32Array(vsUniformScratchBuffer);
 
   const bindGroup = device.createBindGroup({
     layout: bindGroupLayout,
@@ -290,22 +275,48 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
     cpuInstanceStagingF32 = new Float32Array(cpuInstanceStagingBuffer);
   };
 
-  // Issue 2.5: skip VS uniform write when affine unchanged.
+  // Issue 2.5: skip VS uniform write when affine / log projection unchanged.
   let lastAx = Number.NaN;
   let lastBx = Number.NaN;
   let lastAy = Number.NaN;
   let lastBy = Number.NaN;
+  let lastLogFlags = 0;
+  let lastLogBaseX = Number.NaN;
+  let lastLogBaseY = Number.NaN;
 
-  const writeVsUniforms = (ax: number, bx: number, ay: number, by: number): void => {
-    if (lastAx === ax && lastBx === bx && lastAy === ay && lastBy === by) {
+  const writeVsUniforms = (
+    ax: number,
+    bx: number,
+    ay: number,
+    by: number,
+    logFlags: number,
+    logBaseX: number,
+    logBaseY: number
+  ): void => {
+    if (
+      lastAx === ax &&
+      lastBx === bx &&
+      lastAy === ay &&
+      lastBy === by &&
+      lastLogFlags === logFlags &&
+      lastLogBaseX === logBaseX &&
+      lastLogBaseY === logBaseY
+    ) {
       return;
     }
     writeTransformMat4F32(vsUniformScratchF32, ax, bx, ay, by);
+    vsUniformScratchF32[16] = logBaseX;
+    vsUniformScratchF32[17] = logBaseY;
+    vsUniformScratchU32[18] = logFlags >>> 0;
+    vsUniformScratchU32[19] = 0;
     writeUniformBuffer(device, vsUniformBuffer, vsUniformScratchBuffer);
     lastAx = ax;
     lastBx = bx;
     lastAy = ay;
     lastBy = by;
+    lastLogFlags = logFlags;
+    lastLogBaseX = logBaseX;
+    lastLogBaseY = logBaseY;
   };
 
   /**
@@ -415,7 +426,7 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
 
   const computeBaselineForBarsFromAxis = (
     seriesConfigs: ReadonlyArray<ResolvedBarSeriesConfig>,
-    yScale: LinearScale,
+    yScale: ContinuousScale,
     plotClipRect: Readonly<{ top: number; bottom: number }>
   ): number => {
     // Determine the visible y-domain from the yScale + plot clip rect (clip-space).
@@ -450,7 +461,7 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
       readonly barCategoryGap?: number;
     },
     clusterCount: number,
-    xScale: LinearScale,
+    xScale: ContinuousScale,
     plotSize: { readonly plotWidthCss: number },
     plotClipRect: Readonly<{ left: number; right: number }>,
     fallbackCategoryCount: number
@@ -484,10 +495,20 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
       // CSS-px width → domain via current x scale (not linear under pure zoom alone).
       const plotClipWidth = plotClipRect.right - plotClipRect.left;
       const clipPerCssX = plotSize.plotWidthCss > 0 ? plotClipWidth / plotSize.plotWidthCss : 0;
-      const { a: ax } = computeClipAffineFromScale(xScale, 0, 1);
-      const absAx = Math.abs(ax);
       const widthClip = Math.max(0, rawBarWidth) * clipPerCssX;
-      barWidthDomain = absAx > 0 && Number.isFinite(absAx) ? widthClip / absAx : 0;
+      if (xScale.kind === 'log') {
+        // Local domain width at geometric mid (log spacing ≠ linear domain width).
+        const { min, max } = xScale.getDomain();
+        const mid = Math.sqrt(Math.max(min, Number.MIN_VALUE) * Math.max(max, Number.MIN_VALUE));
+        const midClip = xScale.scale(mid);
+        const lo = xScale.invert(midClip - widthClip * 0.5);
+        const hi = xScale.invert(midClip + widthClip * 0.5);
+        barWidthDomain = Number.isFinite(lo) && Number.isFinite(hi) ? Math.abs(hi - lo) : 0;
+      } else {
+        const { a: ax } = computeClipAffineFromContinuousScale(xScale);
+        const absAx = Math.abs(ax);
+        barWidthDomain = absAx > 0 && Number.isFinite(absAx) ? widthClip / absAx : 0;
+      }
       barWidthDomain = Math.min(barWidthDomain, maxBarWidthDomain);
     } else if (typeof rawBarWidth === 'string') {
       const p = parsePercent(rawBarWidth);
@@ -552,11 +573,12 @@ export function createBarRenderer(device: GPUDevice, options?: BarRendererOption
     const plotClipRect = computePlotClipRect(gridArea);
 
     // Domain → clip affine always (yMin/yMax-only setOption updates uniforms only).
-    // Sample at (0, 1) like line renderer — works for any linear scale including
-    // intro-animated bar y-scale wrappers (still affine toward baseline).
-    const { a: ax, b: bx } = computeClipAffineFromScale(xScale, 0, 1);
-    const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
-    writeVsUniforms(ax, bx, ay, by);
+    // Linear: sample (0,1); log: affine in log space. Intro-animated bar y wrappers
+    // remain linear ContinuousScale.
+    const { a: ax, b: bx } = computeClipAffineFromContinuousScale(xScale);
+    const { a: ay, b: by } = computeClipAffineFromContinuousScale(yScale);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
+    writeVsUniforms(ax, bx, ay, by, logFlags, logBaseX, logBaseY);
     // Cluster offsets are applied in domain then transformed; flip order under reversed x
     // so clip-space series order matches the pre-domain-pack layout.
     const xDir = ax < 0 ? -1 : 1;

--- a/src/renderers/createCandlestickRenderer.ts
+++ b/src/renderers/createCandlestickRenderer.ts
@@ -1,19 +1,20 @@
 import candlestickWgsl from '../shaders/candlestick.wgsl?raw';
 import type { ResolvedCandlestickSeriesConfig } from '../config/OptionResolver';
 import type { OHLCDataPoint, OHLCDataPointTuple } from '../config/types';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
 import type { GridArea } from './createGridRenderer';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
 import type { PipelineCache } from '../core/PipelineCache';
 import { resolveUploadPolicy } from '../data/seriesResidency';
+import { computeClipAffineFromContinuousScale, resolveLogProjection } from './packedXAffine';
 
 export interface CandlestickRenderer {
   prepare(
     series: ResolvedCandlestickSeriesConfig,
     data: ResolvedCandlestickSeriesConfig['data'],
-    xScale: LinearScale,
-    yScale: LinearScale,
+    xScale: ContinuousScale,
+    yScale: ContinuousScale,
     gridArea: GridArea,
     backgroundColor?: string
   ): void;
@@ -183,21 +184,6 @@ const computeCategoryStep = (data: ReadonlyArray<OHLCDataPoint>): number => {
   return Number.isFinite(minStep) && minStep > 0 ? minStep : 1;
 };
 
-const computeClipAffineFromScale = (
-  scale: LinearScale,
-  v0: number,
-  v1: number
-): { readonly a: number; readonly b: number } => {
-  const p0 = scale.scale(v0);
-  const p1 = scale.scale(v1);
-  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
-    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
-  }
-  const a = (p1 - p0) / (v1 - v0);
-  const b = p0 - a * v0;
-  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
-};
-
 const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: number, by: number): void => {
   out[0] = ax;
   out[1] = 0;
@@ -222,6 +208,22 @@ const nearEqual = (a: number, b: number): boolean => Math.abs(a - b) <= 1e-9 * M
 type CandleGeometryCache = {
   readonly data: ResolvedCandlestickSeriesConfig['data'];
   /**
+   * Source array length. Streaming `appendData` mutates the coordinator-owned
+   * OHLC array in place (stable ref + growing length). Identity skip must miss
+   * when length changes or new candles never reach the instance buffer.
+   */
+  readonly dataLength: number;
+  /**
+   * Last candle OHLC fingerprint for equal-N in-place updates (forming candle
+   * via setOption on a stable data array). Axes-only prepares keep the same
+   * values so the skip still hits.
+   */
+  readonly lastTimestamp: number;
+  readonly lastOpen: number;
+  readonly lastClose: number;
+  readonly lastLow: number;
+  readonly lastHigh: number;
+  /**
    * Absolute domain origin subtracted from each instance `x` before Float32
    * upload. Large time-axis timestamps (ms epoch) lose spacing as f32; packing
    * relative to this origin keeps candle x separable. VS transform bakes it
@@ -239,6 +241,28 @@ type CandleGeometryCache = {
   readonly backgroundColor: string | undefined;
   readonly instanceCount: number;
   readonly hollowInstanceCount: number;
+};
+
+/** Last candle OHLC for geometry-cache content fingerprint (or NaNs when empty). */
+const lastCandleFingerprint = (
+  data: ResolvedCandlestickSeriesConfig['data']
+): {
+  readonly timestamp: number;
+  readonly open: number;
+  readonly close: number;
+  readonly low: number;
+  readonly high: number;
+} => {
+  if (data.length === 0) {
+    return {
+      timestamp: Number.NaN,
+      open: Number.NaN,
+      close: Number.NaN,
+      low: Number.NaN,
+      high: Number.NaN,
+    };
+  }
+  return getOHLC(data[data.length - 1]!);
 };
 
 /** First finite OHLC timestamp — packing origin for f32 domain x. */
@@ -404,50 +428,87 @@ export function createCandlestickRenderer(
       geometryCache && geometryCache.data === data ? geometryCache.categoryStep : computeCategoryStep(data);
 
     // Pack x as (timestamp - packingOrigin) for f32-safe time axes.
-    // Affine MUST be sampled near packingOrigin — computeClipAffineFromScale(0,1)
-    // loses digits when domain is ~1e12 epoch-ms; bx + ax*origin then fails to cancel.
+    // Affine MUST be sampled near packingOrigin — (0,1) loses digits on ~1e12 epoch-ms.
+    // Log X: packing is invalid under log projection — keep raw timestamps (origin 0).
     const packingOrigin =
-      geometryCache && geometryCache.data === data ? geometryCache.packingOrigin : firstFiniteTimestamp(data);
-    const xDelta = Number.isFinite(categoryStep) && categoryStep > 0 ? categoryStep : 1;
-    const pX0 = xScale.scale(packingOrigin);
-    const pX1 = xScale.scale(packingOrigin + xDelta);
-    const ax = Number.isFinite(pX0) && Number.isFinite(pX1) && xDelta !== 0 ? (pX1 - pX0) / xDelta : 0;
-    // clipX = ax * x_packed + pX0
-    const bxPacked = Number.isFinite(pX0) ? pX0 : 0;
+      xScale.kind === 'log'
+        ? 0
+        : geometryCache && geometryCache.data === data
+          ? geometryCache.packingOrigin
+          : firstFiniteTimestamp(data);
+    let ax: number;
+    let bxPacked: number;
+    if (xScale.kind === 'log') {
+      const aff = computeClipAffineFromContinuousScale(xScale);
+      ax = aff.a;
+      bxPacked = aff.b;
+    } else {
+      const xDelta = Number.isFinite(categoryStep) && categoryStep > 0 ? categoryStep : 1;
+      const pX0 = xScale.scale(packingOrigin);
+      const pX1 = xScale.scale(packingOrigin + xDelta);
+      ax = Number.isFinite(pX0) && Number.isFinite(pX1) && xDelta !== 0 ? (pX1 - pX0) / xDelta : 0;
+      // clipX = ax * x_packed + pX0
+      bxPacked = Number.isFinite(pX0) ? pX0 : 0;
+    }
 
-    // Y prices are typically O(1e2)–O(1e6); sampling (0,1) stays stable.
-    const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
-    const absAx = Math.abs(ax);
-    const domainPerCssX = absAx > 1e-20 ? clipPerCssX / absAx : 0;
+    // Y: linear samples (0,1); log solves affine in log space.
+    const { a: ay, b: by } = computeClipAffineFromContinuousScale(yScale);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
+
+    // CSS → domain width. On log X, clip-space slope is d(clip)/d(log x), so
+    // invert-at-mid yields local linear domain width (mirrors bar renderer).
+    const cssWidthToDomainX = (cssPx: number): number => {
+      const widthClip = Math.max(0, cssPx) * clipPerCssX;
+      if (!(widthClip > 0)) return 0;
+      if (xScale.kind === 'log') {
+        const { min, max } = xScale.getDomain();
+        const mid = Math.sqrt(Math.max(min, Number.MIN_VALUE) * Math.max(max, Number.MIN_VALUE));
+        const midClip = xScale.scale(mid);
+        const lo = xScale.invert(midClip - widthClip * 0.5);
+        const hi = xScale.invert(midClip + widthClip * 0.5);
+        return Number.isFinite(lo) && Number.isFinite(hi) ? Math.abs(hi - lo) : 0;
+      }
+      const absAx = Math.abs(ax);
+      return absAx > 1e-20 ? widthClip / absAx : 0;
+    };
 
     // Body width in domain units (percent of category is zoom-invariant).
     let bodyWidthDomain = 0;
     const rawBarWidth = series.barWidth;
     if (typeof rawBarWidth === 'number') {
-      bodyWidthDomain = Math.max(0, rawBarWidth) * domainPerCssX;
+      bodyWidthDomain = cssWidthToDomainX(rawBarWidth);
     } else if (typeof rawBarWidth === 'string') {
       const p = parsePercent(rawBarWidth);
       bodyWidthDomain = p == null ? 0 : categoryStep * clamp01(p);
     }
-    const minWidthDomain = series.barMinWidth * domainPerCssX;
-    const maxWidthDomain = series.barMaxWidth * domainPerCssX;
+    const minWidthDomain = cssWidthToDomainX(series.barMinWidth);
+    const maxWidthDomain = cssWidthToDomainX(series.barMaxWidth);
     bodyWidthDomain = Math.min(Math.max(bodyWidthDomain, minWidthDomain), maxWidthDomain);
 
     const wickWidthCssPx = series.itemStyle.borderWidth ?? DEFAULT_WICK_WIDTH_CSS_PX;
-    const wickWidthDomain = Math.max(0, wickWidthCssPx) * domainPerCssX;
-    const hollowBorderDomain = hollowMode ? Math.max(0, series.itemStyle.borderWidth * domainPerCssX) : 0;
+    const wickWidthDomain = cssWidthToDomainX(wickWidthCssPx);
+    const hollowBorderDomain = hollowMode ? cssWidthToDomainX(series.itemStyle.borderWidth) : 0;
 
     const upColorKey = series.itemStyle.upColor;
     const downColorKey = series.itemStyle.downColor;
     const upBorderKey = series.itemStyle.upBorderColor;
     const downBorderKey = series.itemStyle.downBorderColor;
 
-    // Geometry identity skip: same data + domain layout → no instance rewrite.
-    // Policy verb shared via seriesResidency (issue 3.4).
+    // Geometry identity skip: same data ref + domain layout → no instance rewrite.
+    // Also require stable length and last-candle OHLC so streaming append
+    // (in-place push) and forming-candle setOption (mutate last bar) re-upload.
+    // Policy verb shared via seriesResidency (issue 3.4 / 1.3).
+    const lastFp = lastCandleFingerprint(data);
     const geometryHit =
       geometryCache != null &&
       instanceBuffer != null &&
       geometryCache.data === data &&
+      geometryCache.dataLength === data.length &&
+      nearEqual(geometryCache.lastTimestamp, lastFp.timestamp) &&
+      nearEqual(geometryCache.lastOpen, lastFp.open) &&
+      nearEqual(geometryCache.lastClose, lastFp.close) &&
+      nearEqual(geometryCache.lastLow, lastFp.low) &&
+      nearEqual(geometryCache.lastHigh, lastFp.high) &&
       nearEqual(geometryCache.packingOrigin, packingOrigin) &&
       nearEqual(geometryCache.categoryStep, categoryStep) &&
       nearEqual(geometryCache.bodyWidthDomain, bodyWidthDomain) &&
@@ -472,12 +533,13 @@ export function createCandlestickRenderer(
       needsGrowth: false,
     });
 
+    const vsUniformScratchU32 = new Uint32Array(vsUniformScratchBuffer);
     const writeVsUniforms = (): void => {
       writeTransformMat4F32(vsUniformScratchF32, ax, bxPacked, ay, by);
       vsUniformScratchF32[16] = wickWidthDomain;
-      vsUniformScratchF32[17] = 0;
-      vsUniformScratchF32[18] = 0;
-      vsUniformScratchF32[19] = 0;
+      vsUniformScratchF32[17] = logBaseX;
+      vsUniformScratchF32[18] = logBaseY;
+      vsUniformScratchU32[19] = logFlags >>> 0;
       writeUniformBuffer(device, vsUniformBuffer, vsUniformScratchBuffer);
     };
 
@@ -626,6 +688,12 @@ export function createCandlestickRenderer(
 
     geometryCache = {
       data,
+      dataLength: data.length,
+      lastTimestamp: lastFp.timestamp,
+      lastOpen: lastFp.open,
+      lastClose: lastFp.close,
+      lastLow: lastFp.low,
+      lastHigh: lastFp.high,
       packingOrigin,
       categoryStep,
       bodyWidthDomain,

--- a/src/renderers/createGridRenderer.ts
+++ b/src/renderers/createGridRenderer.ts
@@ -48,6 +48,16 @@ export interface GridPrepareOptions {
    * the prepared geometry each frame.
    */
   readonly append?: boolean;
+  /**
+   * Explicit horizontal line Y positions in **clip space** (same space as axis scales).
+   * When non-empty, overrides even-count horizontal placement (log / tick-aligned grid).
+   */
+  readonly horizontalClipYs?: readonly number[];
+  /**
+   * Explicit vertical line X positions in **clip space**.
+   * When non-empty, overrides even-count vertical placement.
+   */
+  readonly verticalClipXs?: readonly number[];
 }
 
 export interface GridRendererOptions {
@@ -87,7 +97,13 @@ const IDENTITY_MAT4_BUFFER: ArrayBuffer = (() => {
   return buffer;
 })();
 
-const generateGridVertices = (gridArea: GridArea, horizontal: number, vertical: number): Float32Array => {
+const generateGridVertices = (
+  gridArea: GridArea,
+  horizontal: number,
+  vertical: number,
+  horizontalClipYs?: readonly number[],
+  verticalClipXs?: readonly number[]
+): Float32Array => {
   const { left, right, top, bottom, canvasWidth, canvasHeight } = gridArea;
   // Be resilient: older call sites may omit/incorrectly pass DPR. Defaulting avoids hard crashes.
   const devicePixelRatio =
@@ -102,48 +118,52 @@ const generateGridVertices = (gridArea: GridArea, horizontal: number, vertical: 
   const plotWidth = plotRight - plotLeft;
   const plotHeight = plotBottom - plotTop;
 
+  const useHClips = horizontalClipYs != null && horizontalClipYs.length > 0;
+  const useVClips = verticalClipXs != null && verticalClipXs.length > 0;
+  const hCount = useHClips ? horizontalClipYs!.length : horizontal;
+  const vCount = useVClips ? verticalClipXs!.length : vertical;
+
   // Total vertices: (horizontal + vertical) * 2 vertices per line
-  const totalLines = horizontal + vertical;
+  const totalLines = hCount + vCount;
   const vertices = new Float32Array(totalLines * 2 * 2); // 2 vertices * 2 floats per vertex
 
   let idx = 0;
 
+  const xClipLeft = (plotLeft / canvasWidth) * 2.0 - 1.0;
+  const xClipRight = (plotRight / canvasWidth) * 2.0 - 1.0;
+  const yClipTop = 1.0 - (plotTop / canvasHeight) * 2.0;
+  const yClipBottom = 1.0 - (plotBottom / canvasHeight) * 2.0;
+
   // Generate horizontal lines (constant Y, varying X)
-  for (let i = 0; i < horizontal; i++) {
-    // Calculate t parameter for even spacing
-    const t = horizontal === 1 ? 0.5 : i / (horizontal - 1);
-    const yDevice = plotTop + t * plotHeight;
+  for (let i = 0; i < hCount; i++) {
+    let yClip: number;
+    if (useHClips) {
+      yClip = horizontalClipYs![i]!;
+    } else {
+      const t = hCount === 1 ? 0.5 : i / (hCount - 1);
+      const yDevice = plotTop + t * plotHeight;
+      yClip = 1.0 - (yDevice / canvasHeight) * 2.0; // Flip Y-axis
+    }
 
-    // Convert to clip space
-    const xClipLeft = (plotLeft / canvasWidth) * 2.0 - 1.0;
-    const xClipRight = (plotRight / canvasWidth) * 2.0 - 1.0;
-    const yClip = 1.0 - (yDevice / canvasHeight) * 2.0; // Flip Y-axis
-
-    // First vertex (left edge)
     vertices[idx++] = xClipLeft;
     vertices[idx++] = yClip;
-
-    // Second vertex (right edge)
     vertices[idx++] = xClipRight;
     vertices[idx++] = yClip;
   }
 
   // Generate vertical lines (constant X, varying Y)
-  for (let i = 0; i < vertical; i++) {
-    // Calculate t parameter for even spacing
-    const t = vertical === 1 ? 0.5 : i / (vertical - 1);
-    const xDevice = plotLeft + t * plotWidth;
+  for (let i = 0; i < vCount; i++) {
+    let xClip: number;
+    if (useVClips) {
+      xClip = verticalClipXs![i]!;
+    } else {
+      const t = vCount === 1 ? 0.5 : i / (vCount - 1);
+      const xDevice = plotLeft + t * plotWidth;
+      xClip = (xDevice / canvasWidth) * 2.0 - 1.0;
+    }
 
-    // Convert to clip space
-    const xClip = (xDevice / canvasWidth) * 2.0 - 1.0;
-    const yClipTop = 1.0 - (plotTop / canvasHeight) * 2.0; // Flip Y-axis
-    const yClipBottom = 1.0 - (plotBottom / canvasHeight) * 2.0; // Flip Y-axis
-
-    // First vertex (top edge)
     vertices[idx++] = xClip;
     vertices[idx++] = yClipTop;
-
-    // Second vertex (bottom edge)
     vertices[idx++] = xClip;
     vertices[idx++] = yClipBottom;
   }
@@ -318,7 +338,11 @@ export function createGridRenderer(device: GPUDevice, options?: GridRendererOpti
     const isOptionsObject =
       lineCountOrOptions != null &&
       typeof lineCountOrOptions === 'object' &&
-      ('lineCount' in lineCountOrOptions || 'color' in lineCountOrOptions || 'append' in lineCountOrOptions);
+      ('lineCount' in lineCountOrOptions ||
+        'color' in lineCountOrOptions ||
+        'append' in lineCountOrOptions ||
+        'horizontalClipYs' in lineCountOrOptions ||
+        'verticalClipXs' in lineCountOrOptions);
 
     const optionsArg: GridPrepareOptions | undefined = isOptionsObject
       ? (lineCountOrOptions as GridPrepareOptions)
@@ -328,8 +352,16 @@ export function createGridRenderer(device: GPUDevice, options?: GridRendererOpti
       ? optionsArg?.lineCount
       : (lineCountOrOptions as GridLineCount | undefined);
 
-    const horizontal = lineCount?.horizontal ?? DEFAULT_HORIZONTAL_LINES;
-    const vertical = lineCount?.vertical ?? DEFAULT_VERTICAL_LINES;
+    const horizontalClipYs = optionsArg?.horizontalClipYs;
+    const verticalClipXs = optionsArg?.verticalClipXs;
+    const horizontal =
+      horizontalClipYs != null && horizontalClipYs.length > 0
+        ? horizontalClipYs.length
+        : (lineCount?.horizontal ?? DEFAULT_HORIZONTAL_LINES);
+    const vertical =
+      verticalClipXs != null && verticalClipXs.length > 0
+        ? verticalClipXs.length
+        : (lineCount?.vertical ?? DEFAULT_VERTICAL_LINES);
     const colorString = optionsArg?.color ?? DEFAULT_GRID_COLOR;
     const append = optionsArg?.append === true;
 
@@ -361,8 +393,8 @@ export function createGridRenderer(device: GPUDevice, options?: GridRendererOpti
       return;
     }
 
-    // Generate vertices for this batch
-    const vertices = generateGridVertices(gridArea, horizontal, vertical);
+    // Generate vertices for this batch (even-count or tick-aligned clip positions)
+    const vertices = generateGridVertices(gridArea, horizontal, vertical, horizontalClipYs, verticalClipXs);
     const newBatchVertexCount = (horizontal + vertical) * 2;
 
     // Parse color for this batch (fallbacks to internal default)

--- a/src/renderers/createLineRenderer.ts
+++ b/src/renderers/createLineRenderer.ts
@@ -1,12 +1,16 @@
 import lineWgsl from '../shaders/line.wgsl?raw';
 import type { ResolvedLineSeriesConfig } from '../config/OptionResolver';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
 import { getPointCount } from '../data/cartesianData';
 import type { PipelineCache } from '../core/PipelineCache';
 import { resolveLineDrawPolicy, type LineDrawPolicy } from './lineDrawPolicy';
-import { computePackedXAffineFromScale } from './packedXAffine';
+import {
+  computeClipAffineFromContinuousScale,
+  computePackedXAffineFromScale,
+  resolveLogProjection,
+} from './packedXAffine';
 
 export interface LineRenderer {
   /**
@@ -20,8 +24,8 @@ export interface LineRenderer {
   prepare(
     seriesConfig: ResolvedLineSeriesConfig,
     dataBuffer: GPUBuffer,
-    xScale: LinearScale,
-    yScale: LinearScale,
+    xScale: ContinuousScale,
+    yScale: ContinuousScale,
     xOffset?: number,
     devicePixelRatio?: number,
     canvasWidthDevicePx?: number,
@@ -102,24 +106,6 @@ const DEFAULT_LINE_WIDTH_CSS_PX = 2;
 const clamp01 = (v: number): number => Math.min(1, Math.max(0, v));
 const parseSeriesColorToRgba01 = (color: string): Rgba => parseCssColorToRgba01(color) ?? ([0, 0, 0, 1] as const);
 
-const computeClipAffineFromScale = (
-  scale: LinearScale,
-  v0: number,
-  v1: number
-): { readonly a: number; readonly b: number } => {
-  const p0 = scale.scale(v0);
-  const p1 = scale.scale(v1);
-
-  // If the domain sample is degenerate or non-finite, fall back to constant output.
-  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
-    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
-  }
-
-  const a = (p1 - p0) / (v1 - v0);
-  const b = p0 - a * v0;
-  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
-};
-
 const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: number, by: number): void => {
   // Column-major mat4x4 for: clip = M * vec4(x, y, 0, 1)
   out[0] = ax;
@@ -187,8 +173,8 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
   const bindGroupLayout = getLineBindGroupLayout(device);
 
   // VS uniforms: mat4x4 (64) + canvasSize (8) + dpr (4) + lineWidthCssPx (4)
-  // + ringStart/ringCapacity/pad (16) = 96 bytes (16-byte aligned).
-  const vsUniformBuffer = createUniformBuffer(device, 96, {
+  // + ringStart/ringCapacity (8) + logBaseX/logBaseY (8) + logFlags/pad (8) = 112.
+  const vsUniformBuffer = createUniformBuffer(device, 112, {
     label: 'lineRenderer/vsUniforms',
   });
   const fsUniformBuffer = createUniformBuffer(device, 16, {
@@ -196,7 +182,7 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
   });
 
   // Reused CPU-side staging for uniform writes (avoid per-frame allocations).
-  const vsUniformScratchBuffer = new ArrayBuffer(96);
+  const vsUniformScratchBuffer = new ArrayBuffer(112);
   const vsUniformScratchF32 = new Float32Array(vsUniformScratchBuffer);
   const vsUniformScratchU32 = new Uint32Array(vsUniformScratchBuffer);
   const fsUniformScratchF32 = new Float32Array(4);
@@ -227,6 +213,9 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
   let lastLineWidth = Number.NaN;
   let lastRingStart = 0;
   let lastRingCapacity = 0;
+  let lastLogFlags = 0;
+  let lastLogBaseX = Number.NaN;
+  let lastLogBaseY = Number.NaN;
   /** Which VS buffer is currently referenced by currentBindGroup. */
   let boundVsBuffer: GPUBuffer = vsUniformBuffer;
 
@@ -322,13 +311,14 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
         ? Math.floor(pointCountOverride)
         : getPointCount(seriesConfig.data);
 
-    // X: packed-origin affine (stable for epoch-ms time axes). Y: sample (0,1)
-    // — y values stay O(1)–O(1e6), no packing offset.
+    // X: packed-origin affine (stable for epoch-ms time axes; log X uses log-space affine).
+    // Y: linear samples (0,1); log Y solves affine in log space (never sample raw 0,1 on log).
     const { a: ax, b: bxPacked } = computePackedXAffineFromScale(xScale, xOffset);
-    const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
+    const { a: ay, b: by } = computeClipAffineFromContinuousScale(yScale);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
 
     // Write VS uniforms: mat4x4 (16 floats) + canvasSize (2 floats) + dpr (1 float)
-    // + lineWidth (1 float) + ringStart/ringCapacity (u32 pair + pad).
+    // + lineWidth (1 float) + ringStart/ringCapacity + logBaseX/Y + logFlags/pad.
     writeTransformMat4F32(vsUniformScratchF32, ax, bxPacked, ay, by);
     const dpr = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1;
     const canvasW = Number.isFinite(canvasWidthDevicePx) && canvasWidthDevicePx > 0 ? canvasWidthDevicePx : 1;
@@ -366,15 +356,17 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
     vsUniformScratchF32[17] = canvasH;
     vsUniformScratchF32[18] = dpr;
     vsUniformScratchF32[19] = lineWidthCss;
-    // u32 ring fields at byte offset 80 (float index 20).
+    // u32 ring fields at byte offset 80 (float index 20); log bases + flags follow.
     vsUniformScratchU32[20] = ringStart >>> 0;
     vsUniformScratchU32[21] = ringCapacity >>> 0;
-    vsUniformScratchU32[22] = 0;
-    vsUniformScratchU32[23] = 0;
+    vsUniformScratchF32[22] = logBaseX;
+    vsUniformScratchF32[23] = logBaseY;
+    vsUniformScratchU32[24] = logFlags >>> 0;
+    vsUniformScratchU32[25] = 0;
 
     // Private VS only (multi-chart deferred-submit safe). Dirty-skip when affine /
-    // size / width / ring layout unchanged (issue 2.5) — covers axes-only ticks
-    // without a device-global shared buffer that multi-chart slots would clobber.
+    // size / width / ring layout / log projection unchanged (issue 2.5) — covers
+    // axes-only ticks without a device-global shared buffer that multi-chart slots would clobber.
     let vsBufferForBind: GPUBuffer = vsUniformBuffer;
     {
       const vsDirty =
@@ -387,7 +379,10 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
         lastDpr !== dpr ||
         lastLineWidth !== lineWidthCss ||
         lastRingStart !== ringStart ||
-        lastRingCapacity !== ringCapacity;
+        lastRingCapacity !== ringCapacity ||
+        lastLogFlags !== logFlags ||
+        lastLogBaseX !== logBaseX ||
+        lastLogBaseY !== logBaseY;
       if (vsDirty) {
         writeUniformBuffer(device, vsUniformBuffer, vsUniformScratchBuffer);
         lastAx = ax;
@@ -400,6 +395,9 @@ export function createLineRenderer(device: GPUDevice, options?: LineRendererOpti
         lastLineWidth = lineWidthCss;
         lastRingStart = ringStart;
         lastRingCapacity = ringCapacity;
+        lastLogFlags = logFlags;
+        lastLogBaseX = logBaseX;
+        lastLogBaseY = logBaseY;
       }
     }
 

--- a/src/renderers/createScatterDensityRenderer.ts
+++ b/src/renderers/createScatterDensityRenderer.ts
@@ -1,7 +1,7 @@
 import scatterDensityBinningWgsl from '../shaders/scatterDensityBinning.wgsl?raw';
 import scatterDensityColormapWgsl from '../shaders/scatterDensityColormap.wgsl?raw';
 import type { RawBounds, ResolvedScatterSeriesConfig } from '../config/OptionResolver';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import type { GridArea } from './createGridRenderer';
 import {
@@ -12,6 +12,11 @@ import {
   createComputePipeline,
 } from './rendererUtils';
 import type { PipelineCache } from '../core/PipelineCache';
+import {
+  computeClipAffineFromContinuousScale,
+  computeClipAffineFromScale,
+  resolveLogProjection,
+} from './packedXAffine';
 
 export interface ScatterDensityRenderer {
   prepare(
@@ -20,8 +25,8 @@ export interface ScatterDensityRenderer {
     pointCount: number,
     visibleStartIndex: number,
     visibleEndIndex: number,
-    xScale: LinearScale,
-    yScale: LinearScale,
+    xScale: ContinuousScale,
+    yScale: ContinuousScale,
     gridArea: GridArea,
     rawBounds?: RawBounds,
     /**
@@ -60,23 +65,6 @@ const nextPow2 = (v: number): number => {
   if (!Number.isFinite(v) || v <= 0) return 1;
   const n = Math.ceil(v);
   return 2 ** Math.ceil(Math.log2(n));
-};
-
-const computeClipAffineFromScale = (
-  scale: LinearScale,
-  v0: number,
-  v1: number
-): { readonly a: number; readonly b: number } => {
-  const p0 = scale.scale(v0);
-  const p1 = scale.scale(v1);
-
-  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
-    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
-  }
-
-  const a = (p1 - p0) / (v1 - v0);
-  const b = p0 - a * v0;
-  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
 };
 
 const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: number, by: number): void => {
@@ -255,10 +243,10 @@ export function createScatterDensityRenderer(
     ],
   });
 
-  // Compute uniforms:
-  // transform(64) + viewportPx(8)+pad(8)=80
-  // plotOriginPx u32x2(8) + plotSizePx u32x2(8) = 16 => 96
-  // binSize/binCountX/binCountY/start/end/norm u32*6 (24) + pad u32x2 (8) => 128
+  // Compute uniforms (128 bytes):
+  // transform(64) + viewportPx(8) + logBaseX/Y(8) = 80
+  // logFlags/pad(8) + plotOriginPx(8) + plotSizePx(8) = 24 → 104
+  // binSize/binCountX/Y/start/end/norm u32*6 (24) → 128
   const computeUniformBuffer = createUniformBuffer(device, 128, {
     label: 'scatterDensity/computeUniforms',
   });
@@ -352,6 +340,9 @@ export function createScatterDensityRenderer(
   let lastNormalizationU32 = 2; // default 'log'
   // Scale affine samples (clip = a*domain + b). Y-only domain change leaves
   // buffer identity + visible indices stable but must re-bin (issue 0.1).
+  let lastLogFlags = 0;
+  let lastLogBaseX = Number.NaN;
+  let lastLogBaseY = Number.NaN;
   let lastAx = Number.NaN;
   let lastBx = Number.NaN;
   let lastAy = Number.NaN;
@@ -501,8 +492,15 @@ export function createScatterDensityRenderer(
     const yMin = rb?.yMin ?? 0;
     const yMax = rb?.yMax ?? 1;
 
-    const { a: ax, b: bx } = computeClipAffineFromScale(xScale, xMin, xMax);
-    const { a: ay, b: by } = computeClipAffineFromScale(yScale, yMin, yMax);
+    const { a: ax, b: bx } =
+      xScale.kind === 'log'
+        ? computeClipAffineFromContinuousScale(xScale)
+        : computeClipAffineFromScale(xScale, xMin, xMax);
+    const { a: ay, b: by } =
+      yScale.kind === 'log'
+        ? computeClipAffineFromContinuousScale(yScale)
+        : computeClipAffineFromScale(yScale, yMin, yMax);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
 
     // Dirty detection.
     if (lastPointBuffer !== pointBuffer) {
@@ -545,12 +543,23 @@ export function createScatterDensityRenderer(
       lastNormalizationU32 = normU32;
       computeDirty = true;
     }
-    // Scale affine: y-only domain change keeps buffer + visible range stable.
-    if (lastAx !== ax || lastBx !== bx || lastAy !== ay || lastBy !== by) {
+    // Scale affine / log projection: y-only domain change keeps buffer + visible range stable.
+    if (
+      lastAx !== ax ||
+      lastBx !== bx ||
+      lastAy !== ay ||
+      lastBy !== by ||
+      lastLogFlags !== logFlags ||
+      lastLogBaseX !== logBaseX ||
+      lastLogBaseY !== logBaseY
+    ) {
       lastAx = ax;
       lastBx = bx;
       lastAy = ay;
       lastBy = by;
+      lastLogFlags = logFlags;
+      lastLogBaseX = logBaseX;
+      lastLogBaseY = logBaseY;
       computeDirty = true;
     }
     // Content version: equal-N rewrite at same buffer identity must re-bin.
@@ -564,19 +573,21 @@ export function createScatterDensityRenderer(
     writeTransformMat4F32(computeUniformF32, ax, bx, ay, by);
     computeUniformF32[16] = gridArea.canvasWidth > 0 ? gridArea.canvasWidth : 1;
     computeUniformF32[17] = gridArea.canvasHeight > 0 ? gridArea.canvasHeight : 1;
-    computeUniformF32[18] = 0;
-    computeUniformF32[19] = 0;
+    computeUniformF32[18] = logBaseX;
+    computeUniformF32[19] = logBaseY;
+    computeUniformU32[20] = logFlags >>> 0;
+    computeUniformU32[21] = 0;
 
-    computeUniformU32[20] = plotScissor.x >>> 0;
-    computeUniformU32[21] = plotScissor.y >>> 0;
-    computeUniformU32[22] = plotScissor.w >>> 0;
-    computeUniformU32[23] = plotScissor.h >>> 0;
-    computeUniformU32[24] = binSizePx >>> 0;
-    computeUniformU32[25] = binCountX >>> 0;
-    computeUniformU32[26] = binCountY >>> 0;
-    computeUniformU32[27] = (Math.max(0, visibleStartIndex) | 0) >>> 0;
-    computeUniformU32[28] = (Math.max(0, visibleEndIndex) | 0) >>> 0;
-    computeUniformU32[29] = normU32 >>> 0;
+    computeUniformU32[22] = plotScissor.x >>> 0;
+    computeUniformU32[23] = plotScissor.y >>> 0;
+    computeUniformU32[24] = plotScissor.w >>> 0;
+    computeUniformU32[25] = plotScissor.h >>> 0;
+    computeUniformU32[26] = binSizePx >>> 0;
+    computeUniformU32[27] = binCountX >>> 0;
+    computeUniformU32[28] = binCountY >>> 0;
+    computeUniformU32[29] = (Math.max(0, visibleStartIndex) | 0) >>> 0;
+    computeUniformU32[30] = (Math.max(0, visibleEndIndex) | 0) >>> 0;
+    computeUniformU32[31] = normU32 >>> 0;
 
     writeUniformBuffer(device, computeUniformBuffer, computeUniformScratch);
 

--- a/src/renderers/createScatterRenderer.ts
+++ b/src/renderers/createScatterRenderer.ts
@@ -1,7 +1,8 @@
 import scatterWgsl from '../shaders/scatter.wgsl?raw';
 import type { ResolvedScatterSeriesConfig } from '../config/OptionResolver';
 import type { CartesianSeriesData } from '../config/types';
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale } from '../utils/scales';
+import { computeClipAffineFromContinuousScale, resolveLogProjection } from './packedXAffine';
 import { parseCssColorToRgba01 } from '../utils/colors';
 import type { GridArea } from './createGridRenderer';
 import { createRenderPipeline, createUniformBuffer, writeUniformBuffer } from './rendererUtils';
@@ -15,8 +16,8 @@ export interface ScatterRenderer {
   prepare(
     seriesConfig: ResolvedScatterSeriesConfig,
     data: CartesianSeriesData,
-    xScale: LinearScale,
-    yScale: LinearScale,
+    xScale: ContinuousScale,
+    yScale: ContinuousScale,
     gridArea?: GridArea,
     /**
      * When true (`performance.lod: 'strict'`), disable dense radius compaction
@@ -75,24 +76,6 @@ const nextPow2 = (v: number): number => {
   if (!Number.isFinite(v) || v <= 0) return 1;
   const n = Math.ceil(v);
   return 2 ** Math.ceil(Math.log2(n));
-};
-
-const computeClipAffineFromScale = (
-  scale: LinearScale,
-  v0: number,
-  v1: number
-): { readonly a: number; readonly b: number } => {
-  const p0 = scale.scale(v0);
-  const p1 = scale.scale(v1);
-
-  // If the domain sample is degenerate or non-finite, fall back to constant output.
-  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
-    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
-  }
-
-  const a = (p1 - p0) / (v1 - v0);
-  const b = p0 - a * v0;
-  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
 };
 
 const writeTransformMat4F32 = (out: Float32Array, ax: number, bx: number, ay: number, by: number): void => {
@@ -163,8 +146,8 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     ],
   });
 
-  // VSUniforms: mat4x4 (64) + viewportPx vec2 (8) + radiusPx f32 (4) + pad (4) = 80 bytes.
-  const vsUniformBuffer = createUniformBuffer(device, 80, {
+  // VSUniforms: mat4 (64) + viewport (8) + radius (4) + logBaseX (4) + logBaseY/logFlags/pad (12) = 96.
+  const vsUniformBuffer = createUniformBuffer(device, 96, {
     label: 'scatterRenderer/vsUniforms',
   });
   const fsUniformBuffer = createUniformBuffer(device, 16, {
@@ -172,8 +155,9 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
   });
 
   // Reused CPU-side staging for uniform writes (avoid per-frame allocations).
-  const vsUniformScratchBuffer = new ArrayBuffer(80);
+  const vsUniformScratchBuffer = new ArrayBuffer(96);
   const vsUniformScratchF32 = new Float32Array(vsUniformScratchBuffer);
+  const vsUniformScratchU32 = new Uint32Array(vsUniformScratchBuffer);
   const fsUniformScratchF32 = new Float32Array(4);
 
   const bindGroup = device.createBindGroup({
@@ -367,7 +351,10 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     by: number,
     viewportW: number,
     viewportH: number,
-    radiusDevicePx: number
+    radiusDevicePx: number,
+    logFlags: number,
+    logBaseX: number,
+    logBaseY: number
   ): void => {
     const w = Number.isFinite(viewportW) && viewportW > 0 ? viewportW : 1;
     const h = Number.isFinite(viewportH) && viewportH > 0 ? viewportH : 1;
@@ -376,7 +363,11 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     vsUniformScratchF32[16] = w;
     vsUniformScratchF32[17] = h;
     vsUniformScratchF32[18] = radiusDevicePx;
-    vsUniformScratchF32[19] = 0;
+    vsUniformScratchF32[19] = logBaseX;
+    vsUniformScratchF32[20] = logBaseY;
+    vsUniformScratchU32[21] = logFlags >>> 0;
+    vsUniformScratchU32[22] = 0;
+    vsUniformScratchU32[23] = 0;
     writeUniformBuffer(device, vsUniformBuffer, vsUniformScratchBuffer);
 
     lastViewportPx = [w, h];
@@ -385,11 +376,10 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
   const prepare: ScatterRenderer['prepare'] = (seriesConfig, data, xScale, yScale, gridArea, forceStandardDraw) => {
     assertNotDisposed();
 
-    // Linear scales: affine is independent of data bounds — sample at 0 and 1
-    // (same pattern as overlay memo / bar domain pack). Avoids O(n) bounds scan
-    // every full rewrite frame.
-    const { a: ax, b: bx } = computeClipAffineFromScale(xScale, 0, 1);
-    const { a: ay, b: by } = computeClipAffineFromScale(yScale, 0, 1);
+    // Continuous scales: linear samples (0,1); log solves affine in log space.
+    const { a: ax, b: bx } = computeClipAffineFromContinuousScale(xScale);
+    const { a: ay, b: by } = computeClipAffineFromContinuousScale(yScale);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(xScale, yScale);
 
     const dpr = gridArea?.devicePixelRatio ?? 1;
     const hasValidDpr = dpr > 0 && Number.isFinite(dpr);
@@ -456,7 +446,7 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
       });
       drawRadiusDevicePx = drawPol.effectiveRadiusDevicePx;
     }
-    writeVsUniforms(ax, bx, ay, by, viewportW, viewportH, drawRadiusDevicePx);
+    writeVsUniforms(ax, bx, ay, by, viewportW, viewportH, drawRadiusDevicePx, logFlags, logBaseX, logBaseY);
 
     const [r, g, b, a] = parseSeriesColorToRgba01(seriesConfig.color);
     fsUniformScratchF32[0] = r;

--- a/src/renderers/packedXAffine.ts
+++ b/src/renderers/packedXAffine.ts
@@ -1,4 +1,5 @@
-import type { LinearScale } from '../utils/scales';
+import type { ContinuousScale, LinearScale } from '../utils/scales';
+import { DEFAULT_LOG_BASE, normalizeLogBase } from '../utils/scales';
 
 /**
  * Clip affine for buffers packed as `x' = x - xOffset` (time-axis Float32 safety).
@@ -8,11 +9,19 @@ import type { LinearScale } from '../utils/scales';
  * candlestick packing-origin affine.
  *
  * clipX = ax * x' + b  with  b = scale(xOffset), ax = scale(xOffset+δ) - scale(xOffset) for δ=1.
+ *
+ * **Log X:** packing is invalid under log projection (log of offset-relative x is wrong).
+ * Callers must pass `xOffset === 0` for log X; this helper falls back to
+ * {@link computeClipAffineFromContinuousScale} when `scale.kind === 'log'`.
  */
 export function computePackedXAffineFromScale(
   scale: LinearScale,
   xOffset: number
 ): { readonly a: number; readonly b: number } {
+  if (scale.kind === 'log') {
+    // Log projection is applied in the VS to raw data-space x; affine is in log space.
+    return computeClipAffineFromContinuousScale(scale);
+  }
   const origin = Number.isFinite(xOffset) ? xOffset : 0;
   const p0 = scale.scale(origin);
   // Unit probe: for linear scales equals (rangeSpan/domainSpan); stays exact near origin.
@@ -25,4 +34,103 @@ export function computePackedXAffineFromScale(
   }
   const a = p1 - p0;
   return { a: Number.isFinite(a) ? a : 0, b: p0 };
+}
+
+/**
+ * Linear (or raw-sample) clip affine: `clip = a * v + b` solved from two domain samples.
+ *
+ * For linear axes sampling `(0, 1)` recovers the exact domain→range affine regardless of
+ * domain endpoints. **Do not** use raw `(0, 1)` for log axes (0 is outside domain).
+ */
+export function computeClipAffineFromScale(
+  scale: ContinuousScale,
+  v0: number,
+  v1: number
+): { readonly a: number; readonly b: number } {
+  const p0 = scale.scale(v0);
+  const p1 = scale.scale(v1);
+
+  if (!Number.isFinite(v0) || !Number.isFinite(v1) || v0 === v1 || !Number.isFinite(p0) || !Number.isFinite(p1)) {
+    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
+  }
+
+  const a = (p1 - p0) / (v1 - v0);
+  const b = p0 - a * v0;
+  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
+}
+
+/**
+ * Domain→clip affine consistent with vertex-shader log projection.
+ *
+ * - **Linear:** samples domain 0 and 1 (same as historical line/scatter Y path).
+ * - **Log:** solves `clip = a * log_b(v) + b` from domain endpoints so the VS can
+ *   `log(v)/log(base)` then multiply by the mat4.
+ */
+export function computeClipAffineFromContinuousScale(scale: ContinuousScale): {
+  readonly a: number;
+  readonly b: number;
+} {
+  if (scale.kind !== 'log') {
+    return computeClipAffineFromScale(scale, 0, 1);
+  }
+
+  const base = normalizeLogBase(scale.base ?? DEFAULT_LOG_BASE);
+  const { min: d0raw, max: d1raw } = scale.getDomain();
+  let d0 = d0raw;
+  let d1 = d1raw;
+  if (!(d0 > 0) || !(d1 > 0) || !Number.isFinite(d0) || !Number.isFinite(d1)) {
+    d0 = 1;
+    d1 = base > 1 ? base : 10;
+  }
+  if (d0 === d1) {
+    d1 = d0 * base;
+  } else if (d0 > d1) {
+    const t = d0;
+    d0 = d1;
+    d1 = t;
+  }
+
+  const lnB = Math.log(base);
+  const log0 = Math.log(d0) / lnB;
+  const log1 = Math.log(d1) / lnB;
+  const p0 = scale.scale(d0);
+  const p1 = scale.scale(d1);
+
+  if (
+    !Number.isFinite(log0) ||
+    !Number.isFinite(log1) ||
+    log0 === log1 ||
+    !Number.isFinite(p0) ||
+    !Number.isFinite(p1)
+  ) {
+    return { a: 0, b: Number.isFinite(p0) ? p0 : 0 };
+  }
+
+  const a = (p1 - p0) / (log1 - log0);
+  const b = p0 - a * log0;
+  return { a: Number.isFinite(a) ? a : 0, b: Number.isFinite(b) ? b : 0 };
+}
+
+/**
+ * Packed flags for series VS uniforms: bit0 = log X, bit1 = log Y.
+ */
+export function packLogAxisFlags(logX: boolean, logY: boolean): number {
+  return (logX ? 1 : 0) | (logY ? 2 : 0);
+}
+
+/**
+ * Resolve log projection params for a pair of continuous scales.
+ * When both axes are linear, flags are 0 and bases are unused (still written as 10).
+ * X and Y bases are independent so dual-log charts with mismatched bases project
+ * correctly (affine helpers already solve with each scale’s own base).
+ */
+export function resolveLogProjection(
+  xScale: ContinuousScale,
+  yScale: ContinuousScale
+): { readonly logFlags: number; readonly logBaseX: number; readonly logBaseY: number } {
+  const logX = xScale.kind === 'log';
+  const logY = yScale.kind === 'log';
+  const logBaseX = logX && xScale.base != null ? normalizeLogBase(xScale.base) : DEFAULT_LOG_BASE;
+  const logBaseY = logY && yScale.base != null ? normalizeLogBase(yScale.base) : DEFAULT_LOG_BASE;
+  return { logFlags: packLogAxisFlags(logX, logY), logBaseX, logBaseY };
 }

--- a/src/shaders/area.wgsl
+++ b/src/shaders/area.wgsl
@@ -11,8 +11,11 @@
 struct VSUniforms {
   transform: mat4x4<f32>,
   baseline: f32,
-  // Pad to 16-byte multiple (uniform buffer layout requirements).
-  _pad0: vec3<f32>,
+  // Independent bases so dual-log X/Y project correctly.
+  logBaseX: f32,
+  logBaseY: f32,
+  // bit0 = log X, bit1 = log Y (DataStore stays data-space; log before mat4).
+  logFlags: u32,
 };
 
 @group(0) @binding(0) var<uniform> vsUniforms: VSUniforms;
@@ -45,6 +48,34 @@ fn segmentUv(vid: u32) -> vec2<f32> {
   }
 }
 
+// Chrome Tint rejects NaN constants — use explicit positive checks instead.
+fn canLogProject(p: vec2<f32>) -> bool {
+  let flags = vsUniforms.logFlags;
+  if ((flags & 1u) != 0u && p.x <= 0.0) {
+    return false;
+  }
+  if ((flags & 2u) != 0u && p.y <= 0.0) {
+    return false;
+  }
+  return true;
+}
+
+fn projectData(p: vec2<f32>) -> vec2<f32> {
+  let flags = vsUniforms.logFlags;
+  if (flags == 0u) {
+    return p;
+  }
+  var x = p.x;
+  var y = p.y;
+  if ((flags & 1u) != 0u) {
+    x = log(x) / log(vsUniforms.logBaseX);
+  }
+  if ((flags & 2u) != 0u) {
+    y = log(y) / log(vsUniforms.logBaseY);
+  }
+  return vec2<f32>(x, y);
+}
+
 @vertex
 fn vsMain(
   @builtin(vertex_index) vertexIndex: u32,
@@ -65,8 +96,14 @@ fn vsMain(
 
   let uv = segmentUv(vertexIndex);
   let p = select(pA, pB, uv.x > 0.5);
+  // Baseline is data-space; log projection applies after select so fill-to-min works on log Y.
   let y = select(p.y, vsUniforms.baseline, uv.y > 0.5);
-  let pos = vec2<f32>(p.x, y);
+  let domainPos = vec2<f32>(p.x, y);
+  if (!canLogProject(domainPos)) {
+    out.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    return out;
+  }
+  let pos = projectData(domainPos);
   out.clipPosition = vsUniforms.transform * vec4<f32>(pos, 0.0, 1.0);
   return out;
 }

--- a/src/shaders/bar.wgsl
+++ b/src/shaders/bar.wgsl
@@ -13,6 +13,12 @@
 
 struct VSUniforms {
   transform: mat4x4<f32>,
+  // Independent bases so dual-log X/Y project correctly.
+  logBaseX: f32,
+  logBaseY: f32,
+  // bit0 = log X, bit1 = log Y
+  logFlags: u32,
+  _pad0: u32,
 };
 
 @group(0) @binding(0) var<uniform> vsUniforms: VSUniforms;
@@ -50,8 +56,32 @@ fn vsMain(in: VSIn, @builtin(vertex_index) vertexIndex: u32) -> VSOut {
   let corner = corners[vertexIndex];
   let domainPos = rectMin + corner * rectSize;
 
+  // Log projection per-corner (data-space rect → log space → clip affine).
+  var pos = domainPos;
+  let flags = vsUniforms.logFlags;
+  if (flags != 0u) {
+    if ((flags & 1u) != 0u) {
+      if (pos.x <= 0.0) {
+        var outBad: VSOut;
+        outBad.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        outBad.color = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        return outBad;
+      }
+      pos.x = log(pos.x) / log(vsUniforms.logBaseX);
+    }
+    if ((flags & 2u) != 0u) {
+      if (pos.y <= 0.0) {
+        var outBad: VSOut;
+        outBad.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        outBad.color = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        return outBad;
+      }
+      pos.y = log(pos.y) / log(vsUniforms.logBaseY);
+    }
+  }
+
   var out: VSOut;
-  out.clipPosition = vsUniforms.transform * vec4<f32>(domainPos, 0.0, 1.0);
+  out.clipPosition = vsUniforms.transform * vec4<f32>(pos, 0.0, 1.0);
   out.color = in.color;
   return out;
 }

--- a/src/shaders/candlestick.wgsl
+++ b/src/shaders/candlestick.wgsl
@@ -16,9 +16,11 @@
 struct VSUniforms {
   transform: mat4x4<f32>,
   wickWidth: f32,
-  _pad0: f32,
-  _pad1: f32,
-  _pad2: f32,
+  // Independent bases so dual-log X/Y project correctly.
+  logBaseX: f32,
+  logBaseY: f32,
+  // bit0 = log X, bit1 = log Y
+  logFlags: u32,
 };
 
 @group(0) @binding(0) var<uniform> vsUniforms: VSUniforms;
@@ -96,6 +98,29 @@ fn vsMain(in: VSIn, @builtin(vertex_index) vertexIndex: u32) -> VSOut {
     let wickMin = vec2<f32>(wickLeft, in.low);
     let wickMax = vec2<f32>(wickRight, bodyBottom);
     pos = wickMin + corner * (wickMax - wickMin);
+  }
+
+  // Log projection per-corner (OHLC stay data-space in instance buffer).
+  let flags = vsUniforms.logFlags;
+  if (flags != 0u) {
+    if ((flags & 1u) != 0u) {
+      if (pos.x <= 0.0) {
+        var outBad: VSOut;
+        outBad.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        outBad.color = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        return outBad;
+      }
+      pos.x = log(pos.x) / log(vsUniforms.logBaseX);
+    }
+    if ((flags & 2u) != 0u) {
+      if (pos.y <= 0.0) {
+        var outBad: VSOut;
+        outBad.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        outBad.color = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        return outBad;
+      }
+      pos.y = log(pos.y) / log(vsUniforms.logBaseY);
+    }
   }
 
   var out: VSOut;

--- a/src/shaders/line.wgsl
+++ b/src/shaders/line.wgsl
@@ -17,7 +17,7 @@
 const AA_PADDING: f32 = 1.5;
 
 struct VSUniforms {
-  transform       : mat4x4<f32>,  // 64 bytes: data-coord → clip-space
+  transform       : mat4x4<f32>,  // 64 bytes: (log-)data-coord → clip-space
   canvasSize      : vec2<f32>,     //  8 bytes: device pixels (width, height)
   devicePixelRatio: f32,           //  4 bytes
   lineWidthCssPx  : f32,           //  4 bytes: line width in CSS pixels
@@ -25,10 +25,15 @@ struct VSUniforms {
   // logical point. When ringCapacity == 0, storage is linear chronological.
   ringStart       : u32,           //  4 bytes
   ringCapacity    : u32,           //  4 bytes
-  pad0            : u32,           //  4 bytes
-  pad1            : u32,           //  4 bytes
+  // Log projection (DataStore stays data-space): bit0 = log X, bit1 = log Y.
+  // When set, VS applies log_b(v) before the mat4. Non-positive → degenerate gap.
+  // Bases are independent so dual-log X/Y can use different bases.
+  logBaseX        : f32,           //  4 bytes
+  logBaseY        : f32,           //  4 bytes
+  logFlags        : u32,           //  4 bytes
+  _pad0           : u32,           //  4 bytes
 };
-// Total: 96 bytes (aligned to 16).
+// Total: 112 bytes (aligned to 16).
 
 @group(0) @binding(0) var<uniform> vsUniforms : VSUniforms;
 
@@ -57,6 +62,38 @@ fn pointAt(logicalIdx : u32) -> vec2<f32> {
   return points[phys];
 }
 
+// True when log-enabled axes have strictly positive values (required for log).
+// Chrome Tint rejects NaN constants (`0.0/0.0`, bitcast quiet-NaN), so gaps are
+// handled by canLogProject + degenerate verts — never by synthesizing NaN in WGSL.
+fn canLogProject(p : vec2<f32>) -> bool {
+  let flags = vsUniforms.logFlags;
+  if ((flags & 1u) != 0u && p.x <= 0.0) {
+    return false;
+  }
+  if ((flags & 2u) != 0u && p.y <= 0.0) {
+    return false;
+  }
+  return true;
+}
+
+// Optional log projection in data space before the clip affine (mat4).
+// Flags off → identity. Precondition: canLogProject(p) when flags != 0.
+fn projectData(p : vec2<f32>) -> vec2<f32> {
+  let flags = vsUniforms.logFlags;
+  if (flags == 0u) {
+    return p;
+  }
+  var x = p.x;
+  var y = p.y;
+  if ((flags & 1u) != 0u) {
+    x = log(x) / log(vsUniforms.logBaseX);
+  }
+  if ((flags & 2u) != 0u) {
+    y = log(y) / log(vsUniforms.logBaseY);
+  }
+  return vec2<f32>(x, y);
+}
+
 // Returns UV for the 6 vertices of a quad (2 triangles):
 //   uv.x: 0 → endpoint A, 1 → endpoint B
 //   uv.y: 0 → +side, 1 → −side
@@ -79,21 +116,26 @@ fn vsMain(
   let uv = quadUv(vid);
 
   // Read segment endpoints in data coordinates (logical order under ring mode).
-  let pA_data = pointAt(iid);
-  let pB_data = pointAt(iid + 1u);
+  let pA_raw = pointAt(iid);
+  let pB_raw = pointAt(iid + 1u);
 
   // ── Gap detection ──────────────────────────────────────────────
   // Null entries in the data array are packed as NaN by the CPU.
   // Collapse the quad to a degenerate point so the rasterizer discards it.
   // WGSL has no isnan(); use the IEEE 754 property that NaN != NaN.
-  if (pA_data.x != pA_data.x || pA_data.y != pA_data.y ||
-      pB_data.x != pB_data.x || pB_data.y != pB_data.y) {
+  if (pA_raw.x != pA_raw.x || pA_raw.y != pA_raw.y ||
+      pB_raw.x != pB_raw.x || pB_raw.y != pB_raw.y ||
+      !canLogProject(pA_raw) || !canLogProject(pB_raw)) {
     var out: VSOut;
     out.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
     out.acrossDevice = 0.0;
     out.widthDevice = 0.0;
     return out;
   }
+
+  // Log axes: project data → log space, then affine (mat4) is in transformed space.
+  let pA_data = projectData(pA_raw);
+  let pB_data = projectData(pB_raw);
 
   // Transform to clip space.
   let clipA = vsUniforms.transform * vec4<f32>(pA_data, 0.0, 1.0);
@@ -202,15 +244,18 @@ fn vsMainHairline(
   // the whole segment so one-sided nulls cannot draw a spur to clip origin.
   // Modular ring remap matches vsMain / decimation so wrap does not draw physical
   // newest→oldest edges.
-  let pA = pointAt(iid);
-  let pB = pointAt(iid + 1u);
-  if (pA.x != pA.x || pA.y != pA.y || pB.x != pB.x || pB.y != pB.y) {
+  let pA_raw = pointAt(iid);
+  let pB_raw = pointAt(iid + 1u);
+  if (pA_raw.x != pA_raw.x || pA_raw.y != pA_raw.y || pB_raw.x != pB_raw.x || pB_raw.y != pB_raw.y ||
+      !canLogProject(pA_raw) || !canLogProject(pB_raw)) {
     var out: VSOut;
     out.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
     out.acrossDevice = 0.0;
     out.widthDevice = 0.0;
     return out;
   }
+  let pA = projectData(pA_raw);
+  let pB = projectData(pB_raw);
 
   // vid is 0 or 1 for line-list topology.
   let p = select(pA, pB, vid != 0u);

--- a/src/shaders/scatter.wgsl
+++ b/src/shaders/scatter.wgsl
@@ -20,7 +20,13 @@ struct VSUniforms {
   viewportPx: vec2<f32>,
   // Constant-radius path: used by vsMainConstRadius. Per-instance path ignores this.
   radiusPx: f32,
-  _pad0: f32,
+  // Independent bases so dual-log X/Y project correctly.
+  logBaseX: f32,
+  logBaseY: f32,
+  // bit0 = log X, bit1 = log Y. Pad to 16-byte trailing alignment.
+  logFlags: u32,
+  _pad1: u32,
+  _pad2: u32,
 };
 
 @group(0) @binding(0) var<uniform> vsUniforms: VSUniforms;
@@ -53,6 +59,34 @@ struct VSOut {
   @location(1) radiusPx: f32,
 };
 
+// Chrome Tint rejects NaN constants — use explicit positive checks instead.
+fn canLogProject(p: vec2<f32>) -> bool {
+  let flags = vsUniforms.logFlags;
+  if ((flags & 1u) != 0u && p.x <= 0.0) {
+    return false;
+  }
+  if ((flags & 2u) != 0u && p.y <= 0.0) {
+    return false;
+  }
+  return true;
+}
+
+fn projectData(p: vec2<f32>) -> vec2<f32> {
+  let flags = vsUniforms.logFlags;
+  if (flags == 0u) {
+    return p;
+  }
+  var x = p.x;
+  var y = p.y;
+  if ((flags & 1u) != 0u) {
+    x = log(x) / log(vsUniforms.logBaseX);
+  }
+  if ((flags & 2u) != 0u) {
+    y = log(y) / log(vsUniforms.logBaseY);
+  }
+  return vec2<f32>(x, y);
+}
+
 fn expandCircle(center: vec2<f32>, radiusPx: f32, vertexIndex: u32) -> VSOut {
   // Fixed local corners for 2 triangles (triangle-list).
   // `localNdc` is a quad in [-1, 1]^2; we convert it to pixel offsets via radiusPx.
@@ -72,7 +106,17 @@ fn expandCircle(center: vec2<f32>, radiusPx: f32, vertexIndex: u32) -> VSOut {
   // Clip space spans [-1, 1] across the viewport, so px -> clip is (2 / viewportPx).
   let localClip = localPx * (2.0 / vsUniforms.viewportPx);
 
-  let centerClip = (vsUniforms.transform * vec4<f32>(center, 0.0, 1.0)).xy;
+  // Non-positive on log axis: collapse marker (omit).
+  if (!canLogProject(center)) {
+    var out: VSOut;
+    out.clipPosition = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+    out.localPx = vec2<f32>(0.0, 0.0);
+    out.radiusPx = 0.0;
+    return out;
+  }
+  let projected = projectData(center);
+
+  let centerClip = (vsUniforms.transform * vec4<f32>(projected, 0.0, 1.0)).xy;
 
   var out: VSOut;
   out.clipPosition = vec4<f32>(centerClip + localClip, 0.0, 1.0);

--- a/src/shaders/scatterDensityBinning.wgsl
+++ b/src/shaders/scatterDensityBinning.wgsl
@@ -1,7 +1,12 @@
 struct ComputeUniforms {
   transform: mat4x4<f32>,
   viewportPx: vec2f,
-  _pad0: vec2f,
+  // Log projection before transform (bins still accumulate in screen space).
+  // Independent bases so dual-log X/Y project correctly.
+  logBaseX: f32,
+  logBaseY: f32,
+  logFlags: u32, // bit0 = log X, bit1 = log Y
+  _padLog: u32,
   plotOriginPx: vec2<u32>,
   plotSizePx: vec2<u32>,
   binSizePx: u32,
@@ -10,7 +15,6 @@ struct ComputeUniforms {
   visibleStart: u32,
   visibleEnd: u32,
   normalization: u32,
-  _pad1: vec2<u32>,
 };
 
 @group(0) @binding(0) var<uniform> u: ComputeUniforms;
@@ -37,7 +41,23 @@ fn binPoints(@builtin(global_invocation_id) gid: vec3<u32>) {
     return;
   }
 
-  let p = points[idx];
+  var p = points[idx];
+  // Non-positive on log axes: skip (omit from bins).
+  let flags = u.logFlags;
+  if (flags != 0u) {
+    if ((flags & 1u) != 0u) {
+      if (p.x <= 0.0) {
+        return;
+      }
+      p.x = log(p.x) / log(u.logBaseX);
+    }
+    if ((flags & 2u) != 0u) {
+      if (p.y <= 0.0) {
+        return;
+      }
+      p.y = log(p.y) / log(u.logBaseY);
+    }
+  }
   let clip4 = u.transform * vec4f(p.x, p.y, 0.0, 1.0);
   let clip = clip4.xy / max(1e-9, clip4.w);
   let px = clipToDevicePx(clip);

--- a/src/utils/__tests__/scales.test.ts
+++ b/src/utils/__tests__/scales.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+import { createAxisScale, createLinearScale, createLogScale, normalizeLogBase, DEFAULT_LOG_BASE } from '../scales';
+import {
+  computeClipAffineFromContinuousScale,
+  computeClipAffineFromScale,
+  resolveLogProjection,
+} from '../../renderers/packedXAffine';
+import { sanitizeLogDomain } from '../../core/renderCoordinator/utils/boundsComputation';
+import {
+  formatLogTickValue,
+  generateLogTicks,
+  generateLogTicksForVisibleDomain,
+} from '../../core/renderCoordinator/axis/computeAxisTicks';
+
+describe('createLinearScale (kind continuous)', () => {
+  it('exposes kind linear and getDomain/getRange', () => {
+    const s = createLinearScale().domain(0, 10).range(0, 100);
+    expect(s.kind).toBe('linear');
+    expect(s.getDomain()).toEqual({ min: 0, max: 10 });
+    expect(s.getRange()).toEqual({ min: 0, max: 100 });
+    expect(s.scale(5)).toBe(50);
+    expect(s.invert(50)).toBe(5);
+  });
+});
+
+describe('createLogScale', () => {
+  it('round-trips scale/invert for base 10 within float tolerance', () => {
+    const s = createLogScale(10).domain(0.01, 1000).range(0, 400);
+    for (const v of [0.01, 0.1, 1, 10, 100, 1000]) {
+      const p = s.scale(v);
+      const back = s.invert(p);
+      expect(back / v).toBeCloseTo(1, 10);
+    }
+  });
+
+  it('returns NaN for non-positive scale inputs', () => {
+    const s = createLogScale().domain(1, 100).range(0, 1);
+    expect(Number.isNaN(s.scale(0))).toBe(true);
+    expect(Number.isNaN(s.scale(-1))).toBe(true);
+  });
+
+  it('supports base 2', () => {
+    const s = createLogScale(2).domain(1, 16).range(0, 4);
+    expect(s.scale(1)).toBeCloseTo(0, 10);
+    expect(s.scale(16)).toBeCloseTo(4, 10);
+    expect(s.scale(4)).toBeCloseTo(2, 10);
+  });
+
+  it('clamps each non-positive domain end independently', () => {
+    // Preserve valid max when min is non-positive (not hard [1, 10]).
+    const s = createLogScale(10).domain(-1, 100).range(0, 1);
+    const d = s.getDomain();
+    expect(d.min).toBe(1);
+    expect(d.max).toBe(100);
+
+    // Preserve valid min when max is non-positive.
+    const s2 = createLogScale(10).domain(5, -1).range(0, 1);
+    const d2 = s2.getDomain();
+    expect(d2.min).toBe(5);
+    expect(d2.max).toBe(10); // fallbackMax for base 10
+  });
+
+  it('maps equal decades to equal range spacing', () => {
+    const s = createLogScale(10).domain(1, 1000).range(0, 300);
+    const p1 = s.scale(1);
+    const p10 = s.scale(10);
+    const p100 = s.scale(100);
+    const p1000 = s.scale(1000);
+    expect(p10 - p1).toBeCloseTo(p100 - p10, 8);
+    expect(p100 - p10).toBeCloseTo(p1000 - p100, 8);
+  });
+});
+
+describe('normalizeLogBase', () => {
+  it('defaults invalid bases to 10', () => {
+    expect(normalizeLogBase(undefined)).toBe(DEFAULT_LOG_BASE);
+    expect(normalizeLogBase(1)).toBe(10);
+    expect(normalizeLogBase(-2)).toBe(10);
+    expect(normalizeLogBase(Number.NaN)).toBe(10);
+    expect(normalizeLogBase(2)).toBe(2);
+  });
+});
+
+describe('createAxisScale', () => {
+  it('returns log scale for type log', () => {
+    const s = createAxisScale({ type: 'log', logBase: 10 });
+    expect(s.kind).toBe('log');
+    expect(s.base).toBe(10);
+  });
+
+  it('returns linear for value/time', () => {
+    expect(createAxisScale({ type: 'value' }).kind).toBe('linear');
+    expect(createAxisScale({ type: 'time' }).kind).toBe('linear');
+  });
+});
+
+describe('generateLogTicks', () => {
+  it('includes powers for [0.01, 1000] base 10', () => {
+    const ticks = generateLogTicks(0.01, 1000, 10);
+    expect(ticks).toEqual([0.01, 0.1, 1, 10, 100, 1000]);
+  });
+
+  it('handles reversed domain', () => {
+    const ticks = generateLogTicks(1000, 0.01, 10);
+    expect(ticks[0]).toBeLessThan(ticks[ticks.length - 1]!);
+    expect(ticks).toContain(1);
+  });
+
+  it('handles base 2', () => {
+    const ticks = generateLogTicks(1, 16, 2);
+    expect(ticks).toEqual([1, 2, 4, 8, 16]);
+  });
+
+  it('handles non-positive domain with fallback', () => {
+    const ticks = generateLogTicks(-5, 0, 10);
+    expect(ticks.length).toBeGreaterThanOrEqual(1);
+    expect(ticks.every((t) => t > 0)).toBe(true);
+  });
+
+  it('uses domain endpoints for intra-decade domains (no surrounding powers)', () => {
+    const ticks = generateLogTicks(2, 3, 10);
+    expect(ticks).toEqual([2, 3]);
+    // Surrounding powers 1 and 10 must not be emitted outside the domain.
+    expect(ticks).not.toContain(1);
+    expect(ticks).not.toContain(10);
+  });
+});
+
+describe('generateLogTicksForVisibleDomain', () => {
+  it('densifies intra-decade zoom [2e3, 8e3] with in-range intermediate ticks', () => {
+    const ticks = generateLogTicksForVisibleDomain(2e3, 8e3, 10);
+    // Must not fall back to only full-span powers (1e3/1e4 outside window).
+    expect(ticks).not.toContain(1e3);
+    expect(ticks).not.toContain(1e4);
+    // All ticks inside the visible window.
+    for (const t of ticks) {
+      expect(t).toBeGreaterThanOrEqual(2e3 * (1 - 1e-12));
+      expect(t).toBeLessThanOrEqual(8e3 * (1 + 1e-12));
+    }
+    // More than bare endpoints — densified mantissas (2×/3×/5×…).
+    expect(ticks.length).toBeGreaterThanOrEqual(3);
+    expect(ticks).toContain(2e3);
+    expect(ticks).toContain(5e3);
+    // Visible domain endpoints always merged (8e3 is not on 1/2/3/5/7 ladder).
+    expect(ticks).toContain(8e3);
+  });
+
+  it('keeps integer-power majors when they fall inside the visible domain', () => {
+    const ticks = generateLogTicksForVisibleDomain(500, 2e4, 10);
+    expect(ticks).toContain(1e3);
+    expect(ticks).toContain(1e4);
+    for (const t of ticks) {
+      expect(t).toBeGreaterThanOrEqual(500 * (1 - 1e-12));
+      expect(t).toBeLessThanOrEqual(2e4 * (1 + 1e-12));
+    }
+  });
+
+  it('uses classic decade majors for a wide multi-decade window (no forced densify clutter)', () => {
+    const ticks = generateLogTicksForVisibleDomain(1, 1e5, 10);
+    expect(ticks).toEqual([1, 10, 100, 1e3, 1e4, 1e5]);
+  });
+
+  it('matches generateLogTicks majors for full-span powers when domain has ≥3 powers', () => {
+    const full = generateLogTicks(0.01, 1000, 10);
+    const visible = generateLogTicksForVisibleDomain(0.01, 1000, 10);
+    expect(visible).toEqual(full);
+  });
+
+  it('does not emit surrounding powers outside a tight visible band', () => {
+    const ticks = generateLogTicksForVisibleDomain(2, 3, 10);
+    expect(ticks).not.toContain(1);
+    expect(ticks).not.toContain(10);
+    for (const t of ticks) {
+      expect(t).toBeGreaterThanOrEqual(2 * (1 - 1e-12));
+      expect(t).toBeLessThanOrEqual(3 * (1 + 1e-12));
+    }
+    expect(ticks.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('formatLogTickValue', () => {
+  it('formats powers of ten', () => {
+    expect(formatLogTickValue(0.01, 10)).toBe('0.01');
+    expect(formatLogTickValue(1, 10)).toBe('1');
+    expect(formatLogTickValue(100, 10)).toBe('100');
+    expect(formatLogTickValue(1000, 10)).toBe('1e3');
+    expect(formatLogTickValue(1e6, 10)).toBe('1e6');
+  });
+
+  it('returns null for non-positive', () => {
+    expect(formatLogTickValue(0)).toBeNull();
+    expect(formatLogTickValue(-1)).toBeNull();
+  });
+});
+
+describe('sanitizeLogDomain', () => {
+  it('passes through valid positive domains', () => {
+    const r = sanitizeLogDomain(0.1, 100, { base: 10, warn: false });
+    expect(r.min).toBe(0.1);
+    expect(r.max).toBe(100);
+    expect(r.warned).toBe(false);
+  });
+
+  it('falls back when all non-positive', () => {
+    const r = sanitizeLogDomain(-10, -1, { base: 10, warn: false });
+    expect(r.min).toBeGreaterThan(0);
+    expect(r.max).toBeGreaterThan(r.min);
+    expect(r.warned).toBe(true);
+  });
+
+  it('clamps explicit min ≤ 0 using positiveDataMin', () => {
+    const r = sanitizeLogDomain(0, 100, { base: 10, positiveDataMin: 2, warn: false });
+    expect(r.min).toBeGreaterThan(0);
+    expect(r.min).toBeLessThanOrEqual(2);
+    expect(r.max).toBe(100);
+  });
+
+  it('floors positiveDataMin×0.5 to a power of base when clamping ≤0', () => {
+    // pd=9 → half=4.5 → floor power of 10 → 1
+    const r = sanitizeLogDomain(0, 100, { base: 10, positiveDataMin: 9, warn: false });
+    expect(r.min).toBe(1);
+    expect(r.max).toBe(100);
+    expect(r.warned).toBe(true);
+  });
+});
+
+describe('computeClipAffineFromContinuousScale', () => {
+  it('matches linear sample at 0,1', () => {
+    const s = createLinearScale().domain(0, 10).range(-1, 1);
+    const a = computeClipAffineFromContinuousScale(s);
+    const b = computeClipAffineFromScale(s, 0, 1);
+    expect(a.a).toBeCloseTo(b.a, 12);
+    expect(a.b).toBeCloseTo(b.b, 12);
+  });
+
+  it('maps log domain endpoints correctly via log space', () => {
+    const s = createLogScale(10).domain(1, 1000).range(-1, 1);
+    const { a, b } = computeClipAffineFromContinuousScale(s);
+    // clip = a * log10(v) + b
+    const clip1 = a * Math.log10(1) + b;
+    const clip1000 = a * Math.log10(1000) + b;
+    expect(clip1).toBeCloseTo(s.scale(1), 10);
+    expect(clip1000).toBeCloseTo(s.scale(1000), 10);
+  });
+});
+
+describe('resolveLogProjection', () => {
+  it('flags off for linear pair', () => {
+    const x = createLinearScale();
+    const y = createLinearScale();
+    expect(resolveLogProjection(x, y).logFlags).toBe(0);
+  });
+
+  it('sets logY bit for log Y', () => {
+    const x = createLinearScale();
+    const y = createLogScale(10);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(x, y);
+    expect(logFlags & 2).toBe(2);
+    expect(logFlags & 1).toBe(0);
+    expect(logBaseY).toBe(10);
+    expect(logBaseX).toBe(10); // unused when linear X, still written as default
+  });
+
+  it('keeps independent bases for dual log X/Y', () => {
+    const x = createLogScale(2);
+    const y = createLogScale(10);
+    const { logFlags, logBaseX, logBaseY } = resolveLogProjection(x, y);
+    expect(logFlags & 1).toBe(1);
+    expect(logFlags & 2).toBe(2);
+    expect(logBaseX).toBe(2);
+    expect(logBaseY).toBe(10);
+  });
+});

--- a/src/utils/scales.ts
+++ b/src/utils/scales.ts
@@ -1,13 +1,13 @@
-export interface LinearScale {
+export interface ContinuousScale {
   /**
    * Sets the scale domain (data range). Returns self for chaining.
    */
-  domain(min: number, max: number): LinearScale;
+  domain(min: number, max: number): ContinuousScale;
 
   /**
-   * Sets the scale range (pixel range). Returns self for chaining.
+   * Sets the scale range (pixel / clip range). Returns self for chaining.
    */
-  range(min: number, max: number): LinearScale;
+  range(min: number, max: number): ContinuousScale;
 
   /**
    * Maps a domain value to a range value.
@@ -15,6 +15,7 @@ export interface LinearScale {
    * Notes:
    * - No clamping (will extrapolate outside the domain).
    * - If the domain span is 0 (min === max), returns the midpoint of the range.
+   * - Log scales return NaN for non-positive inputs.
    */
   scale(value: number): number;
 
@@ -24,9 +25,28 @@ export interface LinearScale {
    * Notes:
    * - No clamping (will extrapolate outside the range).
    * - If the domain span is 0 (min === max), returns domain min for any input.
+   * - Log scales always return a positive domain value when the mapping is defined.
    */
   invert(pixel: number): number;
+
+  /** Discriminator for GPU projection / affine helpers. */
+  readonly kind: 'linear' | 'log';
+
+  /** Present when `kind === 'log'`. Logarithm base (> 0, ≠ 1). */
+  readonly base?: number;
+
+  /** Current domain endpoints (data space). */
+  getDomain(): { readonly min: number; readonly max: number };
+
+  /** Current range endpoints (pixel / clip space). */
+  getRange(): { readonly min: number; readonly max: number };
 }
+
+/**
+ * Linear continuous scale. Alias of {@link ContinuousScale} for backward compatibility;
+ * instances from {@link createLinearScale} always have `kind: 'linear'`.
+ */
+export type LinearScale = ContinuousScale;
 
 export interface CategoryScale {
   /**
@@ -75,19 +95,34 @@ const assertFinite = (label: string, value: number): void => {
   }
 };
 
+/** Default log base when omitted or invalid. */
+export const DEFAULT_LOG_BASE = 10;
+
+/**
+ * Normalize a user-provided log base. Invalid bases (non-finite, ≤0, or 1) fall back to 10.
+ */
+export function normalizeLogBase(base: number | undefined | null): number {
+  if (base == null || !Number.isFinite(base) || base <= 0 || base === 1) {
+    return DEFAULT_LOG_BASE;
+  }
+  return base;
+}
+
 /**
  * Creates a linear scale for mapping a numeric domain to a numeric range.
  *
  * Defaults to an identity mapping:
  * domain [0, 1] -> range [0, 1]
  */
-export function createLinearScale(): LinearScale {
+export function createLinearScale(): ContinuousScale {
   let domainMin = 0;
   let domainMax = 1;
   let rangeMin = 0;
   let rangeMax = 1;
 
-  const self: LinearScale = {
+  const self: ContinuousScale = {
+    kind: 'linear',
+
     domain(min: number, max: number) {
       assertFinite('domain min', min);
       assertFinite('domain max', max);
@@ -102,6 +137,14 @@ export function createLinearScale(): LinearScale {
       rangeMin = min;
       rangeMax = max;
       return self;
+    },
+
+    getDomain() {
+      return { min: domainMin, max: domainMax };
+    },
+
+    getRange() {
+      return { min: rangeMin, max: rangeMax };
     },
 
     scale(value: number) {
@@ -132,6 +175,119 @@ export function createLinearScale(): LinearScale {
   };
 
   return self;
+}
+
+/**
+ * Creates a logarithmic continuous scale.
+ *
+ * Mapping: range = lerp(log_b(value), log_b(domainMin), log_b(domainMax)).
+ * Non-positive inputs to `scale` return NaN. Domain endpoints must be strictly positive;
+ * non-positive domain values are clamped to a safe positive fallback on `domain()`.
+ *
+ * Defaults:
+ * - base: 10 (or normalized from argument)
+ * - domain: [1, 10]
+ * - range: [0, 1]
+ */
+export function createLogScale(base?: number): ContinuousScale {
+  let logBase = normalizeLogBase(base);
+  let domainMin = 1;
+  let domainMax = logBase;
+  let rangeMin = 0;
+  let rangeMax = 1;
+
+  const lnBase = (): number => Math.log(logBase);
+
+  const logB = (v: number): number => Math.log(v) / lnBase();
+
+  const self: ContinuousScale = {
+    kind: 'log',
+
+    get base() {
+      return logBase;
+    },
+
+    domain(min: number, max: number) {
+      assertFinite('domain min', min);
+      assertFinite('domain max', max);
+      // Clamp each non-positive end independently (mirrors sanitizeLogDomain):
+      // preserve a valid positive partner instead of resetting both to [1, base].
+      const fallbackMax = logBase > 1 ? logBase : 10;
+      let lo = Number.isFinite(min) && min > 0 ? min : 1;
+      let hi = Number.isFinite(max) && max > 0 ? max : fallbackMax;
+      if (lo === hi) {
+        hi = lo * logBase;
+      } else if (lo > hi) {
+        const t = lo;
+        lo = hi;
+        hi = t;
+      }
+      domainMin = lo;
+      domainMax = hi;
+      return self;
+    },
+
+    range(min: number, max: number) {
+      assertFinite('range min', min);
+      assertFinite('range max', max);
+      rangeMin = min;
+      rangeMax = max;
+      return self;
+    },
+
+    getDomain() {
+      return { min: domainMin, max: domainMax };
+    },
+
+    getRange() {
+      return { min: rangeMin, max: rangeMax };
+    },
+
+    scale(value: number) {
+      if (!Number.isFinite(value) || value <= 0) return Number.NaN;
+
+      const d0 = logB(domainMin);
+      const d1 = logB(domainMax);
+      if (d0 === d1) {
+        return (rangeMin + rangeMax) / 2;
+      }
+
+      const t = (logB(value) - d0) / (d1 - d0);
+      return rangeMin + t * (rangeMax - rangeMin);
+    },
+
+    invert(pixel: number) {
+      if (!Number.isFinite(pixel)) return Number.NaN;
+
+      const d0 = logB(domainMin);
+      const d1 = logB(domainMax);
+
+      if (d0 === d1) {
+        return domainMin;
+      }
+
+      if (rangeMin === rangeMax) {
+        return Math.sqrt(domainMin * domainMax); // geometric midpoint
+      }
+
+      const t = (pixel - rangeMin) / (rangeMax - rangeMin);
+      const logV = d0 + t * (d1 - d0);
+      return logBase ** logV;
+    },
+  };
+
+  return self;
+}
+
+/**
+ * Factory: build a continuous scale for an axis config.
+ * Log axes use {@link createLogScale}; all other continuous types use linear.
+ */
+export function createAxisScale(axis: { readonly type: string; readonly logBase?: number }): ContinuousScale {
+  if (axis.type === 'log') {
+    return createLogScale(axis.logBase);
+  }
+  return createLinearScale();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Native logarithmic continuous axes (`AxisType: 'log'`, optional `logBase`) with shader-side log projection (DataStore stays linear), dual `logBaseX`/`logBaseY`, log-space affines, Chrome-safe `canLogProject` gap handling, and visible-domain tick densification on zoom.
- Tick-aligned grid for log axes, sticky log domains, positive-only auto-bounds, area baseline guards on log Y, and showcase examples (log Y/X, scatter, multi-axis, linear vs log compare).
- Candlestick streaming: geometry-cache fingerprints (length + last candle) force instance re-upload on append/forming-bar updates; `syncCandlestickOwnedFromUserSeries` keeps owned OHLC in sync with presentation-only `setOption`.

## Linked issue

Closes #135

## Test plan

- [x] `bun run test` (full suite green)
- [x] Log examples load and zoom: `log-axis-y`, `log-axis-x` (ticks recalculate in visible window)
- [x] Candlestick streaming: candles continue drawing after initial historical pack under auto-scroll
- [x] Linear axes unchanged when `logFlags == 0`
- [ ] Visual smoke on production preview if desired (`bun run build:examples && bun run preview:examples`)