### PR TITLE
chore: bump version to 0.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary

- Bump `@chartgpu/chartgpu` from **0.3.7** → **0.3.8** for the next npm publish.
- Includes surface3d streaming performance work merged in #204 (height-only GPU upload, zero-copy `replaceY`, domain/AABB/contour hot-path skips).

## Test plan

- [ ] CI green on this PR
- [ ] Confirm package version on publish workflow after merge