### PR TITLE
style: brand examples catalog + candlestick/ultimate-benchmark chrome

### DIFF
--- a/dev-site/main.ts
+++ b/dev-site/main.ts
@@ -83,6 +83,34 @@ const examples: readonly Example[] = [
     path: examplePath('band-range'),
   },
   {
+    id: 'error-bars',
+    title: 'Error Bars',
+    desc: 'Per-point high/low whiskers (type: errorBar) — SciChart HLC style; errorMode, capWidth, center markers',
+    category: 'series',
+    path: examplePath('error-bars'),
+  },
+  {
+    id: 'step-line',
+    title: 'Step / Digital Line + Mountain',
+    desc: 'Stairs via step on line/area (after/before/middle) — SciChart isDigitalLine; mountain fill follows stepped top',
+    category: 'series',
+    path: examplePath('step-line'),
+  },
+  {
+    id: 'impulse',
+    title: 'Impulse / Stem Series',
+    desc: 'Vertical stems baseline→y (type: impulse) — SciChart FastImpulseRenderableSeries; optional markers; not errorBar',
+    category: 'series',
+    path: examplePath('impulse'),
+  },
+  {
+    id: 'stacked-mountain',
+    title: 'Stacked Mountain / Area',
+    desc: 'Multi-series composition fill via stack on line+areaStyle (or type: area) — layers sit on cumulative peers',
+    category: 'series',
+    path: examplePath('stacked-mountain'),
+  },
+  {
     id: '3d-showcase',
     title: '3D Showcase',
     desc: 'Labeled axes, contours, cloud FIFO + surface strip streaming, pick tooltips — cartesian3d product demo',
@@ -116,6 +144,13 @@ const examples: readonly Example[] = [
     desc: 'Financial OHLC chart with classic and hollow style toggle',
     category: 'series',
     path: examplePath('candlestick'),
+  },
+  {
+    id: 'ohlc-bars',
+    title: 'OHLC Bars',
+    desc: 'Thin open–high–low–close bars (type: ohlc) with candlestick ↔ ohlc toggle on the same OHLCDataPoint data',
+    category: 'series',
+    path: examplePath('ohlc-bars'),
   },
   {
     id: 'scatter',

--- a/examples/candlestick-streaming/index.html
+++ b/examples/candlestick-streaming/index.html
@@ -13,8 +13,10 @@
   <div class="app">
     <header class="header">
       <div class="ticker" aria-live="polite" aria-atomic="true">
-        <span class="ticker-cash" aria-hidden="true">$</span>
-        <span id="ticker-logo-host" class="ticker-logo-host"></span>
+        <span class="ticker-symbol">
+          <span class="ticker-cash" aria-hidden="true">$</span>
+          <span id="ticker-logo-host" class="ticker-logo-host"></span>
+        </span>
         <span id="current-price" class="ticker-price" data-price="0">100.00</span>
       </div>
       <div class="timeframes" role="group" aria-label="Candle interval">

--- a/examples/candlestick-streaming/index.html
+++ b/examples/candlestick-streaming/index.html
@@ -3,39 +3,37 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ChartGPU - Live Crypto Streaming</title>
+  <title>Candlestick Streaming — ChartGPU</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div class="app">
-    <!-- Header -->
     <header class="header">
-      <div class="logo">
-        <span class="logo-icon">📊</span>
-        <span class="logo-text">ChartGPU</span>
-        <span class="logo-badge">WebGPU</span>
+      <div class="ticker" aria-live="polite" aria-atomic="true">
+        <span class="ticker-symbol">
+          <span class="ticker-cash" aria-hidden="true">$</span>ChartGPU
+        </span>
+        <span id="current-price" class="ticker-price" data-price="0">100.00</span>
       </div>
-      <div class="symbol-info">
-        <span class="symbol-name">MEME/USD</span>
-        <span id="current-price" class="current-price" data-price="0">$100.00</span>
-      </div>
-      <div class="timeframes">
-        <button class="timeframe-btn active" data-tf="1s">1s</button>
-        <button class="timeframe-btn" data-tf="5m">5m</button>
-        <button class="timeframe-btn" data-tf="15m">15m</button>
-        <button class="timeframe-btn" data-tf="1h">1H</button>
-        <button class="timeframe-btn" data-tf="4h">4H</button>
-        <button class="timeframe-btn" data-tf="1d">1D</button>
+      <div class="timeframes" role="group" aria-label="Candle interval">
+        <button type="button" class="timeframe-btn active" data-tf="1s">1s</button>
+        <button type="button" class="timeframe-btn" data-tf="5m">5m</button>
+        <button type="button" class="timeframe-btn" data-tf="15m">15m</button>
+        <button type="button" class="timeframe-btn" data-tf="1h">1H</button>
+        <button type="button" class="timeframe-btn" data-tf="4h">4H</button>
+        <button type="button" class="timeframe-btn" data-tf="1d">1D</button>
       </div>
       <a href="https://github.com/ChartGPU/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer">
-        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
         </svg>
         <span>GitHub</span>
       </a>
     </header>
 
-    <!-- Stats Bar -->
     <div class="stats-bar">
       <div class="stat">
         <span class="stat-label">FPS</span>
@@ -46,37 +44,35 @@
         <span id="stat-candles" class="stat-value">60</span>
       </div>
       <div class="stat">
-        <span class="stat-label">Tick Rate</span>
+        <span class="stat-label">Tick rate</span>
         <span id="stat-ticks" class="stat-value">0/s</span>
       </div>
       <div class="stat">
-        <span class="stat-label">Total Ticks</span>
+        <span class="stat-label">Total ticks</span>
         <span id="stat-total-ticks" class="stat-value">0</span>
       </div>
-      <div class="stat-separator"></div>
-      <div class="candle-presets">
-        <span class="preset-label">Candles:</span>
-        <button class="preset-btn active" data-count="60">60</button>
-        <button class="preset-btn" data-count="1000">1K</button>
-        <button class="preset-btn" data-count="10000">10K</button>
-        <button class="preset-btn" data-count="50000">50K</button>
-        <button class="preset-btn" data-count="100000">100K</button>
-        <button class="preset-btn" data-count="1000000">1M</button>
-        <button class="preset-btn" data-count="5000000">5M</button>
+      <div class="stat-separator" aria-hidden="true"></div>
+      <div class="candle-presets" role="group" aria-label="Candle count">
+        <span class="preset-label">Candles</span>
+        <button type="button" class="preset-btn active" data-count="60">60</button>
+        <button type="button" class="preset-btn" data-count="1000">1K</button>
+        <button type="button" class="preset-btn" data-count="10000">10K</button>
+        <button type="button" class="preset-btn" data-count="50000">50K</button>
+        <button type="button" class="preset-btn" data-count="100000">100K</button>
+        <button type="button" class="preset-btn" data-count="1000000">1M</button>
+        <button type="button" class="preset-btn" data-count="5000000">5M</button>
       </div>
-      <div class="stat-separator"></div>
-      <button id="toggle-btn" class="control-btn">▶ Start</button>
-      <button id="style-btn" class="control-btn secondary">Style: Classic</button>
-      <button id="autoscroll-btn" class="control-btn secondary toggle-active">📍 Auto-Scroll: ON</button>
+      <div class="stat-separator" aria-hidden="true"></div>
+      <button type="button" id="toggle-btn" class="control-btn">Start</button>
+      <button type="button" id="style-btn" class="control-btn secondary">Style: Classic</button>
+      <button type="button" id="autoscroll-btn" class="control-btn secondary toggle-active">Auto-scroll: On</button>
     </div>
 
-    <!-- Chart Container -->
     <div id="chart" class="chart-container"></div>
 
-    <!-- Footer -->
     <footer class="footer">
-      <span>Powered by WebGPU • Scale from 60 to 5M candles • Real-time streaming</span>
-      <a href="https://github.com/ChartGPU/ChartGPU" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <span>Live tick simulation · 60 candles → 5M · WebGPU</span>
+      <a href="https://github.com/ChartGPU/ChartGPU" target="_blank" rel="noopener noreferrer">Source</a>
     </footer>
   </div>
 

--- a/examples/candlestick-streaming/index.html
+++ b/examples/candlestick-streaming/index.html
@@ -13,9 +13,8 @@
   <div class="app">
     <header class="header">
       <div class="ticker" aria-live="polite" aria-atomic="true">
-        <span class="ticker-symbol">
-          <span class="ticker-cash" aria-hidden="true">$</span>ChartGPU
-        </span>
+        <span class="ticker-cash" aria-hidden="true">$</span>
+        <span id="ticker-logo-host" class="ticker-logo-host"></span>
         <span id="current-price" class="ticker-price" data-price="0">100.00</span>
       </div>
       <div class="timeframes" role="group" aria-label="Candle interval">

--- a/examples/candlestick-streaming/logoGpu.ts
+++ b/examples/candlestick-streaming/logoGpu.ts
@@ -1,0 +1,235 @@
+/**
+ * Header wordmark rendered via pure WebGPU (texture sample + alpha blit).
+ *
+ * Why texture (not procedural letterforms): the official mark is a custom
+ * two-tone wordmark. Reverse-engineering bold italic glyphs in WGSL would be
+ * approximate and worse at ~22px. Uploading the brand PNG and drawing it with
+ * WebGPU is exact and still GPU-native. Falls back to <img> if WebGPU fails.
+ */
+import logoUrl from '../../docs/assets/chartgpu.png';
+
+const BLIT_WGSL = /* wgsl */ `
+struct VsOut {
+  @builtin(position) pos : vec4f,
+  @location(0) uv : vec2f,
+};
+
+@vertex
+fn vs(@builtin(vertex_index) vi : u32) -> VsOut {
+  // Fullscreen triangle covering clip space
+  var p = array<vec2f, 3>(
+    vec2f(-1.0, -1.0),
+    vec2f( 3.0, -1.0),
+    vec2f(-1.0,  3.0),
+  );
+  let xy = p[vi];
+  var o : VsOut;
+  o.pos = vec4f(xy, 0.0, 1.0);
+  // Map clip → uv (y flipped for image-space)
+  o.uv = vec2f(xy.x * 0.5 + 0.5, 0.5 - xy.y * 0.5);
+  return o;
+}
+
+@group(0) @binding(0) var logoSamp : sampler;
+@group(0) @binding(1) var logoTex : texture_2d<f32>;
+
+@fragment
+fn fs(in : VsOut) -> @location(0) vec4f {
+  let c = textureSample(logoTex, logoSamp, in.uv);
+  // Premultiply for correct alpha over dark header
+  return vec4f(c.rgb * c.a, c.a);
+}
+`;
+
+export type LogoGpuHandle = {
+  readonly canvas: HTMLCanvasElement;
+  dispose: () => void;
+};
+
+/**
+ * Mount a crisp DPR-aware WebGPU wordmark into `host`.
+ * On failure, inserts a static <img> fallback and returns null.
+ */
+export async function mountLogoGpu(host: HTMLElement): Promise<LogoGpuHandle | null> {
+  const cssH = 22;
+  // Intrinsic aspect ~809/247 ≈ 3.275
+  const aspect = 809 / 247;
+  const cssW = Math.round(cssH * aspect);
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'ticker-logo';
+  canvas.setAttribute('role', 'img');
+  canvas.setAttribute('aria-label', 'ChartGPU');
+  canvas.style.width = `${cssW}px`;
+  canvas.style.height = `${cssH}px`;
+  host.replaceChildren(canvas);
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  canvas.width = Math.max(1, Math.round(cssW * dpr));
+  canvas.height = Math.max(1, Math.round(cssH * dpr));
+
+  const fallback = (): null => {
+    const img = document.createElement('img');
+    img.className = 'ticker-logo';
+    img.src = logoUrl;
+    img.alt = 'ChartGPU';
+    img.width = cssW;
+    img.height = cssH;
+    img.decoding = 'async';
+    host.replaceChildren(img);
+    return null;
+  };
+
+  if (!navigator.gpu) return fallback();
+
+  let adapter: GPUAdapter | null;
+  try {
+    adapter = await navigator.gpu.requestAdapter();
+  } catch {
+    return fallback();
+  }
+  if (!adapter) return fallback();
+
+  let device: GPUDevice;
+  try {
+    device = await adapter.requestDevice();
+  } catch {
+    return fallback();
+  }
+
+  const context = canvas.getContext('webgpu');
+  if (!context) {
+    device.destroy();
+    return fallback();
+  }
+
+  const format = navigator.gpu.getPreferredCanvasFormat();
+  context.configure({
+    device,
+    format,
+    alphaMode: 'premultiplied',
+  });
+
+  // Decode brand PNG
+  let bitmap: ImageBitmap;
+  try {
+    const res = await fetch(logoUrl);
+    if (!res.ok) throw new Error(`logo fetch ${res.status}`);
+    const blob = await res.blob();
+    bitmap = await createImageBitmap(blob, { colorSpaceConversion: 'none' });
+  } catch {
+    device.destroy();
+    return fallback();
+  }
+
+  const texture = device.createTexture({
+    label: 'chartgpu-logo',
+    size: [bitmap.width, bitmap.height],
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  device.queue.copyExternalImageToTexture(
+    { source: bitmap },
+    { texture },
+    [bitmap.width, bitmap.height]
+  );
+  bitmap.close();
+
+  const sampler = device.createSampler({
+    label: 'chartgpu-logo-sampler',
+    magFilter: 'linear',
+    minFilter: 'linear',
+  });
+
+  const module = device.createShaderModule({ label: 'chartgpu-logo-blit', code: BLIT_WGSL });
+  const pipeline = device.createRenderPipeline({
+    label: 'chartgpu-logo-pipeline',
+    layout: 'auto',
+    vertex: { module, entryPoint: 'vs' },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets: [
+        {
+          format,
+          blend: {
+            color: {
+              srcFactor: 'one',
+              dstFactor: 'one-minus-src-alpha',
+              operation: 'add',
+            },
+            alpha: {
+              srcFactor: 'one',
+              dstFactor: 'one-minus-src-alpha',
+              operation: 'add',
+            },
+          },
+        },
+      ],
+    },
+    primitive: { topology: 'triangle-list' },
+  });
+
+  const bindGroup = device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: sampler },
+      { binding: 1, resource: texture.createView() },
+    ],
+  });
+
+  let disposed = false;
+
+  const draw = (): void => {
+    if (disposed) return;
+    const encoder = device.createCommandEncoder({ label: 'chartgpu-logo-encode' });
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: context.getCurrentTexture().createView(),
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+  };
+
+  draw();
+
+  // Redraw on DPR / size changes (rare for header, but keeps it crisp)
+  const ro = new ResizeObserver(() => {
+    if (disposed) return;
+    const nextDpr = Math.min(window.devicePixelRatio || 1, 2);
+    const w = Math.max(1, Math.round(cssW * nextDpr));
+    const h = Math.max(1, Math.round(cssH * nextDpr));
+    if (canvas.width === w && canvas.height === h) return;
+    canvas.width = w;
+    canvas.height = h;
+    context.configure({ device, format, alphaMode: 'premultiplied' });
+    draw();
+  });
+  ro.observe(canvas);
+
+  const onLost = (): void => {
+    dispose();
+    fallback();
+  };
+  device.addEventListener('uncapturederror', onLost);
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    ro.disconnect();
+    device.removeEventListener('uncapturederror', onLost);
+    texture.destroy();
+    device.destroy();
+  };
+
+  return { canvas, dispose };
+}

