### PR TITLE
chore: bump version to 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary
- Bump `@chartgpu/chartgpu` from **0.3.5** → **0.3.6** in `package.json`.
- Landing page version badge/footer continue to inject from package.json via `%APP_VERSION%` (no hardcoded string update needed).

Notable since 0.3.5 (high level):
- New series: step/digital, impulse, stacked mountain, error bars, OHLC bars, band, uniform heatmap (+ spectrogram stream), 3D point cloud/surface (+ GPU labels, polish)
- Perf: multi-M hover hit-test, mountain dense stride LOD, Brownian scatter parity
- Dev-site polish (smooth stacked bars, trade legend hide, examples catalog)

## Test plan
- [x] Confirm `package.json` version is `0.3.6`
- [x] `bun run build:pages` (or `dev:site`) shows `v0.3.6` in nav/footer
- [ ] Publish/release workflow (if used) tags npm as 0.3.6 after merge