### PR TITLE
Polish density plate and footer on the dev-site landing

### DIFF
--- a/dev-site/index.html
+++ b/dev-site/index.html
@@ -825,12 +825,25 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
-      align-items: baseline;
+      align-items: center;
       gap: var(--space-sm);
       padding-block-start: var(--space-sm);
       border-top: var(--rule-hair) solid var(--color-rule);
       font-size: var(--text-xs);
       color: var(--color-ink-3);
+    }
+
+    .foot-stmt__brand {
+      display: inline-flex;
+      align-items: center;
+      min-width: 0;
+      line-height: 0;
+    }
+
+    .foot-stmt__brand img {
+      height: 22px;
+      width: auto;
+      display: block;
     }
 
     .foot-stmt__meta a {
@@ -844,7 +857,16 @@
     .foot-links {
       display: flex;
       flex-wrap: wrap;
-      gap: var(--space-sm);
+      align-items: center;
+      gap: var(--space-2xs);
+    }
+
+    .foot-links .nav-link {
+      color: var(--color-ink-3);
+    }
+
+    .foot-links .nav-link:hover {
+      color: var(--color-ink);
     }
 
     /* ── Viewer ── */
@@ -1255,10 +1277,20 @@
   <footer class="foot-stmt">
     <p class="foot-stmt__line">WebGPU charting for dense data needs.</p>
     <div class="foot-stmt__meta">
-      <span>ChartGPU v%APP_VERSION% · MIT</span>
+      <a href="./" class="foot-stmt__brand" aria-label="ChartGPU">
+        <img id="footLogo" alt="ChartGPU" height="22" width="auto">
+      </a>
       <div class="foot-links">
-        <a href="https://github.com/ChartGPU/ChartGPU" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://www.npmjs.com/package/@chartgpu/chartgpu" target="_blank" rel="noopener">npm</a>
+        <a href="https://www.npmjs.com/package/@chartgpu/chartgpu" class="nav-link" target="_blank" rel="noopener">
+          <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <path fill="currentColor" fill-rule="evenodd" d="M0 0v16h16V0H0zm13 13h-2V5H8v8H3V3h10v10z"/>
+          </svg>
+          <span>npm</span>
+        </a>
+        <a href="https://github.com/ChartGPU/ChartGPU" class="nav-link" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
+          <span>GitHub</span>
+        </a>
       </div>
     </div>
   </footer>

--- a/dev-site/main.ts
+++ b/dev-site/main.ts
@@ -437,6 +437,8 @@ const mulberry32 = (seed: number): (() => number) => {
 };
 
 async function createDensityPoints(count: number, seed: number): Promise<ScatterPointTuple[]> {
+  // Match examples/scatter-density-1m: two tight Gaussian blobs + light noise.
+  // Concentrated cores read as hot yellows on inferno; log norm lifts the purple halos.
   const rng = mulberry32(seed);
   const out: ScatterPointTuple[] = new Array(count);
   const chunk = 40_000;
@@ -444,17 +446,17 @@ async function createDensityPoints(count: number, seed: number): Promise<Scatter
     const end = Math.min(count, base + chunk);
     for (let i = base; i < end; i++) {
       const t = rng();
-      const blob = t < 0.55 ? 0 : t < 0.85 ? 1 : 2;
-      const cx = blob === 0 ? 0.32 : blob === 1 ? 0.68 : 0.5;
-      const cy = blob === 0 ? 0.58 : blob === 1 ? 0.38 : 0.72;
-      const sx = blob === 2 ? 0.14 : 0.07;
-      const sy = blob === 2 ? 0.1 : 0.09;
+      const blob = t < 0.6 ? 0 : 1;
+      const cx = blob === 0 ? 0.35 : 0.7;
+      const cy = blob === 0 ? 0.55 : 0.35;
+      const sx = blob === 0 ? 0.08 : 0.05;
+      const sy = blob === 0 ? 0.1 : 0.07;
       const u1 = Math.max(1e-12, rng());
       const u2 = rng();
       const r = Math.sqrt(-2.0 * Math.log(u1));
       const theta = 2.0 * Math.PI * u2;
-      const x = cx + r * Math.cos(theta) * sx + (rng() - 0.5) * 0.02;
-      const y = cy + r * Math.sin(theta) * sy + (rng() - 0.5) * 0.02;
+      const x = cx + r * Math.cos(theta) * sx + (rng() - 0.5) * 0.03;
+      const y = cy + r * Math.sin(theta) * sy + (rng() - 0.5) * 0.03;
       out[i] = [x, y];
     }
     await new Promise<void>((r) => requestAnimationFrame(() => r()));
@@ -465,22 +467,24 @@ async function createDensityPoints(count: number, seed: number): Promise<Scatter
 
 async function mountDensity(container: HTMLElement): Promise<{ dispose: () => void }> {
   const n = 1_000_000;
-  const points = await createDensityPoints(n, 2026);
+  const points = await createDensityPoints(n, 1337);
+  // No inside dataZoom — wheel scrolls the page past this plate, not zoom the chart.
   const options: ChartGPUOptions = {
     ...plateChrome(),
     grid: { left: 4, right: 4, top: 4, bottom: 4 },
     xAxis: { type: 'value', tickFormatter: hideTicks },
     yAxis: { type: 'value', tickFormatter: hideTicks },
-    dataZoom: [{ type: 'inside' }],
     series: [
       {
         type: 'scatter',
         name: 'density',
         data: points,
         mode: 'density',
-        binSize: 6,
+        // Same punch as scatter-density-1m defaults: fine bins + log curve.
+        // Colormap stays inferno (site plate identity); only resolution/contrast change.
+        binSize: 2,
         densityColormap: 'inferno',
-        densityNormalization: 'linear',
+        densityNormalization: 'log',
         sampling: 'none',
       },
     ],
@@ -1721,6 +1725,8 @@ function checkWebGPU(): boolean {
 function wireStaticAssets(): void {
   const logo = document.getElementById('navLogo') as HTMLImageElement | null;
   if (logo) logo.src = chartgpuLogoUrl;
+  const footLogo = document.getElementById('footLogo') as HTMLImageElement | null;
+  if (footLogo) footLogo.src = chartgpuLogoUrl;
   const brand = document.getElementById('navBrand') as HTMLAnchorElement | null;
   if (brand) brand.href = import.meta.env.BASE_URL;
   const webgpuIcon = document.getElementById('webgpuComIcon') as HTMLImageElement | null;


### PR DESCRIPTION
## Summary
- Match the density plate to `examples/scatter-density-1m`: two-blob point layout, seed `1337`, `binSize: 2`, inferno colormap, log normalization — hot cores and fine grain instead of blocky washed-out bins.
- Disable inside `dataZoom` on the density plate so wheel scroll moves the page.
- Footer branding: ChartGPU logo (left) replaces version/MIT text; npm + GitHub icon links (right) match the nav treatment.

## Test plan
- [ ] Open dev-site density plate — dual blobs with bright yellow cores and speckled purple halos (inferno + log)
- [ ] Wheel over density plate scrolls the page (no zoom)
- [ ] Footer shows ChartGPU logo left; npm + GitHub with icons right; both links work
- [ ] Logo links home; hard-refresh confirms assets load