### PR TITLE
chore: bump version to 0.3.5

### DIFF
--- a/dev-site/index.html
+++ b/dev-site/index.html
@@ -1099,7 +1099,7 @@
   <nav class="nav" aria-label="Primary">
     <a href="./" class="nav-brand" id="navBrand">
       <img id="navLogo" alt="ChartGPU" height="26" width="auto">
-      <span class="nav-version">v0.3.4</span>
+      <span class="nav-version">v%APP_VERSION%</span>
     </a>
     <div class="nav-actions">
       <a href="https://www.npmjs.com/package/@chartgpu/chartgpu" class="nav-link" target="_blank" rel="noopener">
@@ -1255,7 +1255,7 @@
   <footer class="foot-stmt">
     <p class="foot-stmt__line">WebGPU charting for dense data needs.</p>
     <div class="foot-stmt__meta">
-      <span>ChartGPU v0.3.4 · MIT</span>
+      <span>ChartGPU v%APP_VERSION% · MIT</span>
       <div class="foot-links">
         <a href="https://github.com/ChartGPU/ChartGPU" target="_blank" rel="noopener">GitHub</a>
         <a href="https://www.npmjs.com/package/@chartgpu/chartgpu" target="_blank" rel="noopener">npm</a>

--- a/dev-site/vite-env.d.ts
+++ b/dev-site/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Injected from package.json via dev-site/vite.config.ts `define`. */
+declare const __APP_VERSION__: string;

--- a/dev-site/vite.config.ts
+++ b/dev-site/vite.config.ts
@@ -8,6 +8,11 @@ const repoRoot = resolve(__dirname, '..');
 const examplesDir = resolve(repoRoot, 'examples');
 const pagesDist = resolve(repoRoot, 'pages-dist');
 
+const packageJson = JSON.parse(
+  readFileSync(resolve(repoRoot, 'package.json'), 'utf8')
+) as { version?: string };
+const appVersion = packageJson.version ?? '0.0.0';
+
 const exampleDirs = readdirSync(examplesDir).filter((file) => {
   const path = resolve(examplesDir, file);
   return statSync(path).isDirectory() && readdirSync(path).includes('index.html');
@@ -34,6 +39,16 @@ exampleDirs.forEach((dir) => {
  *   dist/foo/index.html      (each demo)
  *   dist/examples/index.html (optional classic list)
  */
+/** Inject package.json version into the landing HTML (dev + build). */
+function injectAppVersionPlugin() {
+  return {
+    name: 'inject-app-version',
+    transformIndexHtml(html: string) {
+      return html.replaceAll('%APP_VERSION%', appVersion);
+    },
+  };
+}
+
 function flattenPagesPlugin() {
   return {
     name: 'flatten-pages',
@@ -97,7 +112,11 @@ export default defineConfig(({ command }) => ({
     port: 4173,
     open: '/ChartGPU/',
   },
-  plugins: [flattenPagesPlugin()],
+  define: {
+    // Available to landing TS as import.meta.env is not used for this constant.
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
+  plugins: [injectAppVersionPlugin(), flattenPagesPlugin()],
   build: {
     outDir: pagesDist,
     emptyOutDir: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

- Bump package version to **0.3.5**.
- Inject `package.json` version into the landing page nav badge and footer at Vite transform time (`%APP_VERSION%`), so the site no longer hardcodes a version string.

## Test plan

- [ ] Confirm `package.json` version is `0.3.5`
- [ ] `bun run build:pages` and check `pages-dist/index.html` shows `v0.3.5` in nav and footer
- [ ] Optional: `bun run dev:site` and confirm version appears in the UI