### PR TITLE
perf(hover): keep multi-M streaming live under pointer hit-test

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,6 +39,21 @@ Zoom triggers resampling on visible range only. Target scales with zoom level (c
 
 **Memory:** Trim when `rawData.length > maxPoints` — `setOption({ series: [{ data: rawData.slice(-maxPoints) }] })`. See [`examples/live-streaming/`](../examples/live-streaming/).
 
+### Hover / hit-test during multi‑M streaming
+
+Pointer-in-plot work (highlight ring + optional tooltip) must stay cheap while appending:
+
+| Path | Behavior |
+|------|----------|
+| **Shared nearest-point** | One `findNearestPoint` result feeds **highlight + item tooltip**. **Time-only rate limit (~60 Hz / 16 ms)** — pointer move does **not** bypass the throttle. Each allowed sample uses the **latest** pointer; suppressed frames reuse the last match and schedule a follow-up render. Crosshair still tracks every frame. |
+| **findNearest multi‑M** | Above ~8k points: **skip mono check entirely**, domain x-window for the hit radius, then expand. When that window still has **≫4k** points (full-span multi‑M: points-per-pixel × maxDist), **stride + local refine** so hover stays O(thousands) not O(100k+). At ~**16M** (128 MiB storage bind / 8 bytes per f32 xy) device auto-window engages ring FIFO — without dense-stride expand, hover freezes streaming even with binary search. |
+| **Tooltip dual-store ring bounds** | When `tooltip.show: true` and device/`maxPoints` ring wraps, hit-test bounds use **O(1) endpoint x + batch y** (same as coordinator) — not a full O(n) rescan of the ~16M ring every append. |
+| **Monotonic X cache** | **Growing XY / arrays** (owned MutableXYColumns): `{ mono, count, lastX }` — pure mono growth re-checks **only the new tail**. First visit of n ≫ 250k uses strided sample + endpoints (avoids multi-second full scan on first hover). **Ring / staging**: generation-aware cache + `contentEpoch`. |
+| **`tooltip.show: false`** | Skips dual hit-test columnar store maintenance on `appendData` (GPU/coordinator only). Highlight/crosshair still use the shared gated path above — turning tooltips off alone does **not** disable hit-test. |
+| **`tooltip.show: true`** | Dual store kept for history/hit APIs; tooltip DOM updates share the same ~60 Hz gate as highlight. |
+
+Prefer library defaults (crosshair + highlight on) over demo-only `tooltip: false` when measuring interactive FPS. CPU-sampled series already hit-test their display resolution; GPU-decimation series keep raw resident data and use binary search when X is mono.
+
 ## appendData vs setOption
 
 | Method | Use case | GPU upload | Animation |

--- a/src/ChartGPU.ts
+++ b/src/ChartGPU.ts
@@ -2942,9 +2942,34 @@ export async function createChartGPU(
               appendData
             );
           } else {
-            runtimeRawBoundsByIndex[seriesIndex] = computeRawBoundsFromCartesianData(
-              owned as unknown as CartesianSeriesData
-            );
+            // Match coordinator appendFlush: O(1) endpoint x + extend y from the
+            // new batch only. Full O(n) rescan of a ~16M device ring every wrap
+            // freezes main-thread streaming (tooltip dual-store path).
+            const ring = owned as RingXYColumns;
+            const prevB = runtimeRawBoundsByIndex[seriesIndex];
+            const x0 = getCartesianX(ring as unknown as CartesianSeriesData, 0);
+            const x1 = getCartesianX(ring as unknown as CartesianSeriesData, Math.max(0, ring.count - 1));
+            let yMin = prevB?.yMin ?? Number.POSITIVE_INFINITY;
+            let yMax = prevB?.yMax ?? Number.NEGATIVE_INFINITY;
+            const end = plan.newSrcOffset + plan.keepNewCount;
+            for (let i = plan.newSrcOffset; i < end; i++) {
+              const y = getCartesianY(appendData, i);
+              if (Number.isFinite(y)) {
+                if (y < yMin) yMin = y;
+                if (y > yMax) yMax = y;
+              }
+            }
+            if (Number.isFinite(x0) && Number.isFinite(x1) && Number.isFinite(yMin) && Number.isFinite(yMax)) {
+              let xMin = x0;
+              let xMax = x1;
+              if (xMin === xMax) xMax = xMin + 1;
+              if (yMin === yMax) yMax = yMin + 1;
+              runtimeRawBoundsByIndex[seriesIndex] = { xMin, xMax, yMin, yMax };
+            } else {
+              runtimeRawBoundsByIndex[seriesIndex] = computeRawBoundsFromCartesianData(
+                ring as unknown as CartesianSeriesData
+              );
+            }
           }
         } else {
           // Unbounded: demote ring → linear if needed, then grow arrays.

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -127,6 +127,14 @@ import type { ZoomRange, ZoomState } from '../../interaction/createZoomState';
 import { findNearestPoint } from '../../interaction/findNearestPoint';
 import { findPointsAtX } from '../../interaction/findPointsAtX';
 import {
+  createHoverHitTestGateState,
+  DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS,
+  DEFAULT_HOVER_HIT_TEST_THROTTLE_MS,
+  invalidateHoverHitTest,
+  resolveHoverHitTestFrame,
+  shouldAllowSyncTooltipHitTest,
+} from '../../interaction/hoverHitTestGate';
+import {
   computeCandlestickBodyWidthRange,
   findCandlestick,
   type FinanceOhlcHitSeriesConfig,
@@ -1606,11 +1614,15 @@ export function createRenderCoordinator(
   // Cache tooltip state to avoid unnecessary DOM updates
   const tooltipCache = createTooltipCache();
 
-  // Throttle tooltip hit-testing to ~30 Hz (P0-4). Crosshair/highlight still track the
-  // pointer every frame; only the expensive tooltip scan + DOM path is rate-limited.
-  // A follow-up render is scheduled so the tooltip catches up after the window elapses.
-  const TOOLTIP_HIT_TEST_THROTTLE_MS = 33;
-  let lastTooltipHitTestMs = -Infinity;
+  // Shared hover hit-test gate (~60 Hz, time-only) for highlight + tooltip.
+  // Crosshair still tracks the pointer every frame (cheap). findNearestPoint is
+  // rate-limited so multi-M streaming hover does not pay a full nearest scan every
+  // paint; suppressed frames reuse the last match. A follow-up render is scheduled
+  // so highlight/tooltip catch up after the throttle window elapses.
+  const HOVER_HIT_TEST_THROTTLE_MS = DEFAULT_HOVER_HIT_TEST_THROTTLE_MS;
+  const hoverHitTestGate = createHoverHitTestGateState();
+  /** Sync tooltips use a separate time gate (do not share mouse match cache). */
+  let lastSyncTooltipHitTestMs = Number.NEGATIVE_INFINITY;
   let pendingTooltipFollowupTimerId: ReturnType<typeof setTimeout> | null = null;
 
   const cancelPendingTooltipFollowup = (): void => {
@@ -2918,6 +2930,12 @@ export function createRenderCoordinator(
     // and other label-affecting options may have changed (functions not in sig).
     axisLabelContentEpoch++;
 
+    // Drop cached hover match when series data/structure may change so highlight
+    // does not ghost the prior nearest point until the throttle window elapses.
+    if (likelyDataChanged || needsBaselineResample || prevSeries.length !== resolvedOptions.series.length) {
+      invalidateHoverHitTest(hoverHitTestGate);
+    }
+
     // Heatmap stream vs setOption identity policy (shouldClearHeatmapStream).
     ensureHeatmapStreamSlots(resolvedOptions.series.length);
     for (let i = 0; i < resolvedOptions.series.length; i++) {
@@ -3880,25 +3898,47 @@ export function createRenderCoordinator(
       }
     );
 
-    // P0-5: single findNearestPoint for highlight + item-mode tooltip.
-    // Computed once when the real pointer is over the plot; shared via prepareOverlays.
+    // Shared findNearestPoint for highlight + item-mode tooltip (P0-5), gated by
+    // ~60 Hz time-only rate limit so multi-M hover is not every-frame O(scan).
     let sharedNearestMatch: ReturnType<typeof findNearestPoint> | undefined;
-    if (
-      effectivePointer.source === 'mouse' &&
-      effectivePointer.hasPointer &&
-      effectivePointer.isInGrid &&
-      interactionScales
-    ) {
-      sharedNearestMatch = findNearestPoint(
-        seriesForRender,
-        effectivePointer.gridX,
-        effectivePointer.gridY,
-        interactionScales.xScale,
-        interactionScales.yScales.values().next().value!,
-        undefined,
-        interactionScales.yScales
-      );
+    /** True when this frame ran a fresh nearest-point compute (mouse path). */
+    let hoverHitTestRecomputed = false;
+    const pointerInGrid = effectivePointer.hasPointer && effectivePointer.isInGrid && interactionScales != null;
+    const mouseInGrid = pointerInGrid && effectivePointer.source === 'mouse';
+
+    if (mouseInGrid && interactionScales) {
+      const now = performance.now();
+      const scales = interactionScales;
+      const frame = resolveHoverHitTestFrame({
+        state: hoverHitTestGate,
+        nowMs: now,
+        gridX: effectivePointer.gridX,
+        gridY: effectivePointer.gridY,
+        options: DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS,
+        findNearest: () =>
+          findNearestPoint(
+            seriesForRender,
+            effectivePointer.gridX,
+            effectivePointer.gridY,
+            scales.xScale,
+            scales.yScales.values().next().value!,
+            undefined,
+            scales.yScales
+          ),
+      });
+      sharedNearestMatch = frame.match;
+      hoverHitTestRecomputed = frame.recomputed;
+      if (frame.scheduleFollowupMs == null) {
+        cancelPendingTooltipFollowup();
+      } else {
+        schedulePendingTooltipFollowup(frame.scheduleFollowupMs);
+      }
+    } else if (!pointerInGrid) {
+      sharedNearestMatch = null;
+      invalidateHoverHitTest(hoverHitTestGate);
+      cancelPendingTooltipFollowup();
     } else {
+      // Sync pointer in grid: highlight is mouse-only; no findNearestPoint.
       sharedNearestMatch = null;
     }
 
@@ -3934,21 +3974,27 @@ export function createRenderCoordinator(
     const tooltipPointerActive =
       effectivePointer.hasPointer && effectivePointer.isInGrid && currentOptions.tooltip?.show !== false;
 
-    // Throttle gate (P0-4): suppress hit-testing within TOOLTIP_HIT_TEST_THROTTLE_MS of
-    // the previous computation. When suppressed, leave the existing tooltip alone and
-    // schedule a follow-up render. Hides (pointer leaving the grid) are not throttled.
+    // Tooltip DOM + axis/pie/candle secondary hit paths share the same ~60 Hz gate
+    // as highlight findNearestPoint (mouse). Sync tooltips use a **separate** time
+    // gate so mouse↔sync transitions do not suppress recomputes wrongly.
+    // When suppressed, leave the existing tooltip alone and rely on the scheduled
+    // follow-up render. Hides (pointer leaving the grid) are not throttled.
     let tooltipHitTestAllowed = true;
     if (tooltipPointerActive) {
-      const now = performance.now();
-      const elapsed = now - lastTooltipHitTestMs;
-      if (elapsed < TOOLTIP_HIT_TEST_THROTTLE_MS) {
-        tooltipHitTestAllowed = false;
-        schedulePendingTooltipFollowup(TOOLTIP_HIT_TEST_THROTTLE_MS - elapsed);
+      if (mouseInGrid) {
+        tooltipHitTestAllowed = hoverHitTestRecomputed;
       } else {
-        lastTooltipHitTestMs = now;
-        cancelPendingTooltipFollowup();
+        const now = performance.now();
+        const syncGate = shouldAllowSyncTooltipHitTest(lastSyncTooltipHitTestMs, now, HOVER_HIT_TEST_THROTTLE_MS);
+        lastSyncTooltipHitTestMs = syncGate.nextLastSyncMs;
+        tooltipHitTestAllowed = syncGate.allowed;
+        if (syncGate.scheduleFollowupMs != null) {
+          schedulePendingTooltipFollowup(syncGate.scheduleFollowupMs);
+        } else {
+          cancelPendingTooltipFollowup();
+        }
       }
-    } else {
+    } else if (!mouseInGrid) {
       cancelPendingTooltipFollowup();
     }
 

--- a/src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts
@@ -135,6 +135,56 @@ describe('computeVisibleSlice', () => {
       const data = new Float32Array([1, 10, NaN, 20, 3, 15]);
       expect(isMonotonicNonDecreasingFiniteX(data)).toBe(false);
     });
+
+    it('FIFO multi-append at capacity stays mono without full rescan (device auto-window hover)', async () => {
+      // ~device ring: many appends between mono polls (hover throttle) must not O(n).
+      const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+      const cap = 10_000;
+      const ring = createRingXYColumns(cap);
+      const seed = {
+        x: Float64Array.from({ length: cap }, (_, i) => i),
+        y: Float64Array.from({ length: cap }, () => 0),
+      };
+      appendIntoRingXY(ring, seed, 0, cap, 0);
+      expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+
+      for (let a = 0; a < 5; a++) {
+        const batch = {
+          x: Float64Array.from({ length: 100 }, (_, i) => cap + a * 100 + i),
+          y: Float64Array.from({ length: 100 }, () => 0),
+        };
+        appendIntoRingXY(ring, batch, 0, 100, 100);
+      }
+      const t0 = performance.now();
+      for (let k = 0; k < 100; k++) {
+        expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+      }
+      expect(performance.now() - t0).toBeLessThan(50);
+    });
+
+    it('growing XY columns only re-check the new tail (streaming multi-M)', () => {
+      // Owned MutableXYColumns grow under stable identity during appendData.
+      const growable = {
+        x: Array.from({ length: 5_000 }, (_, i) => i),
+        y: Array.from({ length: 5_000 }, (_, i) => i),
+      };
+      expect(isMonotonicNonDecreasingFiniteX(growable)).toBe(true);
+      for (let i = 5_000; i < 15_000; i++) {
+        growable.x.push(i);
+        growable.y.push(i);
+      }
+      expect(isMonotonicNonDecreasingFiniteX(growable)).toBe(true);
+      // Same generation: pure cache hits must stay cheap
+      const t1 = performance.now();
+      for (let k = 0; k < 200; k++) {
+        expect(isMonotonicNonDecreasingFiniteX(growable)).toBe(true);
+      }
+      expect(performance.now() - t1).toBeLessThan(50);
+
+      growable.x.push(0);
+      growable.y.push(0);
+      expect(isMonotonicNonDecreasingFiniteX(growable)).toBe(false);
+    });
   });
 
   describe('sliceVisibleRangeByX', () => {
@@ -472,24 +522,195 @@ describe('computeVisibleSlice', () => {
   });
 });
 
-describe('isMonotonicNonDecreasingFiniteX mutable ring/staging (issue 1.5)', () => {
-  it('does not stick mono=true after ring x mutates under same ref', async () => {
+describe('isMonotonicNonDecreasingFiniteX mutable ring/staging (issue 1.5 + generation cache)', () => {
+  it('detects mono violation after FIFO append of decreasing x (same ring ref)', async () => {
     const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
-    const ring = createRingXYColumns(4);
+    const ring = createRingXYColumns(8);
     appendIntoRingXY(ring, { x: [0, 1, 2, 3], y: [0, 1, 2, 3] }, 0, 4, 0);
     expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
-    // Mutate physical x under same object identity to break monotonicity.
-    ring.x[1] = -100;
+    // Append decreasing x via API (generation count advances) — must not stick mono=true.
+    appendIntoRingXY(ring, { x: [-50], y: [9] }, 0, 1, 0);
     expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(false);
   });
 
-  it('does not stick mono=true after StagingRingView mutates', async () => {
+  it('detects mono violation on staging after count growth with decreasing x', async () => {
+    const { createStagingRingView } = await import('../../../../data/cartesianData');
+    const staging = new Float32Array(16);
+    // linear: (0,0)(1,1)(2,2)(3,3)
+    for (let i = 0; i < 4; i++) {
+      staging[i * 2] = i;
+      staging[i * 2 + 1] = i;
+    }
+    const view = createStagingRingView(staging, 0, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(view as any)).toBe(true);
+    // Grow count with a decreasing x (generation change) — must re-verify tail.
+    staging[8] = -1;
+    staging[9] = 0;
+    createStagingRingView(staging, 0, 0, 5, 0, view);
+    expect(isMonotonicNonDecreasingFiniteX(view as any)).toBe(false);
+  });
+
+  it('monotonic ring append stays mono under many pure appends (incremental path)', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const ring = createRingXYColumns(10_000);
+    appendIntoRingXY(ring, { x: [0, 1, 2, 3], y: [0, 1, 2, 3] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+
+    // Many mono appends: generation-aware cache must keep mono=true (O(append) path).
+    for (let k = 0; k < 200; k++) {
+      const x0 = 4 + k;
+      appendIntoRingXY(ring, { x: [x0], y: [0] }, 0, 1, 0);
+      expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    }
+    expect(ring.count).toBe(204);
+  });
+
+  it('same generation returns stable mono result', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const ring = createRingXYColumns(16);
+    appendIntoRingXY(ring, { x: [1, 2, 3, 4], y: [0, 0, 0, 0] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+  });
+
+  it('FIFO wrap at capacity keeps mono then detects violation', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const cap = 8;
+    const ring = createRingXYColumns(cap);
+    // Fill to capacity 0..7
+    appendIntoRingXY(ring, { x: [0, 1, 2, 3, 4, 5, 6, 7], y: [0, 0, 0, 0, 0, 0, 0, 0] }, 0, 8, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    // Drop 2, append 8,9 → still mono
+    appendIntoRingXY(ring, { x: [8, 9], y: [0, 0] }, 0, 2, 2);
+    expect(ring.count).toBe(cap);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    // Drop 2, append decreasing → mono false via incremental
+    appendIntoRingXY(ring, { x: [0, 1], y: [0, 0] }, 0, 2, 2);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(false);
+  });
+
+  it('strict full-buffer replace at start=0 detects non-mono (contentEpoch)', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const cap = 4;
+    const ring = createRingXYColumns(cap);
+    appendIntoRingXY(ring, { x: [0, 1, 2, 3], y: [0, 0, 0, 0] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    // Strict replace: drop all 4, write non-mono 3,1,2,0 — start/count/capacity stay 0/4/4.
+    appendIntoRingXY(ring, { x: [3, 1, 2, 0], y: [0, 0, 0, 0] }, 0, 4, 4);
+    expect(ring.start).toBe(0);
+    expect(ring.count).toBe(cap);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(false);
+  });
+
+  it('wrap then strict full replace detects prefix-only mono violation', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const cap = 4;
+    const ring = createRingXYColumns(cap);
+    appendIntoRingXY(ring, { x: [0, 1, 2, 3], y: [0, 0, 0, 0] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    // Partial wrap so start != 0
+    appendIntoRingXY(ring, { x: [4, 5], y: [0, 0] }, 0, 2, 2);
+    expect(ring.start).not.toBe(0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    // Strict replace entire buffer with non-mono (prefix violation only if tail-only verify)
+    appendIntoRingXY(ring, { x: [10, 0, 1, 2], y: [0, 0, 0, 0] }, 0, 4, 4);
+    expect(ring.start).toBe(0);
+    expect(ring.count).toBe(cap);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(false);
+  });
+
+  it('staging full rewrite under same layout fields detects non-mono via contentEpoch', async () => {
     const { createStagingRingView } = await import('../../../../data/cartesianData');
     const staging = new Float32Array([0, 0, 1, 1, 2, 2, 3, 3]);
     const view = createStagingRingView(staging, 0, 0, 4, 0);
     expect(isMonotonicNonDecreasingFiniteX(view as any)).toBe(true);
-    staging[2] = -5; // break chronological x at logical index 1
+    // Rewrite floats in place; same start/count/capacity/xOffset; bump via createStagingRingView.
+    staging[0] = 9;
+    staging[2] = 1;
+    staging[4] = 5;
+    staging[6] = 0;
+    createStagingRingView(staging, 0, 0, 4, 0, view);
     expect(isMonotonicNonDecreasingFiniteX(view as any)).toBe(false);
+  });
+
+  it('non-finite append tail makes mono false', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const ring = createRingXYColumns(8);
+    appendIntoRingXY(ring, { x: [0, 1, 2], y: [0, 0, 0] }, 0, 3, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    appendIntoRingXY(ring, { x: [Number.NaN], y: [0] }, 0, 1, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(false);
+  });
+
+  it('equal consecutive x stays mono non-decreasing', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const ring = createRingXYColumns(8);
+    appendIntoRingXY(ring, { x: [1, 1, 2, 2], y: [0, 1, 2, 3] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    appendIntoRingXY(ring, { x: [2], y: [4] }, 0, 1, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+  });
+
+  it('mono recovers after false when full mono rewrite replaces content', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const ring = createRingXYColumns(4);
+    appendIntoRingXY(ring, { x: [0, 1, 2, 3], y: [0, 0, 0, 0] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    appendIntoRingXY(ring, { x: [5, 1, 2, 3], y: [0, 0, 0, 0] }, 0, 4, 4);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(false);
+    appendIntoRingXY(ring, { x: [10, 11, 12, 13], y: [0, 0, 0, 0] }, 0, 4, 4);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+  });
+
+  it('capacity change forces re-eval (new ring)', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    const ring = createRingXYColumns(4);
+    appendIntoRingXY(ring, { x: [0, 1, 2, 3], y: [0, 0, 0, 0] }, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    const bigger = createRingXYColumns(8);
+    appendIntoRingXY(bigger, { x: [0, 1, 2, 3, 4], y: [0, 0, 0, 0, 0] }, 0, 5, 0);
+    expect(isMonotonicNonDecreasingFiniteX(bigger as any)).toBe(true);
+  });
+
+  it('staging multi-append mono stays true', async () => {
+    const { createStagingRingView } = await import('../../../../data/cartesianData');
+    const staging = new Float32Array(32);
+    for (let i = 0; i < 4; i++) {
+      staging[i * 2] = i;
+      staging[i * 2 + 1] = 0;
+    }
+    const view = createStagingRingView(staging, 0, 0, 4, 0);
+    expect(isMonotonicNonDecreasingFiniteX(view as any)).toBe(true);
+    for (let n = 5; n <= 10; n++) {
+      staging[(n - 1) * 2] = n - 1;
+      staging[(n - 1) * 2 + 1] = 0;
+      createStagingRingView(staging, 0, 0, n, 0, view);
+      expect(isMonotonicNonDecreasingFiniteX(view as any)).toBe(true);
+    }
+  });
+
+  it('large mono ring: many generation-stable checks stay correct and fast', async () => {
+    const { createRingXYColumns, appendIntoRingXY } = await import('../../../../data/cartesianData');
+    // Behavioral perf guard: after one mono establish, repeated same-generation
+    // checks must not re-walk multi-M points (would time out / be multi-ms).
+    const n = 200_000;
+    const ring = createRingXYColumns(n);
+    const xs = new Float64Array(n);
+    const ys = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+      xs[i] = i;
+      ys[i] = i * 0.01;
+    }
+    appendIntoRingXY(ring, { x: xs, y: ys }, 0, n, 0);
+    expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    const t0 = performance.now();
+    for (let i = 0; i < 500; i++) {
+      expect(isMonotonicNonDecreasingFiniteX(ring as any)).toBe(true);
+    }
+    const elapsed = performance.now() - t0;
+    // 500 cached hits should be well under 50ms (full 200k×500 would be seconds).
+    expect(elapsed).toBeLessThan(50);
   });
 });
 

--- a/src/core/renderCoordinator/data/computeVisibleSlice.ts
+++ b/src/core/renderCoordinator/data/computeVisibleSlice.ts
@@ -28,6 +28,8 @@ import {
   isRingXYColumns,
   isStagingRingView,
   type CoordinatorCartesianData,
+  type RingXYColumns,
+  type StagingRingView,
 } from '../../../data/cartesianData';
 import { clampInt } from '../utils/canvasUtils';
 
@@ -36,51 +38,295 @@ export function isTupleOHLCDataPoint(p: OHLCDataPoint): p is OHLCDataPointTuple 
   return Array.isArray(p);
 }
 
-// Cache monotonicity checks to avoid O(n) scans on every zoom operation
-// WeakMap works for arrays, typed arrays, and object references (XYArraysData)
-const monotonicXCache = new WeakMap<object, boolean>();
+/**
+ * Cache monotonicity for array / XY / interleaved identities that may **grow
+ * in place** (owned MutableXYColumns under a stable object ref).
+ * Storing only `boolean` was wrong for streaming: first hover after multi‑M
+ * growth forced a full O(n) rescan every time the identity was new, and even
+ * with a boolean cache a later grow never re-verified the tail cheaply.
+ */
+type ArrayMonoCacheEntry = {
+  mono: boolean;
+  count: number;
+  lastX: number;
+};
+const monotonicXCache = new WeakMap<object, ArrayMonoCacheEntry>();
 const monotonicTimestampCache = new WeakMap<ReadonlyArray<OHLCDataPoint>, boolean>();
+
+/** Cap one-shot full mono scans so first hover at multi‑M cannot freeze the tab. */
+const MONO_FULL_SCAN_SOFT_CAP = 250_000;
+
+/**
+ * Generation-aware mono state for mutable ring / staging storage.
+ * Identity alone is unsafe (content mutates in place); generation is
+ * (start, count, capacity, xOffset, staging buffer identity, contentEpoch).
+ *
+ * `contentEpoch` is bumped by writers ({@link appendIntoRingXY},
+ * {@link createStagingRingView}) so strict full-buffer rewrite under unchanged
+ * layout fields cannot leave stale mono=true.
+ *
+ * Incremental path: pure append and partial FIFO drop+append of mono data only
+ * verify newly written chronological points — O(append) not O(n). Full replace
+ * (drop ≥ previous count / content rewrite under same layout) full-scans.
+ */
+type MutableMonoCacheEntry = {
+  mono: boolean;
+  start: number;
+  count: number;
+  capacity: number;
+  xOffset: number;
+  contentEpoch: number;
+  /** Ring full-clear generation; staging always 0. */
+  rewriteGen: number;
+  /** Staging buffer identity; null for RingXYColumns. */
+  staging: Float32Array | null;
+  /** Last chronological x when mono (or −∞ when empty). */
+  lastX: number;
+};
+
+const mutableMonoCache = new WeakMap<object, MutableMonoCacheEntry>();
+
+function fullScanMonotonicX(data: CoordinatorCartesianData): { mono: boolean; lastX: number } {
+  let prevX = Number.NEGATIVE_INFINITY;
+  const n = getPointCount(data);
+  for (let i = 0; i < n; i++) {
+    const x = getX(data, i);
+    if (!Number.isFinite(x) || x < prevX) {
+      return { mono: false, lastX: prevX };
+    }
+    prevX = x;
+  }
+  return { mono: true, lastX: prevX };
+}
+
+/**
+ * Verify chronological indices [from, to) stay non-decreasing vs `prevX`.
+ * Returns updated lastX on success, or null on violation.
+ */
+function verifyMonoRange(data: CoordinatorCartesianData, from: number, to: number, prevX: number): number | null {
+  let last = prevX;
+  for (let i = from; i < to; i++) {
+    const x = getX(data, i);
+    if (!Number.isFinite(x) || x < last) return null;
+    last = x;
+  }
+  return last;
+}
+
+function readContentEpoch(data: RingXYColumns | StagingRingView): number {
+  const epoch = data.contentEpoch;
+  return typeof epoch === 'number' && Number.isFinite(epoch) ? epoch | 0 : 0;
+}
+
+function readRewriteGen(data: RingXYColumns | StagingRingView): number {
+  if (isStagingRingView(data)) return 0;
+  const g = (data as RingXYColumns).rewriteGen;
+  return typeof g === 'number' && Number.isFinite(g) ? g | 0 : 0;
+}
+
+function isMonotonicMutableRingOrStaging(data: RingXYColumns | StagingRingView): boolean {
+  const start = data.start;
+  const count = data.count;
+  const capacity = data.capacity;
+  const xOffset = isStagingRingView(data) ? data.xOffset : 0;
+  const staging = isStagingRingView(data) ? data.staging : null;
+  const contentEpoch = readContentEpoch(data);
+  const rewriteGen = readRewriteGen(data);
+
+  const cached = mutableMonoCache.get(data as object);
+
+  // Same generation (layout + contentEpoch + rewriteGen) → reuse.
+  if (
+    cached &&
+    cached.start === start &&
+    cached.count === count &&
+    cached.capacity === capacity &&
+    cached.xOffset === xOffset &&
+    cached.staging === staging &&
+    cached.contentEpoch === contentEpoch &&
+    cached.rewriteGen === rewriteGen
+  ) {
+    return cached.mono;
+  }
+
+  const store = (mono: boolean, lastX: number): boolean => {
+    mutableMonoCache.set(data as object, {
+      mono,
+      start,
+      count,
+      capacity,
+      xOffset,
+      contentEpoch,
+      rewriteGen,
+      staging,
+      lastX,
+    });
+    return mono;
+  };
+
+  // Soft-cap: never full-scan multi‑M rings on the hover hot path (device
+  // auto-window is ~16M points at 128 MiB). Strided sample + endpoints.
+  const maybeSoftMono = (): boolean => {
+    if (count <= MONO_FULL_SCAN_SOFT_CAP) {
+      const scanned = fullScanMonotonicX(data);
+      return store(scanned.mono, scanned.lastX);
+    }
+    let prevX = Number.NEGATIVE_INFINITY;
+    let ok = true;
+    const stride = Math.max(1, Math.floor(count / 2048));
+    for (let i = 0; i < count; i += stride) {
+      const x = getX(data, i);
+      if (!Number.isFinite(x) || x < prevX) {
+        ok = false;
+        break;
+      }
+      prevX = x;
+    }
+    if (ok && count > 0) {
+      const lastX = getX(data, count - 1);
+      if (!Number.isFinite(lastX) || lastX < prevX) ok = false;
+      else prevX = lastX;
+    }
+    return store(ok, ok ? prevX : Number.NEGATIVE_INFINITY);
+  };
+
+  // Full-clear rewrite: retained prefix is invalid — soft/full scan.
+  if (cached && cached.rewriteGen !== rewriteGen) {
+    return maybeSoftMono();
+  }
+
+  // Incremental pure append: start unchanged, count grew, prior mono.
+  // contentEpoch may advance by >1 if mono was not polled between appends.
+  if (
+    cached &&
+    cached.mono &&
+    cached.capacity === capacity &&
+    cached.xOffset === xOffset &&
+    cached.staging === staging &&
+    cached.start === start &&
+    count > cached.count &&
+    contentEpoch > cached.contentEpoch
+  ) {
+    const last = verifyMonoRange(data, cached.count, count, cached.lastX);
+    if (last == null) return store(false, cached.lastX);
+    return store(true, last);
+  }
+
+  // Incremental FIFO at capacity: start advanced by total drops since last
+  // check (one or more appends). Verify only the newly written chronological
+  // tail — O(dropped), not O(capacity). Device auto-window hover depends on this.
+  if (
+    cached &&
+    cached.mono &&
+    cached.capacity === capacity &&
+    capacity > 0 &&
+    cached.xOffset === xOffset &&
+    cached.staging === staging &&
+    count === cached.count &&
+    count === capacity &&
+    start !== cached.start &&
+    contentEpoch > cached.contentEpoch &&
+    rewriteGen === cached.rewriteGen
+  ) {
+    const dropped = (start - cached.start + capacity) % capacity;
+    if (dropped > 0 && dropped < count) {
+      const retainedLastIdx = count - dropped - 1;
+      const prevX = getX(data, retainedLastIdx);
+      if (!Number.isFinite(prevX)) return store(false, cached.lastX);
+      const last = verifyMonoRange(data, count - dropped, count, prevX);
+      if (last == null) return store(false, prevX);
+      return store(true, last);
+    }
+  }
+
+  // Unrecognized transition, first visit, or full replace: soft-capped scan.
+  return maybeSoftMono();
+}
 
 /**
  * Checks if cartesian data is monotonic non-decreasing by X coordinate with all finite values.
- * Results are cached in a WeakMap to avoid repeated O(n) scans for **immutable**
- * DataPoint[] / typed arrays / XYArraysData.
  *
- * **Mutable ring / staging:** `RingXYColumns` and `StagingRingView` mutate content
- * under a stable object identity. WeakMap caching is **disabled** for those shapes
- * so a mono=true result cannot stick after content becomes non-monotonic (issue 1.5).
+ * **Array / XY / interleaved** (including coordinator-owned MutableXYColumns that
+ * grow under a stable identity): WeakMap entry `{ mono, count, lastX }`. Pure
+ * mono growth only re-checks the new tail (O(append)) — critical for multi‑M
+ * streaming hover so we never re-scan 15M points every hit-test.
  *
- * Supports all CartesianSeriesData formats: DataPoint[], XYArraysData, InterleavedXYData,
- * plus internal ring/staging (always scanned).
+ * **Mutable ring / staging:** generation-aware cache (start/count/capacity/
+ * xOffset/staging/`contentEpoch`). Pure mono append and partial FIFO drop+append
+ * re-verify only new points; strict full replace full-scans.
+ *
+ * First visit of huge series (n ≫ soft cap): strided sample + endpoints rather
+ * than a multi-second full scan (streaming line contract is mono-increasing x).
  */
 export function isMonotonicNonDecreasingFiniteX(data: CartesianSeriesData): boolean {
-  // Mutable modular storage: never cache by identity (content mutates in place).
-  const isMutableRingOrStaging = isRingXYColumns(data) || isStagingRingView(data);
+  if (isRingXYColumns(data) || isStagingRingView(data)) {
+    return isMonotonicMutableRingOrStaging(data);
+  }
 
-  // For immutable arrays / XY objects, cache by object reference.
-  const cacheKey = !isMutableRingOrStaging && typeof data === 'object' && data !== null ? (data as object) : null;
+  const cacheKey = typeof data === 'object' && data !== null ? (data as object) : null;
+  const n = getPointCount(data);
+
   if (cacheKey) {
     const cached = monotonicXCache.get(cacheKey);
-    if (cached !== undefined) return cached;
+    if (cached) {
+      if (cached.count === n) return cached.mono;
+      // Pure mono growth: verify only the new chronological tail.
+      if (cached.mono && n > cached.count) {
+        const last = verifyMonoRange(data as CoordinatorCartesianData, cached.count, n, cached.lastX);
+        if (last == null) {
+          monotonicXCache.set(cacheKey, { mono: false, count: n, lastX: cached.lastX });
+          return false;
+        }
+        monotonicXCache.set(cacheKey, { mono: true, count: n, lastX: last });
+        return true;
+      }
+      // Shrink, mono=false with growth, or other transitions → rescan below.
+    }
+  }
+
+  // Soft-cap full scan: multi‑M first hover must not block streaming for seconds.
+  if (n > MONO_FULL_SCAN_SOFT_CAP) {
+    let prevX = Number.NEGATIVE_INFINITY;
+    let ok = true;
+    const stride = Math.max(1, Math.floor(n / 2048));
+    for (let i = 0; i < n; i += stride) {
+      const x = getX(data as CoordinatorCartesianData, i);
+      if (!Number.isFinite(x) || x < prevX) {
+        ok = false;
+        break;
+      }
+      prevX = x;
+    }
+    if (ok) {
+      const lastX = getX(data as CoordinatorCartesianData, n - 1);
+      if (!Number.isFinite(lastX) || lastX < prevX) ok = false;
+      else prevX = lastX;
+    }
+    if (cacheKey) {
+      monotonicXCache.set(cacheKey, {
+        mono: ok,
+        count: n,
+        lastX: ok ? prevX : Number.NEGATIVE_INFINITY,
+      });
+    }
+    return ok;
   }
 
   let prevX = Number.NEGATIVE_INFINITY;
-  const n = getPointCount(data);
-
   for (let i = 0; i < n; i++) {
-    const x = getX(data, i);
-    if (!Number.isFinite(x)) {
-      if (cacheKey) monotonicXCache.set(cacheKey, false);
-      return false;
-    }
-    if (x < prevX) {
-      if (cacheKey) monotonicXCache.set(cacheKey, false);
+    const x = getX(data as CoordinatorCartesianData, i);
+    if (!Number.isFinite(x) || x < prevX) {
+      if (cacheKey) {
+        monotonicXCache.set(cacheKey, { mono: false, count: n, lastX: prevX });
+      }
       return false;
     }
     prevX = x;
   }
 
-  if (cacheKey) monotonicXCache.set(cacheKey, true);
+  if (cacheKey) {
+    monotonicXCache.set(cacheKey, { mono: true, count: n, lastX: prevX });
+  }
   return true;
 }
 

--- a/src/core/renderCoordinator/render/__tests__/prepareOverlaysNearestMatch.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/prepareOverlaysNearestMatch.test.ts
@@ -1,0 +1,213 @@
+/**
+ * prepareOverlays respects precomputed nearestMatch (including null) and
+ * skips findNearestPoint when the coordinator provides a shared result.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createLinearScale } from '../../../../utils/scales';
+import { prepareOverlays } from '../renderOverlays';
+import type { ResolvedChartGPUOptions } from '../../../../config/OptionResolver';
+import type { GridArea } from '../../../../renderers/createGridRenderer';
+import * as findNearestMod from '../../../../interaction/findNearestPoint';
+
+vi.mock('../../../../interaction/findNearestPoint', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../interaction/findNearestPoint')>();
+  return {
+    ...actual,
+    findNearestPoint: vi.fn(actual.findNearestPoint),
+  };
+});
+
+function makeGridArea(): GridArea {
+  return {
+    left: 40,
+    right: 20,
+    top: 20,
+    bottom: 40,
+    canvasWidth: 1280,
+    canvasHeight: 720,
+    devicePixelRatio: 2,
+  };
+}
+
+function makeOptions(): ResolvedChartGPUOptions {
+  return {
+    grid: { left: 40, right: 20, top: 20, bottom: 40 },
+    gridLines: {
+      show: false,
+      color: 'rgba(255,255,255,0.15)',
+      opacity: 1,
+      horizontal: { show: false, count: 5, color: 'rgba(255,255,255,0.15)' },
+      vertical: { show: false, count: 6, color: 'rgba(255,255,255,0.15)' },
+    },
+    xAxis: { type: 'value', id: 'x' },
+    yAxes: [{ type: 'value', id: 'y', position: 'left' }],
+    autoScroll: false,
+    theme: {
+      backgroundColor: '#000',
+      textColor: '#fff',
+      axisLineColor: '#888',
+      axisTickColor: '#666',
+      gridLineColor: 'rgba(255,255,255,0.15)',
+      colorPalette: ['#0af'],
+    },
+    palette: ['#0af'],
+    series: [
+      {
+        type: 'line',
+        name: 'S0',
+        color: '#0af',
+        data: [
+          [0, 0],
+          [1, 1],
+          [2, 2],
+        ],
+      },
+    ],
+  } as unknown as ResolvedChartGPUOptions;
+}
+
+function makeMockRenderers() {
+  return {
+    gridRenderer: { prepare: vi.fn(), render: vi.fn(), dispose: vi.fn() },
+    xAxisRenderer: { prepare: vi.fn(), render: vi.fn(), dispose: vi.fn() },
+    yAxisRenderers: new Map([['y', { prepare: vi.fn(), render: vi.fn(), dispose: vi.fn() }]]),
+    crosshairRenderer: {
+      prepare: vi.fn(),
+      setVisible: vi.fn(),
+      render: vi.fn(),
+      dispose: vi.fn(),
+    },
+    highlightRenderer: {
+      prepare: vi.fn(),
+      setVisible: vi.fn(),
+      render: vi.fn(),
+      dispose: vi.fn(),
+    },
+  };
+}
+
+describe('prepareOverlays nearestMatch (shared hit-test)', () => {
+  beforeEach(() => {
+    vi.mocked(findNearestMod.findNearestPoint).mockClear();
+  });
+
+  it('skips findNearestPoint when nearestMatch is provided and prepares highlight', () => {
+    const renderers = makeMockRenderers();
+    const xScale = createLinearScale().domain(0, 10).range(0, 100);
+    const yScale = createLinearScale().domain(0, 10).range(100, 0);
+    const yScales = new Map([['y', yScale]]);
+    const seriesForRender = makeOptions().series;
+
+    prepareOverlays(
+      renderers as any,
+      {
+        currentOptions: makeOptions(),
+        xScale,
+        yScales,
+        gridArea: makeGridArea(),
+        xTickCount: 5,
+        hasCartesianSeries: true,
+        effectivePointer: {
+          hasPointer: true,
+          isInGrid: true,
+          source: 'mouse',
+          x: 50,
+          y: 50,
+          gridX: 50,
+          gridY: 50,
+        },
+        interactionScales: { xScale, yScales },
+        seriesForRender,
+        withAlpha: (c: string) => c,
+        nearestMatch: {
+          seriesIndex: 0,
+          dataIndex: 1,
+          point: [1, 1],
+          distance: 0,
+        },
+      } as any
+    );
+
+    expect(findNearestMod.findNearestPoint).not.toHaveBeenCalled();
+    expect(renderers.highlightRenderer.prepare).toHaveBeenCalledTimes(1);
+    expect(renderers.highlightRenderer.setVisible).toHaveBeenCalledWith(true);
+  });
+
+  it('skips findNearestPoint when nearestMatch is explicit null and hides highlight', () => {
+    const renderers = makeMockRenderers();
+    const xScale = createLinearScale().domain(0, 10).range(0, 100);
+    const yScale = createLinearScale().domain(0, 10).range(100, 0);
+    const yScales = new Map([['y', yScale]]);
+
+    prepareOverlays(
+      renderers as any,
+      {
+        currentOptions: makeOptions(),
+        xScale,
+        yScales,
+        gridArea: makeGridArea(),
+        xTickCount: 5,
+        hasCartesianSeries: true,
+        effectivePointer: {
+          hasPointer: true,
+          isInGrid: true,
+          source: 'mouse',
+          x: 50,
+          y: 50,
+          gridX: 50,
+          gridY: 50,
+        },
+        interactionScales: { xScale, yScales },
+        seriesForRender: makeOptions().series,
+        withAlpha: (c: string) => c,
+        nearestMatch: null,
+      } as any
+    );
+
+    expect(findNearestMod.findNearestPoint).not.toHaveBeenCalled();
+    expect(renderers.highlightRenderer.prepare).not.toHaveBeenCalled();
+    expect(renderers.highlightRenderer.setVisible).toHaveBeenCalledWith(false);
+  });
+
+  it('falls back to findNearestPoint when nearestMatch is omitted', () => {
+    const renderers = makeMockRenderers();
+    const xScale = createLinearScale().domain(0, 10).range(0, 100);
+    const yScale = createLinearScale().domain(0, 10).range(100, 0);
+    const yScales = new Map([['y', yScale]]);
+    vi.mocked(findNearestMod.findNearestPoint).mockReturnValue({
+      seriesIndex: 0,
+      dataIndex: 0,
+      point: [0, 0],
+      distance: 1,
+    });
+
+    prepareOverlays(
+      renderers as any,
+      {
+        currentOptions: makeOptions(),
+        xScale,
+        yScales,
+        gridArea: makeGridArea(),
+        xTickCount: 5,
+        hasCartesianSeries: true,
+        effectivePointer: {
+          hasPointer: true,
+          isInGrid: true,
+          source: 'mouse',
+          x: 50,
+          y: 50,
+          gridX: 50,
+          gridY: 50,
+        },
+        interactionScales: { xScale, yScales },
+        seriesForRender: makeOptions().series,
+        withAlpha: (c: string) => c,
+        // nearestMatch omitted
+      } as any
+    );
+
+    expect(findNearestMod.findNearestPoint).toHaveBeenCalledTimes(1);
+    expect(renderers.highlightRenderer.prepare).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/data/cartesianData.ts
+++ b/src/data/cartesianData.ts
@@ -53,6 +53,18 @@ export type RingXYColumns = {
   start: number;
   count: number;
   capacity: number;
+  /**
+   * Bumped on every mutating write ({@link appendIntoRingXY}).
+   * Generation-aware mono / identity caches must include this so strict full
+   * replace (start/count/capacity unchanged) cannot leave stale mono=true.
+   */
+  contentEpoch: number;
+  /**
+   * Bumped only on full-clear (drop ≥ count) before rewrite. Mono FIFO
+   * incremental must full-scan when this changes; partial multi-append epoch
+   * jumps alone are still O(dropped) verifiable.
+   */
+  rewriteGen: number;
 };
 
 /**
@@ -87,6 +99,11 @@ export type StagingRingView = {
   capacity: number;
   /** Added back in {@link getX} so domain / binary search use original x. */
   xOffset: number;
+  /**
+   * Bumped on every {@link createStagingRingView} (reuse or new). Staging floats
+   * may be rewritten in place under stable start/count — mono caches must key this.
+   */
+  contentEpoch: number;
 };
 
 /**
@@ -116,6 +133,9 @@ export function isStagingRingView(data: unknown): data is StagingRingView {
 /**
  * Creates or updates a staging-backed ring view (mutates `reuse` when provided
  * to avoid per-append object allocation on the high-rate FIFO path).
+ *
+ * Always bumps {@link StagingRingView.contentEpoch} so generation-aware mono
+ * caches re-evaluate after in-place float rewrites under stable layout fields.
  */
 export function createStagingRingView(
   staging: Float32Array,
@@ -131,6 +151,7 @@ export function createStagingRingView(
     reuse.capacity = capacity;
     reuse.count = count;
     reuse.xOffset = xOffset;
+    reuse.contentEpoch = (reuse.contentEpoch | 0) + 1;
     return reuse;
   }
   return {
@@ -140,6 +161,7 @@ export function createStagingRingView(
     capacity,
     count,
     xOffset,
+    contentEpoch: 1,
   };
 }
 
@@ -160,6 +182,10 @@ export function stagingRingViewToRingXYColumns(view: StagingRingView): RingXYCol
   }
   ring.start = 0;
   ring.count = view.count;
+  // Content was written outside appendIntoRingXY — bump so mono cache keys this pack.
+  if (view.count > 0) {
+    ring.contentEpoch = (ring.contentEpoch | 0) + 1;
+  }
   return ring;
 }
 
@@ -201,6 +227,8 @@ export function createRingXYColumns(capacity: number, withSize = false): RingXYC
     start: 0,
     count: 0,
     capacity: cap,
+    contentEpoch: 0,
+    rewriteGen: 0,
   };
   if (withSize) {
     ring.size = new Float64Array(cap);
@@ -238,10 +266,19 @@ export function appendIntoRingXY(
   dropPrevCount: number
 ): void {
   const cap = ring.capacity;
+  // Any structural or content mutation bumps epoch so mono caches cannot stick
+  // after strict full-buffer rewrite (start/count/capacity may be unchanged).
+  if (dropPrevCount > 0 || keepNewCount > 0) {
+    ring.contentEpoch = (ring.contentEpoch | 0) + 1;
+  }
   if (dropPrevCount > 0) {
     if (dropPrevCount >= ring.count) {
       ring.start = 0;
       ring.count = 0;
+      // Full clear: entire buffer content is discarded. rewriteGen forces mono
+      // full-scan (partial FIFO multi-append can advance contentEpoch by >1
+      // without rewriting the retained prefix).
+      ring.rewriteGen = (ring.rewriteGen | 0) + 1;
     } else {
       ring.start = (ring.start + dropPrevCount) % cap;
       ring.count -= dropPrevCount;

--- a/src/interaction/__tests__/findNearestPoint.test.ts
+++ b/src/interaction/__tests__/findNearestPoint.test.ts
@@ -10,6 +10,127 @@ import type { ResolvedSeriesConfig } from '../../config/OptionResolver';
 import type { DataPoint, CartesianSeriesData } from '../../config/types';
 
 describe('findNearestPoint', () => {
+  describe('multi-M dense line (hover must not O(n) freeze)', () => {
+    it('hits near cursor on 200k mono line without scanning the whole series', () => {
+      const n = 200_000;
+      const xs = new Float64Array(n);
+      const ys = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        xs[i] = i;
+        ys[i] = Math.sin(i * 0.01);
+      }
+      const data = { x: xs, y: ys };
+      const series: ResolvedSeriesConfig[] = [
+        {
+          type: 'line',
+          data,
+          color: '#f00',
+          visible: true,
+          connectNulls: false,
+          sampling: 'none',
+          samplingThreshold: 5000,
+          yAxis: 'y',
+          rawData: data,
+          lineStyle: { width: 1, opacity: 1, color: '#f00' },
+        } as any,
+      ];
+      const xScale = createLinearScale()
+        .domain(0, n - 1)
+        .range(0, 1000);
+      const yScale = createLinearScale().domain(-2, 2).range(400, 0);
+      // Cursor over mid series
+      const target = Math.floor(n / 2);
+      const t0 = performance.now();
+      for (let k = 0; k < 50; k++) {
+        const hit = findNearestPoint(series, xScale.scale(target), yScale.scale(ys[target]!), xScale, yScale, 20);
+        expect(hit).not.toBeNull();
+        expect(Math.abs(hit!.dataIndex - target)).toBeLessThan(5);
+      }
+      // 50 nearest queries on 200k must stay well under a full linear pass budget
+      expect(performance.now() - t0).toBeLessThan(100);
+    });
+
+    it('returns null quickly when cursor is far from the series (no full scan)', () => {
+      const n = 100_000;
+      const data = {
+        x: Float64Array.from({ length: n }, (_, i) => i),
+        y: Float64Array.from({ length: n }, () => 0),
+      };
+      const series: ResolvedSeriesConfig[] = [
+        {
+          type: 'line',
+          data,
+          color: '#f00',
+          visible: true,
+          connectNulls: false,
+          sampling: 'none',
+          samplingThreshold: 5000,
+          yAxis: 'y',
+          rawData: data,
+          lineStyle: { width: 1, opacity: 1, color: '#f00' },
+        } as any,
+      ];
+      const xScale = createLinearScale()
+        .domain(0, n - 1)
+        .range(0, 1000);
+      const yScale = createLinearScale().domain(-1, 1).range(400, 0);
+      // Cursor 200 CSS px above the line (maxDistance 20) — must not scan 100k
+      const t0 = performance.now();
+      const miss = findNearestPoint(series, 500, yScale.scale(0) - 200, xScale, yScale, 20);
+      expect(miss).toBeNull();
+      expect(performance.now() - t0).toBeLessThan(30);
+    });
+
+    it('dense multi-M full-span: hover miss stays sub-linear (points-per-pixel × maxDist window)', () => {
+      // Device-window scale: millions of points across ~1000 CSS px → ~20px hit
+      // radius covers O(100k+) indices. Without stride expand this freezes streaming.
+      const n = 2_000_000;
+      const xs = new Float64Array(n);
+      const ys = new Float64Array(n);
+      for (let i = 0; i < n; i++) {
+        xs[i] = i;
+        ys[i] = Math.sin(i * 0.001);
+      }
+      const data = { x: xs, y: ys };
+      const series: ResolvedSeriesConfig[] = [
+        {
+          type: 'line',
+          data,
+          color: '#0f0',
+          visible: true,
+          connectNulls: false,
+          sampling: 'none',
+          samplingThreshold: 5000,
+          yAxis: 'y',
+          rawData: data,
+          lineStyle: { width: 1, opacity: 1, color: '#0f0' },
+        } as any,
+      ];
+      const xScale = createLinearScale()
+        .domain(0, n - 1)
+        .range(0, 1000);
+      const yScale = createLinearScale().domain(-2, 2).range(400, 0);
+      const target = Math.floor(n / 2);
+
+      // Hit: cursor on the series mid-point
+      const tHit = performance.now();
+      for (let k = 0; k < 20; k++) {
+        const hit = findNearestPoint(series, xScale.scale(target), yScale.scale(ys[target]!), xScale, yScale, 20);
+        expect(hit).not.toBeNull();
+        expect(Math.abs(hit!.dataIndex - target)).toBeLessThan(200);
+      }
+      expect(performance.now() - tHit).toBeLessThan(80);
+
+      // Miss: far above the series — must not walk the full maxDistance x-window
+      const tMiss = performance.now();
+      for (let k = 0; k < 20; k++) {
+        const miss = findNearestPoint(series, xScale.scale(target), yScale.scale(0) - 200, xScale, yScale, 20);
+        expect(miss).toBeNull();
+      }
+      expect(performance.now() - tMiss).toBeLessThan(80);
+    });
+  });
+
   describe('step series uses source samples (not densified corners)', () => {
     it('reports source y values only — never densified stair corners as dataIndex', () => {
       // Source samples (0,1) and (2,3); after-step densified corner is (2,1) — not a sample.

--- a/src/interaction/__tests__/hoverHitTestGate.test.ts
+++ b/src/interaction/__tests__/hoverHitTestGate.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Unit tests for shared hover hit-test dirty gate (highlight + tooltip).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  commitHoverHitTest,
+  createHoverHitTestGateState,
+  DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS,
+  DEFAULT_HOVER_HIT_TEST_THROTTLE_MS,
+  invalidateHoverHitTest,
+  resolveHoverHitTestFrame,
+  shouldAllowSyncTooltipHitTest,
+  shouldRecomputeHoverHitTest,
+} from '../hoverHitTestGate';
+
+describe('hoverHitTestGate', () => {
+  const opts = DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS;
+
+  it('requires recompute when cache is empty', () => {
+    const state = createHoverHitTestGateState();
+    expect(shouldRecomputeHoverHitTest(state, 1000, 10, 20, opts)).toBe(true);
+  });
+
+  it('suppresses recompute within throttle when pointer is stationary', () => {
+    const state = createHoverHitTestGateState();
+    const match = { seriesIndex: 0, dataIndex: 1, point: [1, 2], distance: 0 };
+    commitHoverHitTest(state, 1000, 10, 20, match);
+
+    expect(shouldRecomputeHoverHitTest(state, 1000 + 5, 10, 20, opts)).toBe(false);
+    expect(shouldRecomputeHoverHitTest(state, 1000 + DEFAULT_HOVER_HIT_TEST_THROTTLE_MS - 1, 10, 20, opts)).toBe(false);
+    expect(state.cachedMatch).toBe(match);
+  });
+
+  it('recomputes after throttle window elapses (stationary pointer)', () => {
+    const state = createHoverHitTestGateState();
+    commitHoverHitTest(state, 1000, 10, 20, { id: 'a' });
+    expect(shouldRecomputeHoverHitTest(state, 1000 + DEFAULT_HOVER_HIT_TEST_THROTTLE_MS, 10, 20, opts)).toBe(true);
+  });
+
+  it('rate-limits even when pointer moves (does not bypass throttle)', () => {
+    const state = createHoverHitTestGateState();
+    commitHoverHitTest(state, 1000, 10, 20, { id: 'a' });
+    // Large move inside throttle window — must still suppress so multi-M findNearest
+    // cannot run every mousemove and jam the main thread until the pointer stops.
+    expect(shouldRecomputeHoverHitTest(state, 1000 + 5, 500, 400, opts)).toBe(false);
+  });
+
+  it('after throttle elapses, recompute is allowed at the new pointer position', () => {
+    const state = createHoverHitTestGateState();
+    commitHoverHitTest(state, 1000, 10, 20, { id: 'a' });
+    expect(shouldRecomputeHoverHitTest(state, 1000 + DEFAULT_HOVER_HIT_TEST_THROTTLE_MS, 500, 400, opts)).toBe(true);
+  });
+
+  it('invalidate forces next recompute; null match is a valid cache', () => {
+    const state = createHoverHitTestGateState();
+    commitHoverHitTest(state, 1000, 10, 20, null);
+    expect(state.cachedMatch).toBeNull();
+    expect(shouldRecomputeHoverHitTest(state, 1000 + 5, 10, 20, opts)).toBe(false);
+
+    invalidateHoverHitTest(state);
+    expect(state.cachedMatch).toBeUndefined();
+    expect(shouldRecomputeHoverHitTest(state, 1000 + 5, 10, 20, opts)).toBe(true);
+  });
+
+  it('shared consumers reuse one committed match (highlight + tooltip contract)', () => {
+    const state = createHoverHitTestGateState();
+    const match = { seriesIndex: 0, dataIndex: 3, point: [3, 4], distance: 1 };
+    expect(shouldRecomputeHoverHitTest(state, 0, 5, 5, opts)).toBe(true);
+    commitHoverHitTest(state, 0, 5, 5, match);
+    expect(shouldRecomputeHoverHitTest(state, 5, 5, 5, opts)).toBe(false);
+    expect(state.cachedMatch).toBe(match);
+    expect(state.cachedMatch).toBe(match);
+  });
+});
+
+describe('resolveHoverHitTestFrame (coordinator gate integration)', () => {
+  it('calls findNearest once on first frame and reuses on suppress', () => {
+    const state = createHoverHitTestGateState();
+    const findNearest = vi.fn(() => ({ seriesIndex: 0, dataIndex: 2, point: [2, 3], distance: 0 }));
+
+    const f1 = resolveHoverHitTestFrame({
+      state,
+      nowMs: 0,
+      gridX: 10,
+      gridY: 20,
+      findNearest,
+    });
+    expect(f1.recomputed).toBe(true);
+    expect(f1.match).toEqual({ seriesIndex: 0, dataIndex: 2, point: [2, 3], distance: 0 });
+    expect(f1.scheduleFollowupMs).toBeNull();
+    expect(findNearest).toHaveBeenCalledTimes(1);
+
+    const f2 = resolveHoverHitTestFrame({
+      state,
+      nowMs: 5,
+      gridX: 10,
+      gridY: 20,
+      findNearest,
+    });
+    expect(f2.recomputed).toBe(false);
+    expect(f2.match).toBe(f1.match);
+    expect(f2.scheduleFollowupMs).not.toBeNull();
+    expect(findNearest).toHaveBeenCalledTimes(1);
+
+    const f3 = resolveHoverHitTestFrame({
+      state,
+      nowMs: DEFAULT_HOVER_HIT_TEST_THROTTLE_MS,
+      gridX: 10,
+      gridY: 20,
+      findNearest,
+    });
+    expect(f3.recomputed).toBe(true);
+    expect(findNearest).toHaveBeenCalledTimes(2);
+  });
+
+  it('motion samples use latest pointer after throttle (tracks cursor, not settle-only)', () => {
+    const state = createHoverHitTestGateState();
+    let call = 0;
+    const positions: Array<{ x: number; y: number }> = [];
+    const findNearest = vi.fn(() => {
+      call += 1;
+      // Caller closes over current grid — simulate by reading last requested via mock impl below
+      return { seriesIndex: 0, dataIndex: call, point: [call, 0], distance: 0 };
+    });
+
+    // Frame 1 at (0,0)
+    const f1 = resolveHoverHitTestFrame({
+      state,
+      nowMs: 0,
+      gridX: 0,
+      gridY: 0,
+      findNearest: () => {
+        positions.push({ x: 0, y: 0 });
+        return findNearest();
+      },
+    });
+    expect(f1.recomputed).toBe(true);
+    expect(f1.match).toEqual({ seriesIndex: 0, dataIndex: 1, point: [1, 0], distance: 0 });
+
+    // Mid-window: pointer moved far — still suppressed (rate limit)
+    const f2 = resolveHoverHitTestFrame({
+      state,
+      nowMs: 8,
+      gridX: 200,
+      gridY: 100,
+      findNearest: () => {
+        positions.push({ x: 200, y: 100 });
+        return findNearest();
+      },
+    });
+    expect(f2.recomputed).toBe(false);
+    expect(f2.match).toBe(f1.match); // stale ring for ≤ throttleMs
+    expect(f2.scheduleFollowupMs).toBeGreaterThan(0);
+    expect(findNearest).toHaveBeenCalledTimes(1);
+
+    // After throttle: must sample at the *new* cursor, not wait for settle
+    const f3 = resolveHoverHitTestFrame({
+      state,
+      nowMs: DEFAULT_HOVER_HIT_TEST_THROTTLE_MS,
+      gridX: 200,
+      gridY: 100,
+      findNearest: () => {
+        positions.push({ x: 200, y: 100 });
+        return findNearest();
+      },
+    });
+    expect(f3.recomputed).toBe(true);
+    expect(f3.match).toEqual({ seriesIndex: 0, dataIndex: 2, point: [2, 0], distance: 0 });
+    expect(positions[positions.length - 1]).toEqual({ x: 200, y: 100 });
+    expect(findNearest).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate then frame forces findNearest again', () => {
+    const state = createHoverHitTestGateState();
+    const findNearest = vi.fn(() => null);
+    resolveHoverHitTestFrame({ state, nowMs: 0, gridX: 1, gridY: 1, findNearest });
+    expect(findNearest).toHaveBeenCalledTimes(1);
+    invalidateHoverHitTest(state);
+    resolveHoverHitTestFrame({ state, nowMs: 5, gridX: 1, gridY: 1, findNearest });
+    expect(findNearest).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('shouldAllowSyncTooltipHitTest', () => {
+  it('allows first call and throttles subsequent within window', () => {
+    const a = shouldAllowSyncTooltipHitTest(Number.NEGATIVE_INFINITY, 1000, 33);
+    expect(a.allowed).toBe(true);
+    expect(a.nextLastSyncMs).toBe(1000);
+    expect(a.scheduleFollowupMs).toBeNull();
+
+    const b = shouldAllowSyncTooltipHitTest(a.nextLastSyncMs, 1010, 33);
+    expect(b.allowed).toBe(false);
+    expect(b.nextLastSyncMs).toBe(1000);
+    expect(b.scheduleFollowupMs).toBe(23);
+
+    const c = shouldAllowSyncTooltipHitTest(a.nextLastSyncMs, 1033, 33);
+    expect(c.allowed).toBe(true);
+    expect(c.nextLastSyncMs).toBe(1033);
+  });
+
+  it('does not share state with mouse gate (independent lastMs)', () => {
+    const mouse = createHoverHitTestGateState();
+    commitHoverHitTest(mouse, 5000, 0, 0, { id: 'mouse' });
+    const sync = shouldAllowSyncTooltipHitTest(Number.NEGATIVE_INFINITY, 5001, 33);
+    expect(sync.allowed).toBe(true);
+    expect(shouldRecomputeHoverHitTest(mouse, 5001, 0, 0, DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS)).toBe(false);
+  });
+});

--- a/src/interaction/findNearestPoint.ts
+++ b/src/interaction/findNearestPoint.ts
@@ -26,6 +26,20 @@ const DEFAULT_MAX_DISTANCE_PX = 20;
 const DEFAULT_BAR_GAP = 0.01; // Minimal gap between bars within a group (was 0.1)
 const DEFAULT_BAR_CATEGORY_GAP = 0.2;
 const DEFAULT_SCATTER_RADIUS_CSS_PX = 4;
+/**
+ * Above this count, never full-linear-scan for nearest (would freeze multi‑M hover
+ * and block streaming). Use lowerBound + x-window expand instead (best-effort if
+ * non-monotonic).
+ */
+const LARGE_N_NO_FULL_LINEAR = 8_192;
+/**
+ * Max samples inside the maxDistance x-window before we stride.
+ * Full-span multi‑M (e.g. 16M pts on ~1000 CSS px) puts **hundreds of thousands**
+ * of points under a 20px hit radius. Walking them every hover frame freezes
+ * setInterval streaming even when mono/binary-search is correct. Stride the
+ * window then refine around the best / x-nearest index.
+ */
+const DENSE_EXPAND_MAX_SAMPLES = 4_096;
 
 /**
  * Binary search: finds the lower bound index (first element >= target) in monotonic cartesian data.
@@ -776,147 +790,120 @@ export function findNearestPoint(
     const isScatter = seriesCfg.type === 'scatter';
     const scatterCfg = isScatter ? (seriesCfg as ResolvedScatterSeriesConfig) : null;
 
-    // Check if data is monotonic for O(log n) fast path
-    const canBinarySearch = isMonotonicNonDecreasingFiniteX(data);
+    // Multi‑M (incl. device auto-window ~16M at 128 MiB): never call mono —
+    // even a "soft" mono scan or cache miss under hover freezes setInterval
+    // streaming. Windowed lowerBound+expand is correct for mono line streams
+    // and best-effort for unsorted. Small series still use exact mono check.
+    const useWindowedSearch = n >= LARGE_N_NO_FULL_LINEAR || isMonotonicNonDecreasingFiniteX(data);
 
-    if (canBinarySearch) {
-      // Fast path: binary search + expand outward
-      // Find the index where data[i].x >= xTarget (lower bound)
+    const considerCartesianIndex = (i: number): boolean => {
+      // Returns true when expand should stop (x beyond hit radius).
+      const px = getX(data, i);
+      const py = getY(data, i);
+      if (!Number.isFinite(px) || !Number.isFinite(py)) return false;
+
+      const sx = xScale.scale(px);
+      const sy = yScale.scale(py);
+      if (!Number.isFinite(sx) || !Number.isFinite(sy)) return false;
+
+      const dx = sx - x;
+      const dy = sy - y;
+      const dxSq = dx * dx;
+      // Hard stop: no point with |dx| > maxDistance can be a valid hit
+      // (scatter radius added below for allowedSq only). Critical when
+      // bestDistSq is still +∞ (all prior y non-finite) — without this,
+      // mono expand scans the entire multi‑M series and freezes streaming.
+      let allowedSq = maxDistSq;
+      if (scatterCfg) {
+        const size = getSize(data, i);
+        const p: DataPoint = size !== undefined ? [px, py, size] : [px, py];
+        const r = getScatterRadiusCssPx(scatterCfg, p);
+        const allowed = md + r;
+        allowedSq = allowed * allowed;
+      }
+      if (dxSq > allowedSq) return true;
+
+      const distSq = dxSq + dy * dy;
+      // Also stop when x alone exceeds the current best Euclidean distance.
+      if (dxSq > bestDistSq) return true;
+
+      if (distSq > allowedSq) return false;
+
+      const isBetter =
+        distSq < bestDistSq ||
+        (distSq === bestDistSq &&
+          (bestPoint === null ||
+            originalSeriesIndex < bestSeriesIndex ||
+            (originalSeriesIndex === bestSeriesIndex && i < bestDataIndex)));
+
+      if (isBetter) {
+        bestDistSq = distSq;
+        bestSeriesIndex = originalSeriesIndex;
+        bestDataIndex = i;
+        const size = getSize(data, i);
+        bestPoint = size !== undefined ? [px, py, size] : [px, py];
+      }
+      return false;
+    };
+
+    if (useWindowedSearch) {
+      // Binary search, then only visit points whose range-x is within maxDistance.
+      // Dense multi‑M: that window can still be O(100k+) indices — stride + refine.
       const startIdx = lowerBoundX(data, xTarget);
 
-      // Expand outward from startIdx while points could still be closer
-      // Check right side first (startIdx onwards)
-      for (let i = startIdx; i < n; i++) {
-        const px = getX(data, i);
-        const py = getY(data, i);
-        if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
-
-        const sx = xScale.scale(px);
-        const sy = yScale.scale(py);
-        if (!Number.isFinite(sx) || !Number.isFinite(sy)) continue;
-
-        const dx = sx - x;
-        const dy = sy - y;
-        const distSq = dx * dx + dy * dy;
-
-        // Early exit: if x-distance alone exceeds current best, no point can be closer (monotonic x)
-        const dxSq = dx * dx;
-        if (dxSq > bestDistSq) break;
-
-        // Check scatter radius if applicable
-        let allowedSq = maxDistSq;
-        if (scatterCfg) {
-          const size = getSize(data, i);
-          const p: DataPoint = size !== undefined ? [px, py, size] : [px, py];
-          const r = getScatterRadiusCssPx(scatterCfg, p);
-          const allowed = md + r;
-          allowedSq = allowed * allowed;
-        }
-
-        if (distSq > allowedSq) continue;
-
-        const isBetter =
-          distSq < bestDistSq ||
-          (distSq === bestDistSq &&
-            (bestPoint === null ||
-              originalSeriesIndex < bestSeriesIndex ||
-              (originalSeriesIndex === bestSeriesIndex && i < bestDataIndex)));
-
-        if (isBetter) {
-          bestDistSq = distSq;
-          bestSeriesIndex = originalSeriesIndex;
-          bestDataIndex = i;
-          const size = getSize(data, i);
-          bestPoint = size !== undefined ? [px, py, size] : [px, py];
+      // Scatter hit radius extends past `md`; pad the domain window a little so
+      // large markers near the edge of the cursor radius are not skipped.
+      const padPx = scatterCfg ? md + DEFAULT_SCATTER_RADIUS_CSS_PX * 4 : md;
+      const xLo = xScale.invert(x - padPx);
+      const xHi = xScale.invert(x + padPx);
+      let iLeft = 0;
+      let iRight = n;
+      if (Number.isFinite(xLo) && Number.isFinite(xHi)) {
+        const domainLeft = Math.min(xLo, xHi);
+        const domainRight = Math.max(xLo, xHi);
+        iLeft = lowerBoundX(data, domainLeft);
+        // Exclusive end: first index with domain x > domainRight (mono).
+        iRight = lowerBoundX(data, domainRight);
+        while (iRight < n && getX(data, iRight) <= domainRight) {
+          iRight++;
         }
       }
+      // Always include the x-nearest neighbourhood even if invert failed.
+      iLeft = Math.max(0, Math.min(iLeft, startIdx > 0 ? startIdx - 1 : 0));
+      iRight = Math.min(n, Math.max(iRight, Math.min(n, startIdx + 1)));
 
-      // Check left side (before startIdx)
-      for (let i = startIdx - 1; i >= 0; i--) {
-        const px = getX(data, i);
-        const py = getY(data, i);
-        if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
-
-        const sx = xScale.scale(px);
-        const sy = yScale.scale(py);
-        if (!Number.isFinite(sx) || !Number.isFinite(sy)) continue;
-
-        const dx = sx - x;
-        const dy = sy - y;
-        const distSq = dx * dx + dy * dy;
-
-        // Early exit: if x-distance alone exceeds current best, no point can be closer
-        const dxSq = dx * dx;
-        if (dxSq > bestDistSq) break;
-
-        // Check scatter radius if applicable
-        let allowedSq = maxDistSq;
-        if (scatterCfg) {
-          const size = getSize(data, i);
-          const p: DataPoint = size !== undefined ? [px, py, size] : [px, py];
-          const r = getScatterRadiusCssPx(scatterCfg, p);
-          const allowed = md + r;
-          allowedSq = allowed * allowed;
+      const span = iRight - iLeft;
+      if (span <= 0) {
+        // fall through — nothing in window
+      } else if (span <= DENSE_EXPAND_MAX_SAMPLES) {
+        for (let i = startIdx; i < iRight; i++) {
+          if (considerCartesianIndex(i)) break;
         }
+        for (let i = startIdx - 1; i >= iLeft; i--) {
+          if (considerCartesianIndex(i)) break;
+        }
+      } else {
+        // Dense window: stride so hover stays O(DENSE_EXPAND_MAX_SAMPLES), then
+        // refine ±stride around the best hit (or x-nearest if no hit yet).
+        const stride = Math.max(1, Math.ceil(span / DENSE_EXPAND_MAX_SAMPLES));
+        for (let i = iLeft; i < iRight; i += stride) {
+          considerCartesianIndex(i);
+        }
+        // Ensure the two x-nearest samples are always evaluated (exact for flat y).
+        if (startIdx < n) considerCartesianIndex(startIdx);
+        if (startIdx > 0) considerCartesianIndex(startIdx - 1);
 
-        if (distSq > allowedSq) continue;
-
-        const isBetter =
-          distSq < bestDistSq ||
-          (distSq === bestDistSq &&
-            (bestPoint === null ||
-              originalSeriesIndex < bestSeriesIndex ||
-              (originalSeriesIndex === bestSeriesIndex && i < bestDataIndex)));
-
-        if (isBetter) {
-          bestDistSq = distSq;
-          bestSeriesIndex = originalSeriesIndex;
-          bestDataIndex = i;
-          const size = getSize(data, i);
-          bestPoint = size !== undefined ? [px, py, size] : [px, py];
+        const refineCenter = bestSeriesIndex === originalSeriesIndex && bestDataIndex >= 0 ? bestDataIndex : startIdx;
+        const refineLo = Math.max(iLeft, refineCenter - stride);
+        const refineHi = Math.min(iRight, refineCenter + stride + 1);
+        for (let i = refineLo; i < refineHi; i++) {
+          considerCartesianIndex(i);
         }
       }
     } else {
-      // Fallback: linear scan for non-monotonic data
+      // Small non-monotonic series: full linear scan.
       for (let i = 0; i < n; i++) {
-        const px = getX(data, i);
-        const py = getY(data, i);
-        if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
-
-        const sx = xScale.scale(px);
-        const sy = yScale.scale(py);
-        if (!Number.isFinite(sx) || !Number.isFinite(sy)) continue;
-
-        const dx = sx - x;
-        const dy = sy - y;
-        const distSq = dx * dx + dy * dy;
-
-        // Check scatter radius if applicable
-        let allowedSq = maxDistSq;
-        if (scatterCfg) {
-          const size = getSize(data, i);
-          const p: DataPoint = size !== undefined ? [px, py, size] : [px, py];
-          const r = getScatterRadiusCssPx(scatterCfg, p);
-          const allowed = md + r;
-          allowedSq = allowed * allowed;
-        }
-
-        if (distSq > allowedSq) continue;
-
-        const isBetter =
-          distSq < bestDistSq ||
-          (distSq === bestDistSq &&
-            (bestPoint === null ||
-              originalSeriesIndex < bestSeriesIndex ||
-              (originalSeriesIndex === bestSeriesIndex && i < bestDataIndex)));
-
-        if (isBetter) {
-          bestDistSq = distSq;
-          bestSeriesIndex = originalSeriesIndex;
-          bestDataIndex = i;
-          const size = getSize(data, i);
-          bestPoint = size !== undefined ? [px, py, size] : [px, py];
-        }
+        considerCartesianIndex(i);
       }
     }
   }

--- a/src/interaction/hoverHitTestGate.ts
+++ b/src/interaction/hoverHitTestGate.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared hover hit-test dirty gate for highlight + tooltip.
+ *
+ * Recompute when:
+ * - no cached match yet
+ * - throttle window elapsed (~60 Hz default)
+ *
+ * **Always rate-limited** — pointer move does **not** bypass the throttle.
+ * Bypassing caused multi‑M `findNearestPoint` every mousemove/frame and jammed
+ * the main thread so the highlight only painted when the pointer “resettled”.
+ * While rate-limited, consumers reuse the last match; the next allowed sample
+ * always uses the **latest** pointer position (caller passes current gridX/Y).
+ * Crosshair still tracks the pointer every frame (not gated here).
+ *
+ * @module hoverHitTestGate
+ * @internal
+ */
+
+export type HoverHitTestGateState = {
+  lastMs: number;
+  lastGridX: number;
+  lastGridY: number;
+  /**
+   * `undefined` = never computed / invalidated (must recompute).
+   * `null` = last compute found no match.
+   */
+  cachedMatch: unknown;
+};
+
+export type HoverHitTestGateOptions = Readonly<{
+  /**
+   * Minimum time between recomputes (ms), whether the pointer is moving or
+   * stationary. Caps findNearest rate so multi‑M hover stays interactive.
+   */
+  throttleMs: number;
+  /**
+   * @deprecated No longer used for recompute decisions (rate limit is time-only).
+   * Kept optional for call-site compatibility; ignored when deciding recompute.
+   */
+  moveEpsPx?: number;
+}>;
+
+/**
+ * Default ~60 Hz sample rate: snappy highlight tracking while moving, without
+ * unbounded per-mousemove findNearest on multi‑M series.
+ */
+export const DEFAULT_HOVER_HIT_TEST_THROTTLE_MS = 16;
+/**
+ * Legacy default; ignored by shouldRecompute (time-only rate limit).
+ * Retained so existing tests / call sites importing the constant keep compiling.
+ */
+export const DEFAULT_HOVER_HIT_TEST_MOVE_EPS_PX = 0.75;
+
+/** Hoisted default options (avoid per-frame object allocation). */
+export const DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS: HoverHitTestGateOptions = {
+  throttleMs: DEFAULT_HOVER_HIT_TEST_THROTTLE_MS,
+  moveEpsPx: DEFAULT_HOVER_HIT_TEST_MOVE_EPS_PX,
+};
+
+export function createHoverHitTestGateState(): HoverHitTestGateState {
+  return {
+    lastMs: Number.NEGATIVE_INFINITY,
+    lastGridX: Number.NaN,
+    lastGridY: Number.NaN,
+    cachedMatch: undefined,
+  };
+}
+
+/**
+ * Returns true when findNearestPoint (or equivalent) should run this frame.
+ *
+ * Time-only rate limit: after a successful commit, further calls within
+ * `throttleMs` are suppressed even if the pointer moved. The next allowed
+ * frame must pass the **current** gridX/Y into findNearest so the ring
+ * tracks the cursor (does not wait for the pointer to stop).
+ */
+export function shouldRecomputeHoverHitTest(
+  state: HoverHitTestGateState,
+  nowMs: number,
+  _gridX: number,
+  _gridY: number,
+  options: HoverHitTestGateOptions = DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS
+): boolean {
+  if (state.cachedMatch === undefined) return true;
+  if (!Number.isFinite(state.lastGridX) || !Number.isFinite(state.lastGridY)) return true;
+
+  const throttleMs = options.throttleMs;
+  if (nowMs - state.lastMs < throttleMs) return false;
+  return true;
+}
+
+/**
+ * Record a successful recompute (or explicit null miss) into gate state.
+ */
+export function commitHoverHitTest(
+  state: HoverHitTestGateState,
+  nowMs: number,
+  gridX: number,
+  gridY: number,
+  match: unknown
+): void {
+  state.lastMs = nowMs;
+  state.lastGridX = gridX;
+  state.lastGridY = gridY;
+  state.cachedMatch = match;
+}
+
+/**
+ * Invalidate cache (pointer left grid / series context destroyed / setOptions data change).
+ */
+export function invalidateHoverHitTest(state: HoverHitTestGateState): void {
+  state.cachedMatch = undefined;
+  state.lastGridX = Number.NaN;
+  state.lastGridY = Number.NaN;
+  // Keep lastMs so a brief leave/re-enter still respects throttle if desired;
+  // full invalidate forces recompute via cachedMatch === undefined.
+}
+
+export type ResolveHoverHitTestFrameResult<T> = {
+  /** Match for this frame (fresh or reused). */
+  match: T | null;
+  /** True when findNearest ran this frame. */
+  recomputed: boolean;
+  /**
+   * When non-null, caller should schedule a follow-up render after this many ms
+   * so motion samples are not deferred until the pointer stops.
+   * When null and recomputed, caller should cancel any pending follow-up.
+   */
+  scheduleFollowupMs: number | null;
+};
+
+/**
+ * Pure one-frame hover hit-test resolution (mouse path).
+ * Injectable `findNearest` enables hard call-count unit tests without a full coordinator.
+ *
+ * `findNearest` must close over the **current** pointer (caller's gridX/Y) so
+ * each allowed sample tracks the cursor, not a stale position.
+ */
+export function resolveHoverHitTestFrame<T>(input: {
+  readonly state: HoverHitTestGateState;
+  readonly nowMs: number;
+  readonly gridX: number;
+  readonly gridY: number;
+  readonly options?: HoverHitTestGateOptions;
+  readonly findNearest: () => T | null;
+}): ResolveHoverHitTestFrameResult<T> {
+  const options = input.options ?? DEFAULT_HOVER_HIT_TEST_GATE_OPTIONS;
+  if (shouldRecomputeHoverHitTest(input.state, input.nowMs, input.gridX, input.gridY, options)) {
+    const match = input.findNearest();
+    commitHoverHitTest(input.state, input.nowMs, input.gridX, input.gridY, match);
+    return { match, recomputed: true, scheduleFollowupMs: null };
+  }
+  const match = (input.state.cachedMatch as T | null | undefined) ?? null;
+  const elapsed = input.nowMs - input.state.lastMs;
+  return {
+    match,
+    recomputed: false,
+    // Always schedule a follow-up while suppressed so continuous motion is
+    // sampled at the throttle rate even if no further mousemove arrives
+    // exactly on the boundary (e.g. pointer stopped mid-window).
+    scheduleFollowupMs: Math.max(0, options.throttleMs - elapsed),
+  };
+}
+
+/**
+ * Time-only throttle for sync tooltips (separate from mouse findNearest gate).
+ * Returns whether the tooltip secondary hit path should run this frame.
+ */
+export function shouldAllowSyncTooltipHitTest(
+  lastSyncMs: number,
+  nowMs: number,
+  throttleMs: number = DEFAULT_HOVER_HIT_TEST_THROTTLE_MS
+): { allowed: boolean; nextLastSyncMs: number; scheduleFollowupMs: number | null } {
+  const elapsed = nowMs - lastSyncMs;
+  if (Number.isFinite(lastSyncMs) && elapsed < throttleMs) {
+    return {
+      allowed: false,
+      nextLastSyncMs: lastSyncMs,
+      scheduleFollowupMs: Math.max(0, throttleMs - elapsed),
+    };
+  }
+  return { allowed: true, nextLastSyncMs: nowMs, scheduleFollowupMs: null };
+}


### PR DESCRIPTION
## Summary

- Shared hover hit-test gate (~60 Hz, time-only) for highlight + item tooltip so multi‑M `findNearestPoint` is not every-frame work; crosshair still tracks every frame; follow-up renders keep the ring moving with the pointer
- Mono-X caches fixed for streaming: growing XY tails, ring/staging `contentEpoch` + `rewriteGen`, FIFO multi-append O(dropped) verification, soft-capped first visit — no full multi‑M mono scan on hover
- Dense hit expand: when the maxDistance x-window still has ≫4k points (full-span multi‑M points-per-pixel), stride + local refine instead of walking hundreds of thousands of indices
- Tooltip dual-store device/maxPoints ring wrap uses O(1) endpoint bounds (match coordinator) instead of rescanning ~16M points every append

Fixes Ultimate Benchmark freezes where chart lines stood still under the pointer around ~15–18M total points (device auto-window band), with and without tooltip DOM.

## Test plan

- [x] `bun run test -- src/interaction/__tests__/findNearestPoint.test.ts src/interaction/__tests__/hoverHitTestGate.test.ts src/core/renderCoordinator/data/__tests__/computeVisibleSlice.test.ts`
- [x] Dual-store / device auto-window ChartGPU dataAppend tests (filtered)
- [ ] Production build: `bun run build:examples && bun run preview:examples`
- [ ] Ultimate Benchmark: stream line @ 10k pts/frame past ~18M **with pointer in plot** (`tooltip.show: true` and `false`) — lines keep scrolling; highlight tracks
- [ ] No-hover baseline still ~steady FPS; hover should stay interactive (no multi-second main-thread freeze)