### PR TITLE
chore: bump version to 0.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

Bumps `@chartgpu/chartgpu` from **0.3.6 → 0.3.7** so npm/site version matches main after recent merges.

No library code changes in this PR—version field only (same pattern as prior bumps).

### What this tag is meant to cover (already on `main`)

- **Present-fidelity GPU decimation** (#199): encode when the sampling identity changes; density period no longer used to skip LTTB on streaming FIFO (fixes the visible “period-flash” on large multi-series FIFO).
- **Multi‑M dense LTTB cost control** (#199, Phase B): when pts/bucket is very high, LTTB/min/max use denser candidate caps (128 / 64 coarse averages) and cold multi‑M content stamps avoid full FNV. This is an **honest speed tradeoff**—not a claim of full-scan LTTB at extreme density, and it does **not** reintroduce present lag.
- **Docs/hygiene**: README redesign and cleanup merges since 0.3.6.

### Honest caveats

- Suite G7 numbers are machine/session-sensitive; treat competitive comparisons as directional, not guarantees.
- Dense caps change LTTB candidate selection at extreme density (exact scan still used at moderate density, e.g. ~1M×2500 thresholds in the PR notes). Review #199 for the exact behavior.
- `CHANGELOG.md` still has a large `[Unreleased]` block spanning much of 0.3.x; this PR does **not** restructure the changelog—only the package version.

## Test plan

- [ ] Confirm `package.json` version is `0.3.7`
- [ ] After merge/publish: install/tag matches expected release process
- [ ] Dev-site injects version from `package.json` (no hardcode in this PR)