--- a/examples/candlestick-streaming/main.ts
+++ b/examples/candlestick-streaming/main.ts
@@ -24,7 +24,7 @@ const TIMEFRAME_TIMESCALES: Record<string, number> = {
 
 // Configuration (base values - some are mutable for user control)
 const CONFIG = {
-  symbol: 'MEME/USD',
+  symbol: 'ChartGPU',
   ticksPerSecond: 20, // Moderate tick rate for visible updates
   tickVolatility: 0.008, // Per-tick volatility (visible but not wild)
   startPrice: 100, // Nice round starting price
@@ -138,6 +138,13 @@ async function init() {
   // Create chart
   // Candle-primary defaults: first Y → right, grid left=20 / right=70 (no grid override needed).
   fullChartOptions = {
+    // Darker than built-in dark (#1a1a2e) — metallic near-black plot field
+    theme: {
+      backgroundColor: '#07070a',
+      gridLineColor: 'rgba(255,255,255,0.06)',
+      axisLineColor: 'rgba(224,224,224,0.28)',
+      axisTickColor: 'rgba(224,224,224,0.45)',
+    },
     xAxis: { type: 'time', name: 'Time' },
     // Non-rotated top-rail unit header (exchange-style); series name carries the symbol.
     yAxis: { type: 'value', header: 'USD' },
@@ -271,11 +278,11 @@ function toggleStreaming() {
   isStreaming = !isStreaming;
   if (isStreaming) {
     tickSimulator.start();
-    document.getElementById('toggle-btn')!.textContent = '⏸ Pause';
+    document.getElementById('toggle-btn')!.textContent = 'Pause';
     document.getElementById('toggle-btn')!.classList.add('active');
   } else {
     tickSimulator.stop();
-    document.getElementById('toggle-btn')!.textContent = '▶ Start';
+    document.getElementById('toggle-btn')!.textContent = 'Start';
     document.getElementById('toggle-btn')!.classList.remove('active');
   }
 }
@@ -284,7 +291,7 @@ function toggleAutoScroll() {
   autoScrollEnabled = !autoScrollEnabled;
   chart.setOption({ autoScroll: autoScrollEnabled });
   const btn = document.getElementById('autoscroll-btn')!;
-  btn.textContent = autoScrollEnabled ? '📍 Auto-Scroll: ON' : '📍 Auto-Scroll: OFF';
+  btn.textContent = autoScrollEnabled ? 'Auto-scroll: On' : 'Auto-scroll: Off';
   btn.classList.toggle('toggle-active', autoScrollEnabled);
 }
 
@@ -516,18 +523,9 @@ function setupControls() {
 
 function updatePrice(price: number) {
   const priceEl = document.getElementById('current-price')!;
-  const prevPrice = parseFloat(priceEl.dataset.price || '0');
-
-  priceEl.textContent = `$${price.toFixed(2)}`;
-  priceEl.dataset.price = price.toString();
-
-  // Flash color on change
-  priceEl.classList.remove('price-up', 'price-down');
-  if (price > prevPrice) {
-    priceEl.classList.add('price-up');
-  } else if (price < prevPrice) {
-    priceEl.classList.add('price-down');
-  }
+  // Steady ink — no flash; $ lives on the ticker symbol, not the quote.
+  priceEl.textContent = price.toFixed(2);
+  priceEl.dataset.price = String(price);
 }
 
 function startStatsLoop() {

--- a/examples/candlestick-streaming/main.ts
+++ b/examples/candlestick-streaming/main.ts
@@ -1,6 +1,7 @@
 import { createChart, type ChartGPUInstance, type OHLCDataPoint } from '../../src/index';
 import { generateHistoricalData } from './generateHistoricalData';
 import { createTickSimulator, createCandleAggregator, type Tick } from './tickSimulator';
+import { mountLogoGpu } from './logoGpu';
 
 // Timeframe intervals in milliseconds
 const TIMEFRAME_INTERVALS: Record<string, number> = {
@@ -111,6 +112,12 @@ function getMaxCandles(candleCount: number): number {
 
 async function init() {
   const container = document.getElementById('chart')!;
+
+  // Brand wordmark via pure WebGPU blit (PNG is exact; procedural glyphs would not be)
+  const logoHost = document.getElementById('ticker-logo-host');
+  if (logoHost) {
+    void mountLogoGpu(logoHost);
+  }
 
   // Generate impressive historical data
   console.log(`Generating ${currentCandleCount.toLocaleString()} historical candles...`);

--- a/examples/candlestick-streaming/styles.css
+++ b/examples/candlestick-streaming/styles.css
@@ -94,30 +94,41 @@ body {
   border-bottom: 1px solid var(--color-rule);
 }
 
-/* Stock ticker: $ChartGPU + last price */
+/* Stock ticker: $ + WebGPU wordmark + last price */
 .ticker {
   display: flex;
-  align-items: baseline;
-  gap: 0.65rem;
+  align-items: center;
+  gap: 0.55rem;
   flex-shrink: 0;
   min-width: 0;
   line-height: 1;
 }
 
-.ticker-symbol {
+.ticker-cash {
   font-family: var(--font-display);
-  font-size: 1.05rem;
-  font-weight: 600;
+  font-size: 1.1rem;
+  font-weight: 700;
   font-style: normal;
-  letter-spacing: -0.03em;
-  color: var(--color-ink);
-  white-space: nowrap;
+  color: var(--color-accent);
+  line-height: 1;
+  flex-shrink: 0;
 }
 
-.ticker-cash {
-  color: var(--color-accent);
-  font-weight: 700;
-  margin-right: 0.02em;
+.ticker-logo-host {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+.ticker-logo {
+  display: block;
+  height: 22px;
+  width: auto;
+  /* ~809/247 aspect locked by logoGpu */
+  object-fit: contain;
+  /* Avoid subpixel blur on the gold edge */
+  image-rendering: auto;
 }
 
 .ticker-price {
@@ -422,7 +433,6 @@ body {
     display: none;
   }
 
-  .ticker-symbol,
   .ticker-price {
     font-size: var(--text-md);
   }

--- a/examples/candlestick-streaming/styles.css
+++ b/examples/candlestick-streaming/styles.css
@@ -94,24 +94,38 @@ body {
   border-bottom: 1px solid var(--color-rule);
 }
 
-/* Stock ticker: $ + WebGPU wordmark + last price */
+/* Stock ticker: $wordmark + last price */
 .ticker {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.65rem;
   flex-shrink: 0;
   min-width: 0;
   line-height: 1;
 }
 
+/* Cashtag + logo as one unit — tight tracking like $AAPL */
+.ticker-symbol {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.05rem;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
 .ticker-cash {
   font-family: var(--font-display);
-  font-size: 1.1rem;
-  font-weight: 700;
+  /* Sit just under the wordmark cap height (~22px logo) */
+  font-size: 0.8125rem;
+  font-weight: 600;
   font-style: normal;
-  color: var(--color-accent);
+  letter-spacing: -0.02em;
+  /* Quiet ink — gold fights the logo's GPU gold; blue would fight CHART */
+  color: var(--color-ink-2);
   line-height: 1;
   flex-shrink: 0;
+  /* Optical: near wordmark cap-height, tucked into logo leading edge */
+  transform: translate(1px, -1px);
 }
 
 .ticker-logo-host {

--- a/examples/candlestick-streaming/styles.css
+++ b/examples/candlestick-streaming/styles.css
@@ -1,306 +1,437 @@
+/* Hallmark · pre-emit critique: P5 H5 E5 S4 R5 V4
+ * Hallmark · component: app-chrome · genre: atmospheric · theme: ChartGPU brand
+ * tone: technical · paper: oklch(12% 0.012 265) · accent: gold · display: Space Grotesk + body: DM Sans
+ * axes: dark / geometric-sans / warm · enrichment: none · studied: no
+ * states: default · hover · focus · active · disabled
+ */
+
 :root {
-  --bg-primary: #0d0d0f;
-  --bg-secondary: #16161a;
-  --bg-tertiary: #1e1e24;
-  --text-primary: #ffffff;
-  --text-secondary: #a0a0a8;
-  --accent: #6366f1;
-  --green: #22c55e;
-  --red: #ef4444;
-  --border: #2a2a32;
+  --color-paper: oklch(12% 0.012 265);
+  --color-paper-2: oklch(15% 0.014 265);
+  --color-paper-3: oklch(19% 0.016 265);
+  --color-paper-hover: oklch(22% 0.018 265);
+
+  --color-ink: oklch(92% 0.01 265);
+  --color-ink-2: oklch(62% 0.02 265);
+  --color-ink-3: oklch(42% 0.015 265);
+
+  --color-accent: oklch(74% 0.14 85);
+  --color-accent-soft: oklch(74% 0.14 85 / 0.14);
+  --color-accent-ink: oklch(18% 0.03 85);
+  --color-blue: oklch(58% 0.14 250);
+  --color-focus: oklch(74% 0.14 85);
+
+  --color-rule: oklch(92% 0.01 265 / 0.08);
+  --color-rule-strong: oklch(92% 0.01 265 / 0.14);
+
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-body: 'DM Sans', system-ui, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Mono', Consolas, monospace;
+
+  --text-xs: 0.6875rem;
+  --text-sm: 0.8125rem;
+  --text-md: 0.9375rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.5rem;
+
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.5rem;
+  --space-xs: 0.75rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --dur-short: 180ms;
+  --dur-mid: 280ms;
+
+  --header-h: 52px;
+  --stats-h: 48px;
+  --footer-h: 36px;
 }
 
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
+html,
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  min-height: 100vh;
+  height: 100%;
+  overflow-x: clip;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
+  -webkit-font-smoothing: antialiased;
 }
 
 .app {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  min-height: 0;
 }
 
-/* Header */
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
 .header {
   display: flex;
   align-items: center;
-  gap: 24px;
-  padding: 12px 20px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
+  gap: var(--space-md);
+  min-height: var(--header-h);
+  padding: 0 var(--space-md);
+  background: var(--color-paper-2);
+  border-bottom: 1px solid var(--color-rule);
 }
 
-.logo {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.logo-icon {
-  font-size: 24px;
-}
-
-.logo-text {
-  font-size: 18px;
-  font-weight: 700;
-  background: linear-gradient(135deg, #6366f1, #a855f7);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-.logo-badge {
-  font-size: 10px;
-  font-weight: 600;
-  padding: 2px 6px;
-  background: var(--accent);
-  border-radius: 4px;
-  text-transform: uppercase;
-}
-
-.symbol-info {
+/* Stock ticker: $ChartGPU + last price */
+.ticker {
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: 0.65rem;
+  flex-shrink: 0;
+  min-width: 0;
+  line-height: 1;
 }
 
-.symbol-name {
-  font-size: 20px;
+.ticker-symbol {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
   font-weight: 600;
+  font-style: normal;
+  letter-spacing: -0.03em;
+  color: var(--color-ink);
+  white-space: nowrap;
 }
 
-.current-price {
-  font-size: 24px;
+.ticker-cash {
+  color: var(--color-accent);
   font-weight: 700;
+  margin-right: 0.02em;
+}
+
+.ticker-price {
+  font-family: var(--font-mono);
+  font-size: 1.05rem;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  transition: color 0.15s;
-}
-
-.current-price.price-up {
-  color: var(--green);
-}
-
-.current-price.price-down {
-  color: var(--red);
+  letter-spacing: -0.03em;
+  color: var(--color-ink);
+  /* Steady ink — no flash on ticks */
 }
 
 .timeframes {
   display: flex;
+  flex-wrap: wrap;
   gap: 4px;
 }
 
 .github-link {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 6px 12px;
+  gap: var(--space-2xs);
   margin-left: auto;
-  background-color: var(--bg-tertiary);
-  color: var(--text-secondary);
-  text-decoration: none;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  font-size: 13px;
+  padding: 0.4rem 0.75rem;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
   font-weight: 500;
-  transition: all 0.15s;
+  color: var(--color-ink-2);
+  text-decoration: none;
+  background: transparent;
+  border: 1px solid var(--color-rule-strong);
+  border-radius: var(--radius-sm);
+  transition:
+    color var(--dur-short) var(--ease-out),
+    border-color var(--dur-short) var(--ease-out),
+    background var(--dur-short) var(--ease-out);
 }
 
 .github-link:hover {
-  color: var(--text-primary);
-  border-color: var(--text-secondary);
+  color: var(--color-ink);
+  border-color: var(--color-ink-3);
+  background: var(--color-paper-3);
+}
+
+.github-link:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
 .github-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   fill: currentColor;
 }
 
 .timeframe-btn {
-  padding: 6px 12px;
-  font-size: 13px;
+  padding: 0.35rem 0.65rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--color-ink-2);
   background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 6px;
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    color var(--dur-short) var(--ease-out),
+    border-color var(--dur-short) var(--ease-out),
+    background var(--dur-short) var(--ease-out);
 }
 
 .timeframe-btn:hover {
-  color: var(--text-primary);
-  border-color: var(--text-secondary);
+  color: var(--color-ink);
+  border-color: var(--color-rule-strong);
+  background: var(--color-paper-3);
+}
+
+.timeframe-btn:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
 .timeframe-btn.active {
-  color: var(--text-primary);
-  background: var(--accent);
-  border-color: var(--accent);
+  color: var(--color-accent-ink);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
 }
 
-/* Stats Bar */
+/* ── Stats bar ──────────────────────────────────────────────────────────── */
+
 .stats-bar {
   display: flex;
   align-items: center;
-  gap: 24px;
-  padding: 10px 20px;
-  background: var(--bg-tertiary);
-  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+  gap: var(--space-sm) var(--space-md);
+  min-height: var(--stats-h);
+  padding: var(--space-2xs) var(--space-md);
+  background: var(--color-paper);
+  border-bottom: 1px solid var(--color-rule);
 }
 
 .stat {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
+  min-width: 3.5rem;
 }
 
 .stat-label {
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
   font-weight: 500;
-  color: var(--text-secondary);
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  color: var(--color-ink-3);
 }
 
 .stat-value {
-  font-size: 16px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: var(--green);
+  color: var(--color-ink);
 }
 
 .stat-separator {
   width: 1px;
-  height: 32px;
-  background: var(--border);
-  margin: 0 8px;
+  height: 1.75rem;
+  background: var(--color-rule-strong);
+  flex-shrink: 0;
 }
 
-.control-btn {
-  padding: 8px 16px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  background: var(--green);
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.control-btn:hover {
-  filter: brightness(1.1);
-}
-
-.control-btn.active {
-  background: var(--red);
-}
-
-.control-btn.secondary {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-}
-
-.control-btn.secondary:hover {
-  border-color: var(--text-secondary);
-}
-
-.control-btn.toggle-active {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
-/* Candle Presets */
 .candle-presets {
   display: flex;
   align-items: center;
-  gap: 6px;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .preset-label {
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
   font-weight: 500;
-  color: var(--text-secondary);
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-right: 4px;
+  color: var(--color-ink-3);
+  margin-right: 2px;
 }
 
 .preset-btn {
-  padding: 4px 10px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
+  padding: 0.25rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-ink-2);
   background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 4px;
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    color var(--dur-short) var(--ease-out),
+    border-color var(--dur-short) var(--ease-out),
+    background var(--dur-short) var(--ease-out);
 }
 
 .preset-btn:hover {
-  color: var(--text-primary);
-  border-color: var(--text-secondary);
+  color: var(--color-ink);
+  border-color: var(--color-rule-strong);
+}
+
+.preset-btn:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
 .preset-btn.active {
-  color: var(--text-primary);
-  background: var(--accent);
-  border-color: var(--accent);
+  color: var(--color-accent-ink);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
 }
 
-/* Chart */
+.control-btn {
+  padding: 0.4rem 0.85rem;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-accent-ink);
+  background: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    filter var(--dur-short) var(--ease-out),
+    background var(--dur-short) var(--ease-out),
+    border-color var(--dur-short) var(--ease-out),
+    color var(--dur-short) var(--ease-out);
+}
+
+.control-btn:hover {
+  filter: brightness(1.06);
+}
+
+.control-btn:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.control-btn:active {
+  filter: brightness(0.96);
+}
+
+.control-btn.active {
+  color: var(--color-ink);
+  background: oklch(42% 0.12 25);
+  border-color: oklch(50% 0.14 25);
+  filter: none;
+}
+
+.control-btn.secondary {
+  color: var(--color-ink-2);
+  background: var(--color-paper-2);
+  border-color: var(--color-rule-strong);
+  filter: none;
+}
+
+.control-btn.secondary:hover {
+  color: var(--color-ink);
+  border-color: var(--color-ink-3);
+  background: var(--color-paper-3);
+  filter: none;
+}
+
+.control-btn.toggle-active {
+  color: var(--color-accent-ink);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+/* ── Chart ──────────────────────────────────────────────────────────────── */
+
 .chart-container {
   flex: 1;
   min-height: 0;
-  background: var(--bg-primary);
+  /* Match chart theme.backgroundColor — metallic black plot field */
+  background: #07070a;
 }
 
-/* Footer */
+/* ── Footer ─────────────────────────────────────────────────────────────── */
+
 .footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
-  font-size: 12px;
-  color: var(--text-secondary);
-  background: var(--bg-secondary);
-  border-top: 1px solid var(--border);
+  gap: var(--space-sm);
+  min-height: var(--footer-h);
+  padding: 0 var(--space-md);
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+  background: var(--color-paper-2);
+  border-top: 1px solid var(--color-rule);
 }
 
 .footer a {
-  color: var(--accent);
+  color: var(--color-ink-2);
   text-decoration: none;
+  transition: color var(--dur-short) var(--ease-out);
 }
 
 .footer a:hover {
-  text-decoration: underline;
+  color: var(--color-accent);
 }
 
-/* Responsive */
+.footer a:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
 @media (max-width: 768px) {
   .header {
     flex-wrap: wrap;
-    gap: 12px;
+    gap: var(--space-xs);
+    padding: var(--space-2xs) var(--space-sm);
   }
 
   .timeframes {
     order: 3;
     width: 100%;
+  }
+
+  .github-link {
     margin-left: 0;
   }
 
   .stats-bar {
-    flex-wrap: wrap;
-    gap: 12px 24px;
+    gap: var(--space-xs) var(--space-sm);
+    padding: var(--space-2xs) var(--space-sm);
+  }
+
+  .stat-separator {
+    display: none;
+  }
+
+  .ticker-symbol,
+  .ticker-price {
+    font-size: var(--text-md);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
   }
 }

--- a/examples/ultimate-benchmark/index.html
+++ b/examples/ultimate-benchmark/index.html
@@ -3,43 +3,42 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ChartGPU Ultimate Benchmark</title>
+  <title>Ultimate Benchmark — ChartGPU</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-  <!-- Header -->
   <header class="header">
     <a href="https://github.com/ChartGPU/ChartGPU" class="github-link" target="_blank" rel="noopener noreferrer" aria-label="ChartGPU on GitHub">
-      <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg class="github-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/>
       </svg>
       <span>GitHub</span>
     </a>
-    <h1 class="title">ChartGPU Ultimate Benchmark</h1>
-    <p class="subtitle">Hardcore benchmark with exact FPS measurement and unlimited configurability (main thread)</p>
+    <h1 class="title">Ultimate Benchmark</h1>
+    <p class="subtitle">Exact FPS and frame-time metrics with configurable series load. Main-thread harness.</p>
   </header>
 
-  <!-- Main Container -->
   <div class="main-container">
-    <!-- Configuration Panel -->
     <aside class="config-panel">
       <div class="panel-section">
         <h2 class="section-title">Configuration</h2>
-        
+
         <div class="form-group">
-          <label for="pointCount">Point Count (per series)</label>
+          <label for="pointCount">Point count (per series)</label>
           <input type="number" id="pointCount" value="1000000" step="1000" min="100">
-          <span class="hint">No limit - enter billions if you dare</span>
+          <span class="hint">No hard cap — large values may freeze the tab</span>
         </div>
 
         <div class="form-group">
-          <label for="seriesCount">Series Count</label>
+          <label for="seriesCount">Series count</label>
           <input type="number" id="seriesCount" value="1" min="1" max="20" step="1">
         </div>
 
-        <!-- Total Rendered Points Display -->
         <div class="total-points-display" id="totalPointsDisplay">
-          <div class="total-points-label">Total Rendered Points</div>
+          <div class="total-points-label">Total rendered points</div>
           <div class="total-points-value" id="totalPointsValue" data-warning="false">
             1,000,000
           </div>
@@ -47,7 +46,7 @@
         </div>
 
         <div class="form-group">
-          <label for="dataType">Data Type</label>
+          <label for="dataType">Data type</label>
           <select id="dataType">
             <option value="line">Line</option>
             <option value="scatter">Scatter</option>
@@ -59,9 +58,9 @@
 
       <div class="panel-section">
         <h2 class="section-title">Streaming</h2>
-        
+
         <div class="form-group">
-          <label for="streamRate">Points per Frame (series 0)</label>
+          <label for="streamRate">Points per frame (series 0)</label>
           <input type="number" id="streamRate" value="10000" min="100" step="100">
         </div>
 
@@ -72,59 +71,50 @@
       </div>
 
       <div class="panel-section actions">
-        <button id="btnGenerate" class="btn btn-primary">Generate</button>
-        <button id="btnStream" class="btn btn-secondary">Start Streaming</button>
-        <button id="btnClear" class="btn btn-secondary">Clear</button>
-        <button id="btnEmergency" class="btn btn-danger">Emergency Stop</button>
+        <button type="button" id="btnGenerate" class="btn btn-primary">Generate</button>
+        <button type="button" id="btnStream" class="btn btn-secondary">Start streaming</button>
+        <button type="button" id="btnClear" class="btn btn-secondary">Clear</button>
+        <button type="button" id="btnEmergency" class="btn btn-danger">Emergency stop</button>
       </div>
 
-      <div id="statusMessage" class="status-message"></div>
+      <div id="statusMessage" class="status-message" role="status"></div>
     </aside>
 
-    <!-- Chart and Metrics Area -->
     <main class="content-area">
-      <!-- Chart Container -->
       <div id="chart" class="chart-container"></div>
 
-      <!-- Metrics Panel -->
       <div class="metrics-panel">
         <div class="metrics-grid">
-          <!-- Exact FPS Display -->
           <div class="metric-card fps-card">
             <div class="metric-label">FPS</div>
             <div id="fpsDisplay" class="metric-value fps-value" data-quality="smooth">--</div>
             <div class="metric-hint">60+ = smooth</div>
           </div>
 
-          <!-- Frame Time -->
           <div class="metric-card">
-            <div class="metric-label">Frame Time</div>
+            <div class="metric-label">Frame time</div>
             <div id="frameTimeDisplay" class="metric-value">--</div>
-            <div class="metric-hint">Min / Avg / Max / P95 / P99</div>
+            <div class="metric-hint">Min / avg / max / p95 / p99</div>
           </div>
 
-          <!-- Memory Usage -->
           <div class="metric-card">
             <div class="metric-label">Memory</div>
             <div id="memoryDisplay" class="metric-value">--</div>
-            <div class="metric-hint">Used / Peak</div>
+            <div class="metric-hint">Used / peak</div>
           </div>
 
-          <!-- Frame Drops -->
           <div class="metric-card">
-            <div class="metric-label">Frame Drops</div>
+            <div class="metric-label">Frame drops</div>
             <div id="frameDropsDisplay" class="metric-value">--</div>
-            <div class="metric-hint">Total / Consecutive</div>
+            <div class="metric-hint">Total / consecutive</div>
           </div>
 
-          <!-- Total Frames -->
           <div class="metric-card">
-            <div class="metric-label">Total Frames</div>
+            <div class="metric-label">Total frames</div>
             <div id="totalFramesDisplay" class="metric-value">--</div>
             <div class="metric-hint">Since start</div>
           </div>
 
-          <!-- Elapsed Time -->
           <div class="metric-card">
             <div class="metric-label">Elapsed</div>
             <div id="elapsedDisplay" class="metric-value">--</div>
@@ -132,13 +122,12 @@
           </div>
         </div>
 
-        <!-- Frame Time Graph -->
         <div class="frame-graph-container">
           <div class="frame-graph-header">
-            <span class="frame-graph-title">Frame Times (last 120 frames)</span>
+            <span class="frame-graph-title">Frame times (last 120)</span>
             <span class="frame-graph-legend">
               <span class="legend-item"><span class="legend-color good"></span>Good (&lt;16.67ms)</span>
-              <span class="legend-item"><span class="legend-color slow"></span>Slow (16.67-33ms)</span>
+              <span class="legend-item"><span class="legend-color slow"></span>Slow (16.67–33ms)</span>
               <span class="legend-item"><span class="legend-color drop"></span>Drop (&gt;33ms)</span>
             </span>
           </div>
@@ -148,10 +137,8 @@
     </main>
   </div>
 
-  <!-- Error/Warning Messages -->
-  <div id="warningToast" class="toast toast-warning"></div>
+  <div id="warningToast" class="toast toast-warning" role="alert"></div>
 
   <script type="module" src="./main.ts"></script>
 </body>
 </html>
-

--- a/examples/ultimate-benchmark/main.ts
+++ b/examples/ultimate-benchmark/main.ts
@@ -81,14 +81,14 @@ class FrameTimeGraph {
     const width = canvas.width;
     const height = canvas.height;
 
-    // Clear canvas
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
+    // Clear canvas (paper-2 surface; canvas can't read CSS vars reliably)
+    ctx.fillStyle = 'oklch(15% 0.014 265)';
     ctx.fillRect(0, 0, width, height);
     if (frameTimes.length === 0) return;
 
     // Draw 60fps target line
     const targetY = height - (EXPECTED_FRAME_TIME_MS / this.maxFrameTime) * height;
-    ctx.strokeStyle = 'rgba(255, 255, 255, 0.2)';
+    ctx.strokeStyle = 'oklch(92% 0.01 265 / 0.14)';
     ctx.lineWidth = 1;
     ctx.setLineDash([4, 4]);
     ctx.beginPath();
@@ -104,10 +104,11 @@ class FrameTimeGraph {
       const barHeight = Math.min(1, frameTime / this.maxFrameTime) * height;
       const y = height - barHeight;
 
+      // Brand-aligned quality bands (success / warning / danger)
       let color: string;
-      if (frameTime <= EXPECTED_FRAME_TIME_MS) color = '#10b981';
-      else if (frameTime <= FRAME_TIME_SLOW_THRESHOLD) color = '#f59e0b';
-      else color = '#ef4444';
+      if (frameTime <= EXPECTED_FRAME_TIME_MS) color = '#6BCB77';
+      else if (frameTime <= FRAME_TIME_SLOW_THRESHOLD) color = '#F0A202';
+      else color = '#E05A8C';
 
       ctx.fillStyle = color;
       ctx.fillRect(x, y, Math.max(0, barWidth - 1), barHeight);
@@ -301,17 +302,18 @@ async function createChart(dataType: DataType, seriesData: Array<DataPoint[] | O
   const container = document.getElementById('chart');
   if (!container) throw new Error('Missing #chart container');
 
+  // ChartGPU brand palette (dev-site)
   const palette = [
-    '#06b6d4',
-    '#6366f1',
-    '#10b981',
-    '#f59e0b',
-    '#ef4444',
-    '#a78bfa',
-    '#22c55e',
-    '#eab308',
-    '#fb7185',
-    '#38bdf8',
+    '#D4A520',
+    '#3B7DD8',
+    '#3ECFCF',
+    '#E05A8C',
+    '#6BCB77',
+    '#8B7CFF',
+    '#F0A202',
+    '#7A8494',
+    '#D4A520',
+    '#3B7DD8',
   ];
 
   const baseSeries = seriesData.map((data, i) => {

--- a/examples/ultimate-benchmark/styles.css
+++ b/examples/ultimate-benchmark/styles.css
@@ -1,176 +1,202 @@
-/* ========================================
-   CSS Custom Properties (Theme)
-   ======================================== */
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4
+ * Hallmark · component: app-chrome · genre: atmospheric · theme: ChartGPU brand
+ * tone: technical · paper: oklch(12% 0.012 265) · accent: gold · display: Space Grotesk + body: DM Sans
+ * axes: dark / geometric-sans / warm · enrichment: none · studied: no
+ * states: default · hover · focus · active · disabled
+ */
+
 :root {
-  /* Colors */
-  --color-bg: #0a0e1a;
-  --color-bg-elevated: #1a1f2e;
-  --color-bg-card: rgba(26, 31, 46, 0.6);
-  --color-border: rgba(255, 255, 255, 0.08);
-  --color-border-hover: rgba(255, 255, 255, 0.15);
-  
-  --color-text: #e0e4ea;
-  --color-text-secondary: #9ca3af;
-  --color-text-hint: #6b7280;
-  
-  --color-primary: #06b6d4;
-  --color-primary-hover: #22d3ee;
-  --color-secondary: #6366f1;
-  --color-secondary-hover: #818cf8;
-  
-  --color-success: #10b981;
-  --color-warning: #f59e0b;
-  --color-danger: #ef4444;
-  
-  --color-fps-smooth: #10b981;
-  --color-fps-medium: #f59e0b;
-  --color-fps-choppy: #ef4444;
-  
-  /* Glassmorphism */
-  --glass-bg: rgba(26, 31, 46, 0.4);
-  --glass-border: rgba(255, 255, 255, 0.08);
-  --glass-blur: 12px;
-  
-  /* Spacing */
-  --spacing-xs: 0.25rem;
-  --spacing-sm: 0.5rem;
-  --spacing-md: 1rem;
-  --spacing-lg: 1.5rem;
-  --spacing-xl: 2rem;
-  
-  /* Sizes */
-  --config-panel-width: 320px;
-  --header-height: 80px;
-  
-  /* Transitions */
-  --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
-  --transition-base: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  --color-paper: oklch(12% 0.012 265);
+  --color-paper-2: oklch(15% 0.014 265);
+  --color-paper-3: oklch(19% 0.016 265);
+  --color-paper-hover: oklch(22% 0.018 265);
+
+  --color-ink: oklch(92% 0.01 265);
+  --color-ink-2: oklch(62% 0.02 265);
+  --color-ink-3: oklch(42% 0.015 265);
+
+  --color-accent: oklch(74% 0.14 85);
+  --color-accent-soft: oklch(74% 0.14 85 / 0.14);
+  --color-accent-ink: oklch(18% 0.03 85);
+  --color-blue: oklch(58% 0.14 250);
+  --color-blue-soft: oklch(58% 0.14 250 / 0.16);
+  --color-focus: oklch(74% 0.14 85);
+
+  --color-success: oklch(72% 0.15 155);
+  --color-warning: oklch(78% 0.14 75);
+  --color-danger: oklch(62% 0.2 25);
+
+  --color-rule: oklch(92% 0.01 265 / 0.08);
+  --color-rule-strong: oklch(92% 0.01 265 / 0.14);
+
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-body: 'DM Sans', system-ui, sans-serif;
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Mono', Consolas, monospace;
+
+  --text-xs: 0.6875rem;
+  --text-sm: 0.8125rem;
+  --text-md: 0.9375rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.5rem;
+  --text-2xl: clamp(1.5rem, 2.5vw, 2rem);
+
+  --space-3xs: 0.25rem;
+  --space-2xs: 0.5rem;
+  --space-xs: 0.75rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --dur-short: 180ms;
+  --dur-mid: 280ms;
+
+  --config-panel-width: 288px;
+  --header-height: 72px;
 }
 
-/* ========================================
-   Reset and Base Styles
-   ======================================== */
-* {
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
 
+html,
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background-color: var(--color-bg);
-  color: var(--color-text);
+  height: 100%;
+  overflow-x: clip;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  background: var(--color-paper);
+  color: var(--color-ink);
   overflow: hidden;
   height: 100vh;
   display: flex;
   flex-direction: column;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* ========================================
-   Header
-   ======================================== */
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
 .header {
-  height: var(--header-height);
-  background: linear-gradient(135deg, var(--color-bg-elevated) 0%, rgba(10, 14, 26, 0.95) 100%);
-  border-bottom: 1px solid var(--color-border);
+  position: relative;
+  min-height: var(--header-height);
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0 var(--spacing-xl);
-  backdrop-filter: blur(var(--glass-blur));
-  position: relative;
+  gap: var(--space-3xs);
+  padding: var(--space-sm) var(--space-lg);
+  padding-right: 9rem;
+  background: var(--color-paper-2);
+  border-bottom: 1px solid var(--color-rule);
 }
 
 .title {
-  font-size: 1.75rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-secondary) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin-bottom: var(--spacing-xs);
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  font-style: normal;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--color-ink);
 }
 
 .subtitle {
-  font-size: 0.875rem;
-  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+  max-width: 42rem;
+  line-height: 1.45;
 }
 
-/* ========================================
-   GitHub Button
-   ======================================== */
 .github-link {
   position: absolute;
-  top: 16px;
-  right: var(--spacing-xl);
+  top: 50%;
+  right: var(--space-lg);
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: rgba(0, 0, 0, 0.25);
-  color: var(--color-text);
+  gap: var(--space-2xs);
+  padding: 0.4rem 0.75rem;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-ink-2);
   text-decoration: none;
-  border-radius: 8px;
-  border: 1px solid var(--color-border);
-  font-size: 0.85rem;
-  transition: all var(--transition-base);
+  background: transparent;
+  border: 1px solid var(--color-rule-strong);
+  border-radius: var(--radius-sm);
+  transition:
+    color var(--dur-short) var(--ease-out),
+    border-color var(--dur-short) var(--ease-out),
+    background var(--dur-short) var(--ease-out);
 }
 
 .github-link:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: var(--color-border-hover);
-  transform: translateY(-1px);
+  color: var(--color-ink);
+  border-color: var(--color-ink-3);
+  background: var(--color-paper-3);
+}
+
+.github-link:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
 .github-icon {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   fill: currentColor;
 }
 
-/* ========================================
-   Main Layout
-   ======================================== */
+/* ── Layout ─────────────────────────────────────────────────────────────── */
+
 .main-container {
   display: flex;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 
-/* ========================================
-   Configuration Panel
-   ======================================== */
+/* ── Config panel ───────────────────────────────────────────────────────── */
+
 .config-panel {
   width: var(--config-panel-width);
-  background: var(--glass-bg);
-  border-right: 1px solid var(--glass-border);
-  backdrop-filter: blur(var(--glass-blur));
-  overflow-y: auto;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-lg);
-  padding: var(--spacing-lg);
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  background: var(--color-paper-2);
+  border-right: 1px solid var(--color-rule);
+  overflow-y: auto;
 }
 
 .panel-section {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: var(--spacing-lg);
-  backdrop-filter: blur(8px);
+  padding: var(--space-sm);
+  background: var(--color-paper);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-md);
 }
 
 .section-title {
-  font-size: 0.875rem;
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
   font-weight: 600;
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: var(--spacing-md);
+  font-style: normal;
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+  margin-bottom: var(--space-xs);
 }
 
 .form-group {
-  margin-bottom: var(--spacing-md);
+  margin-bottom: var(--space-xs);
 }
 
 .form-group:last-child {
@@ -179,168 +205,182 @@ body {
 
 .form-group label {
   display: block;
-  font-size: 0.875rem;
+  font-size: var(--text-sm);
   font-weight: 500;
-  margin-bottom: var(--spacing-sm);
-  color: var(--color-text);
+  margin-bottom: var(--space-3xs);
+  color: var(--color-ink-2);
 }
 
 .form-group input,
 .form-group select {
   width: 100%;
-  padding: var(--spacing-sm) var(--spacing-md);
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  color: var(--color-text);
-  font-size: 0.875rem;
-  transition: all var(--transition-base);
+  padding: 0.5rem 0.65rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-ink);
+  background: var(--color-paper-2);
+  border: 1px solid var(--color-rule-strong);
+  border-radius: var(--radius-sm);
+  transition:
+    border-color var(--dur-short) var(--ease-out),
+    background var(--dur-short) var(--ease-out);
+}
+
+.form-group input:hover,
+.form-group select:hover {
+  border-color: var(--color-ink-3);
 }
 
 .form-group input:focus,
 .form-group select:focus {
   outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.1);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
-.form-group input:hover,
-.form-group select:hover {
-  border-color: var(--color-border-hover);
+.form-group input:focus-visible,
+.form-group select:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 1px;
+  box-shadow: none;
 }
 
 .hint {
   display: block;
-  font-size: 0.75rem;
-  color: var(--color-text-hint);
-  margin-top: var(--spacing-xs);
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+  margin-top: var(--space-3xs);
+  line-height: 1.35;
 }
 
-/* ========================================
-   Total Rendered Points Display
-   ======================================== */
+/* Total points */
+
 .total-points-display {
-  background: linear-gradient(135deg, rgba(6, 182, 212, 0.1) 0%, rgba(99, 102, 241, 0.1) 100%);
-  border: 1px solid rgba(6, 182, 212, 0.3);
-  border-radius: 12px;
-  padding: var(--spacing-lg);
-  margin-bottom: var(--spacing-md);
-  backdrop-filter: blur(8px);
-  text-align: center;
-  transition: all var(--transition-base);
-}
-
-.total-points-display:hover {
-  border-color: rgba(6, 182, 212, 0.5);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(6, 182, 212, 0.2);
+  padding: var(--space-sm);
+  margin-bottom: var(--space-xs);
+  text-align: left;
+  background: var(--color-paper-2);
+  border: 1px solid var(--color-rule-strong);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-sm);
 }
 
 .total-points-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: var(--spacing-sm);
+  color: var(--color-ink-3);
+  margin-bottom: var(--space-3xs);
 }
 
 .total-points-value {
-  font-size: 2rem;
-  font-weight: 700;
+  font-family: var(--font-mono);
+  font-size: 1.75rem;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: var(--color-primary);
-  line-height: 1.2;
-  transition: color var(--transition-base);
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--color-accent);
+  transition: color var(--dur-short) var(--ease-out);
 }
 
-.total-points-value[data-warning="true"] {
+.total-points-value[data-warning='true'] {
   color: var(--color-warning);
 }
 
-.total-points-value[data-warning="extreme"] {
+.total-points-value[data-warning='extreme'] {
   color: var(--color-danger);
 }
 
 .total-points-hint {
-  font-size: 0.875rem;
-  color: var(--color-text-hint);
-  margin-top: var(--spacing-xs);
-  font-weight: 500;
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+  margin-top: var(--space-3xs);
+  font-family: var(--font-mono);
 }
 
-/* ========================================
-   Buttons
-   ======================================== */
+/* Actions */
+
 .actions {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: var(--space-2xs);
 }
 
 .btn {
-  padding: var(--spacing-md);
-  border: none;
-  border-radius: 8px;
-  font-size: 0.875rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
   font-weight: 600;
   cursor: pointer;
-  transition: all var(--transition-base);
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
+  border: 1px solid transparent;
+  transition:
+    background var(--dur-short) var(--ease-out),
+    border-color var(--dur-short) var(--ease-out),
+    color var(--dur-short) var(--ease-out),
+    filter var(--dur-short) var(--ease-out);
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-secondary) 100%);
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-accent-ink);
+  border-color: var(--color-accent);
 }
 
 .btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 16px rgba(6, 182, 212, 0.3);
+  filter: brightness(1.06);
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
+  background: var(--color-paper);
+  color: var(--color-ink-2);
+  border-color: var(--color-rule-strong);
 }
 
 .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: var(--color-border-hover);
+  color: var(--color-ink);
+  border-color: var(--color-ink-3);
+  background: var(--color-paper-3);
 }
 
 .btn-danger {
-  background: var(--color-danger);
-  color: white;
+  background: transparent;
+  color: var(--color-danger);
+  border-color: oklch(62% 0.2 25 / 0.45);
 }
 
 .btn-danger:hover {
-  background: #dc2626;
-  transform: translateY(-2px);
-  box-shadow: 0 8px 16px rgba(239, 68, 68, 0.3);
+  background: oklch(62% 0.2 25 / 0.12);
+  border-color: var(--color-danger);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
 .btn:active {
-  transform: translateY(0);
+  filter: brightness(0.96);
 }
 
 .btn:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
-  transform: none !important;
+  filter: none;
 }
 
-/* ========================================
-   Status Message
-   ======================================== */
+/* Status */
+
 .status-message {
-  font-size: 0.75rem;
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: 6px;
-  background: rgba(16, 185, 129, 0.1);
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  padding: var(--space-2xs) var(--space-xs);
+  border-radius: var(--radius-sm);
+  background: oklch(72% 0.15 155 / 0.1);
+  border: 1px solid oklch(72% 0.15 155 / 0.28);
   color: var(--color-success);
   display: none;
 }
@@ -350,158 +390,150 @@ body {
 }
 
 .status-message.warning {
-  background: rgba(245, 158, 11, 0.1);
-  border-color: rgba(245, 158, 11, 0.3);
+  background: oklch(78% 0.14 75 / 0.1);
+  border-color: oklch(78% 0.14 75 / 0.28);
   color: var(--color-warning);
 }
 
 .status-message.error {
-  background: rgba(239, 68, 68, 0.1);
-  border-color: rgba(239, 68, 68, 0.3);
+  background: oklch(62% 0.2 25 / 0.1);
+  border-color: oklch(62% 0.2 25 / 0.28);
   color: var(--color-danger);
 }
 
-/* ========================================
-   Content Area
-   ======================================== */
+/* ── Content ────────────────────────────────────────────────────────────── */
+
 .content-area {
   flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
-/* ========================================
-   Chart Container
-   ======================================== */
 .chart-container {
   flex: 1;
   position: relative;
   overflow: hidden;
   min-height: 0;
+  background: var(--color-paper);
 }
 
-/* ========================================
-   Metrics Panel
-   ======================================== */
+/* ── Metrics ────────────────────────────────────────────────────────────── */
+
 .metrics-panel {
-  background: var(--glass-bg);
-  border-top: 1px solid var(--glass-border);
-  backdrop-filter: blur(var(--glass-blur));
-  padding: var(--spacing-lg);
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-lg);
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--color-paper-2);
+  border-top: 1px solid var(--color-rule);
 }
 
 .metrics-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: var(--spacing-md);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-2xs);
 }
 
 .metric-card {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: var(--spacing-md);
-  backdrop-filter: blur(8px);
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
-  transition: all var(--transition-base);
-}
-
-.metric-card:hover {
-  border-color: var(--color-border-hover);
-  transform: translateY(-2px);
+  gap: 2px;
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-paper);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-sm);
 }
 
 .metric-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: var(--color-ink-3);
 }
 
 .metric-value {
-  font-size: 1.5rem;
-  font-weight: 700;
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: var(--color-text);
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+  line-height: 1.25;
 }
 
 .metric-hint {
-  font-size: 0.75rem;
-  color: var(--color-text-hint);
-}
-
-/* FPS-specific styling */
-.fps-card {
-  border-color: var(--color-border);
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
 }
 
 .fps-value {
-  font-size: 2.5rem;
-  transition: color var(--transition-base);
+  font-size: 2rem;
+  letter-spacing: -0.04em;
+  transition: color var(--dur-short) var(--ease-out);
 }
 
-.fps-value[data-quality="smooth"] {
-  color: var(--color-fps-smooth);
+.fps-value[data-quality='smooth'] {
+  color: var(--color-success);
 }
 
-.fps-value[data-quality="medium"] {
-  color: var(--color-fps-medium);
+.fps-value[data-quality='medium'] {
+  color: var(--color-warning);
 }
 
-.fps-value[data-quality="choppy"] {
-  color: var(--color-fps-choppy);
+.fps-value[data-quality='choppy'] {
+  color: var(--color-danger);
 }
 
-/* ========================================
-   Frame Time Graph
-   ======================================== */
+/* Frame graph */
+
 .frame-graph-container {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: var(--spacing-md);
-  backdrop-filter: blur(8px);
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--color-paper);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-sm);
 }
 
 .frame-graph-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--spacing-md);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-2xs);
+  flex-wrap: wrap;
 }
 
 .frame-graph-title {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: var(--color-ink-3);
 }
 
 .frame-graph-legend {
   display: flex;
-  gap: var(--spacing-lg);
-  font-size: 0.75rem;
-  color: var(--color-text-hint);
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
-  gap: var(--spacing-xs);
+  gap: 0.35rem;
 }
 
 .legend-color {
-  width: 12px;
-  height: 12px;
-  border-radius: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 1px;
 }
 
 .legend-color.good {
@@ -518,28 +550,27 @@ body {
 
 .frame-graph {
   width: 100%;
-  height: 100px;
-  border-radius: 6px;
-  background: rgba(0, 0, 0, 0.3);
+  height: 88px;
+  border-radius: var(--radius-sm);
+  background: var(--color-paper-2);
+  display: block;
 }
 
-/* ========================================
-   Toast Notifications
-   ======================================== */
+/* Toast */
+
 .toast {
   position: fixed;
-  bottom: var(--spacing-xl);
-  right: var(--spacing-xl);
-  padding: var(--spacing-md) var(--spacing-lg);
-  border-radius: 8px;
-  font-size: 0.875rem;
+  bottom: var(--space-md);
+  right: var(--space-md);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
   font-weight: 500;
-  backdrop-filter: blur(var(--glass-blur));
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  transform: translateY(120%);
-  transition: transform var(--transition-base);
+  max-width: min(400px, calc(100vw - 2rem));
   z-index: 1000;
-  max-width: 400px;
+  transform: translateY(120%);
+  transition: transform var(--dur-mid) var(--ease-out);
+  border: 1px solid transparent;
 }
 
 .toast.show {
@@ -547,14 +578,13 @@ body {
 }
 
 .toast-warning {
-  background: rgba(245, 158, 11, 0.9);
-  color: white;
-  border: 1px solid rgba(245, 158, 11, 1);
+  background: var(--color-paper-3);
+  color: var(--color-warning);
+  border-color: oklch(78% 0.14 75 / 0.4);
 }
 
-/* ========================================
-   Responsive Design
-   ======================================== */
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
 @media (max-width: 1024px) {
   .main-container {
     flex-direction: column;
@@ -562,36 +592,36 @@ body {
 
   .config-panel {
     width: 100%;
-    max-height: 300px;
+    max-height: 40vh;
     border-right: none;
-    border-bottom: 1px solid var(--glass-border);
+    border-bottom: 1px solid var(--color-rule);
   }
 
   .metrics-grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 768px) {
-  :root {
-    --config-panel-width: 100%;
-    --header-height: 100px;
+  .header {
+    padding: var(--space-sm);
+    padding-right: var(--space-sm);
+    min-height: auto;
   }
 
-  .header {
-    padding: var(--spacing-md);
+  .github-link {
+    position: static;
+    transform: none;
+    align-self: flex-start;
+    margin-top: var(--space-2xs);
   }
 
   .title {
     font-size: 1.25rem;
   }
 
-  .subtitle {
-    font-size: 0.75rem;
-  }
-
   .metrics-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .frame-graph-legend {
@@ -599,23 +629,40 @@ body {
   }
 }
 
-/* ========================================
-   Scrollbar Styling
-   ======================================== */
+@media (max-width: 414px) {
+  .metrics-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* Scrollbar */
+
+.config-panel {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(92% 0.01 265 / 0.12) transparent;
+}
+
 .config-panel::-webkit-scrollbar {
-  width: 8px;
+  width: 6px;
 }
 
 .config-panel::-webkit-scrollbar-track {
-  background: rgba(0, 0, 0, 0.2);
+  background: transparent;
 }
 
 .config-panel::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
+  background: oklch(92% 0.01 265 / 0.12);
+  border-radius: 3px;
 }
 
-.config-panel::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.15);
-}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+  }
 
+  .toast {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Register recent series demos (error-bars, step-line, impulse, stacked-mountain, ohlc-bars) in the hand-maintained dev-site examples catalog so they appear under All demos.
- Restyle ultimate-benchmark and candlestick-streaming to ChartGPU brand tokens (Space Grotesk / DM Sans, gold accent, dark paper); drop AI chrome (gradients, glass, emoji, price flash).
- Candlestick header: metallic-black plot theme, WebGPU-blitted official wordmark with img fallback, stock-ticker `$` cashtag optically aligned to the logo.

## Test plan
- [ ] Open dev-site All demos → Series and confirm error-bars, step-line, impulse, stacked-mountain, ohlc-bars cards link correctly
- [ ] Load `examples/ultimate-benchmark/` — controls, generate/stream, metrics, frame graph still work
- [ ] Load `examples/candlestick-streaming/` — streaming, timeframes, presets, style toggle still work
- [ ] Confirm header shows `$` + ChartGPU wordmark (WebGPU canvas) + steady price; no green/red flash
- [ ] Confirm wordmark falls back to `<img>` if WebGPU is unavailable (optional)
- [ ] Spot-check mobile wrap on both example headers