### PR TITLE
fix(axis): candle right-rail gutter and stable 2D nice ticks

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -508,15 +508,18 @@ Example: [`examples/impulse/`](../../examples/impulse/). Step digital line: [`ex
 - **Finance-primary layout defaults** (when `series[0].type === 'candlestick'` or `'ohlc'`):
   - **Predicate**: only the first series type matters. Overlay lines as `series[0]` mean the chart is **not** candle-primary (set `position: 'right'` explicitly if needed). Helper: `isCandlePrimaryChart(userOptions)`.
   - **Y position**: the **first** Y axis defaults to `position: 'right'` when the user leaves `position` unset (`yAxis` or `axes.y[0]`). Secondary Y axes still default to `'left'`. Explicit `position` always wins.
-  - **Soft grid gutters** (per-key only — each of `grid.left` / `grid.right` is set only when that key is `undefined` on user options; `0` is preserved):
+  - **Soft grid gutters** (per-key only for most cases — each of `grid.left` / `grid.right` is set only when that key is `undefined` on user options; `0` is preserved):
 
     | Scenario | `grid.left` if unset | `grid.right` if unset |
     |----------|----------------------|------------------------|
-    | Single candle, price on right | `20` | `70` |
-    | Candle + volume (left Y remains) | `60` | `70` |
+    | Single candle, price on right | `20` | `80` |
+    | Candle + volume (left Y remains) | `60` | `80` |
     | User set `grid.left: 80` only | `80` (kept) | `70` |
-    | User set both margins | unchanged | unchanged |
+    | User set both margins (right ≥ 80 or 0) | unchanged | unchanged |
+    | User set both with small right (e.g. `right: 24`) and a right Y | unchanged | **floored to `80`** |
     | Non-candle-primary | `60` | `20` |
+
+  - **Right-rail floor**: when candle-primary and any Y is on the right, a **positive** `grid.right` below `80` is raised to `80` so left-Y line-chart templates (`left: 70, right: 24`) do not clip tick labels or the last-price badge. Explicit `right: 0` (full-bleed) and `right ≥ 80` are unchanged.
 
   - Non-candle-primary charts keep the standard grid defaults and left Y.
   - **Migration (P1 default badge)**: candle-primary charts also **auto-enable** `priceLabel` (last-price badge + price line) when `priceLabel` is omitted. This is a **default visual change** for existing candle consumers. Opt out with `priceLabel: false`. To restore a pre-upgrade left-axis look:
@@ -529,11 +532,11 @@ Example: [`examples/impulse/`](../../examples/impulse/). Step digital line: [`ex
 }
 ```
 
-  - Recommended candle + volume dual-Y (or omit both gutters — dual-Y policy yields left `60` / right `70`):
+  - Recommended candle + volume dual-Y (or omit both gutters — dual-Y policy yields left `60` / right `80`):
 
 ```ts
 {
-  grid: { left: 60, right: 70 },
+  grid: { left: 60, right: 80 },
   axes: {
     y: [
       { id: 'price', position: 'right', type: 'value', header: 'USDT' },
@@ -554,10 +557,10 @@ Example: [`examples/impulse/`](../../examples/impulse/). Step digital line: [`ex
 ```
 
   - **Visual / acceptance checklist** (manual or example review):
-    1. Candle-only, no axis/grid overrides → right price rail, thicker right gutter (~70), last-price badge + horizontal line at last close.
+    1. Candle-only, no axis/grid overrides → right price rail, thicker right gutter (~80), last-price badge + horizontal line at last close.
     2. `priceLabel: false` → no badge/line; axis defaults still apply unless you also set `position` / `grid`.
     3. Explicit `yAxis.position: 'left'` → left rail; badge anchors on the left when still shown.
-    4. Dual-Y volume on left → left gutter ≥ 60, right 70; badge follows the **price** candlestick series only.
+    4. Dual-Y volume on left → left gutter ≥ 60, right 80; badge follows the **price** candlestick series only.
     5. Streaming with `intervalMs` + stable `nowMs` → countdown ticks under the price without extra GPU frames.
     6. `yAxis.header: 'USDT'` (or quote unit) → non-rotated top-rail label (not the rotated `name` title).
     7. Unit tests / acceptance: [`src/config/__tests__/OptionResolver.test.ts`](../../src/config/__tests__/OptionResolver.test.ts), [`resolvePriceLabel.test.ts`](../../src/config/__tests__/resolvePriceLabel.test.ts), [`examples/acceptance/candle-price-axis.ts`](../../examples/acceptance/candle-price-axis.ts).
@@ -760,7 +763,7 @@ See [`defaults.ts`](../../src/config/defaults.ts) for the defaults (including gr
 
 **Behavior notes (essential):**
 
-- **Default grid**: `left: 60`, `right: 20`, `top: 40`, `bottom: 40` (non-candle-primary). Candle-primary soft gutters: see **Candle-primary layout defaults** under Axis Configuration (`right: 70`; `left: 20` or `60` depending on left Y axes).
+- **Default grid**: `left: 60`, `right: 20`, `top: 40`, `bottom: 40` (non-candle-primary). Candle-primary soft gutters: see **Candle-primary layout defaults** under Axis Configuration (`right: 80`; `left: 20` or `60` depending on left Y axes).
 - **Palette / series colors**: `ChartGPUOptions.palette` acts as an override for the resolved theme palette (`resolvedOptions.theme.colorPalette`). When `series[i].color` is missing, the default series color comes from `resolvedOptions.theme.colorPalette[i % ...]`. For backward compatibility, the resolved `palette` is the resolved theme palette. See [`resolveOptions`](../../src/config/OptionResolver.ts) and [`ThemeConfig`](themes.md#themeconfig).
 - **Line series stroke color precedence**: for `type: 'line'`, effective stroke color follows: `lineStyle.color` → `series.color` → theme palette. See [`resolveOptions`](../../src/config/OptionResolver.ts).
 - **Line series fill color precedence**: for `type: 'line'` with `areaStyle`, effective fill color follows: `areaStyle.color` → resolved stroke color (from above precedence). See [`resolveOptions`](../../src/config/OptionResolver.ts).

--- a/examples/acceptance/candle-price-axis.ts
+++ b/examples/acceptance/candle-price-axis.ts
@@ -76,7 +76,7 @@ console.log('[acceptance:candle-price-axis] candle-primary Y + grid defaults...'
   const resolved = resolveOptions({ series: [candleSeries] });
   assertEqual('synthetic y position right', resolved.yAxes[0]!.position, 'right');
   assertEqual('left gutter single candle', resolved.grid.left, 20);
-  assertEqual('right gutter candle', resolved.grid.right, 70);
+  assertEqual('right gutter candle', resolved.grid.right, 80);
   assertEqual('top unchanged', resolved.grid.top, 40);
   assertEqual('bottom unchanged', resolved.grid.bottom, 40);
 }
@@ -88,7 +88,7 @@ console.log('[acceptance:candle-price-axis] candle-primary Y + grid defaults...'
   });
   assertEqual('explicit left wins', resolved.yAxes[0]!.position, 'left');
   assertEqual('left Y → left gutter 60', resolved.grid.left, 60);
-  assertEqual('right still soft 70', resolved.grid.right, 70);
+  assertEqual('right still soft 80', resolved.grid.right, 80);
 }
 
 {
@@ -97,7 +97,7 @@ console.log('[acceptance:candle-price-axis] candle-primary Y + grid defaults...'
     grid: { left: 80 },
   });
   assertEqual('user left kept', resolved.grid.left, 80);
-  assertEqual('right soft default', resolved.grid.right, 70);
+  assertEqual('right soft default', resolved.grid.right, 80);
 }
 
 {
@@ -106,7 +106,7 @@ console.log('[acceptance:candle-price-axis] candle-primary Y + grid defaults...'
     grid: { left: 0 },
   });
   assertEqual('grid.left 0 preserved (not missing)', resolved.grid.left, 0);
-  assertEqual('right soft default with left 0', resolved.grid.right, 70);
+  assertEqual('right soft default with left 0', resolved.grid.right, 80);
 }
 
 {
@@ -125,7 +125,7 @@ console.log('[acceptance:candle-price-axis] candle-primary Y + grid defaults...'
   assertEqual('dual-Y price right', resolved.yAxes[0]!.position, 'right');
   assertEqual('dual-Y vol left', resolved.yAxes[1]!.position, 'left');
   assertEqual('dual-Y left gutter 60', resolved.grid.left, 60);
-  assertEqual('dual-Y right gutter 70', resolved.grid.right, 70);
+  assertEqual('dual-Y right gutter 80', resolved.grid.right, 80);
 }
 
 {

--- a/examples/candlestick-streaming/main.ts
+++ b/examples/candlestick-streaming/main.ts
@@ -143,7 +143,7 @@ async function init() {
   lastSimPerfNow = performance.now();
 
   // Create chart
-  // Candle-primary defaults: first Y → right, grid left=20 / right=70 (no grid override needed).
+  // Candle-primary defaults: first Y → right, grid left=20 / right=80 (no grid override needed).
   fullChartOptions = {
     // Darker than built-in dark (#1a1a2e) — metallic near-black plot field
     theme: {

--- a/examples/candlestick/main.ts
+++ b/examples/candlestick/main.ts
@@ -73,7 +73,7 @@ async function main() {
   const msPerSecond = 1000;
   const timestampPadding = msPerSecond;
 
-  // Candle-primary defaults: first Y → right, grid left=20 / right=70 when unset.
+  // Candle-primary defaults: first Y → right, grid left=20 / right=80 when unset.
   // Only override top/bottom for axis title room; leave left/right to the library.
   const initialOptions: ChartGPUOptions = {
     grid: { top: 24, bottom: 56 },

--- a/src/config/OptionResolver.ts
+++ b/src/config/OptionResolver.ts
@@ -2075,11 +2075,25 @@ export function resolveOptions(
 
   // Soft gutters for candle-primary: per-key only when user left that key undefined.
   // Dual-Y safety: keep left 60 when any Y remains on the left after position defaults.
+  // Right rail floor: when any Y is on the right, never honor a positive-but-too-small
+  // `grid.right` (common left-Y template is right:20/24) — that clips tick labels and
+  // the last-price badge (canvas text overlay cannot paint past the container edge).
+  // `grid.right: 0` stays full-bleed; larger explicit rights still win.
   const hasLeftY = yAxes.some((a) => (a.position ?? 'left') === 'left');
+  const hasRightY = yAxes.some((a) => (a.position ?? 'left') === 'right');
   const candleLeftDefault = hasLeftY ? candlePrimaryGridDefaults.leftWithLeftY : candlePrimaryGridDefaults.leftNoLeftY;
+  const candleRightSoft = candlePrimaryGridDefaults.right;
+  const resolveCandlePrimaryRight = (): number => {
+    const userRight = userOptions.grid?.right;
+    if (userRight === undefined) return candleRightSoft;
+    if (hasRightY && userRight > 0 && userRight < candleRightSoft) return candleRightSoft;
+    return userRight;
+  };
   const grid: ResolvedGridConfig = {
     left: userOptions.grid?.left ?? (candlePrimary ? candleLeftDefault : defaultOptions.grid.left),
-    right: userOptions.grid?.right ?? (candlePrimary ? candlePrimaryGridDefaults.right : defaultOptions.grid.right),
+    right: candlePrimary
+      ? resolveCandlePrimaryRight()
+      : (userOptions.grid?.right ?? defaultOptions.grid.right),
     top: userOptions.grid?.top ?? defaultOptions.grid.top,
     bottom: userOptions.grid?.bottom ?? defaultOptions.grid.bottom,
   };

--- a/src/config/__tests__/OptionResolver.test.ts
+++ b/src/config/__tests__/OptionResolver.test.ts
@@ -1087,7 +1087,7 @@ describe('OptionResolver ohlc series', () => {
       expect(s.rawData).toBe(data);
     }
     expect(resolved.yAxes[0]!.position).toBe('right');
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
   });
 
   it('falls back sampling to default when invalid mode provided', () => {
@@ -1108,11 +1108,11 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
     data: [[1_700_000_000_000, 100, 101, 99, 102]] as const satisfies ReadonlyArray<OHLCDataPoint>,
   };
 
-  it('defaults first Y position to right and gutters left=20 / right=70 when unset', () => {
+  it('defaults first Y position to right and gutters left=20 / right=80 when unset', () => {
     const resolved = resolveOptions({ series: [candleSeries] });
     expect(resolved.yAxes[0]!.position).toBe('right');
     expect(resolved.grid.left).toBe(20);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
     // Non-gutter keys still use standard defaults
     expect(resolved.grid.top).toBe(40);
     expect(resolved.grid.bottom).toBe(40);
@@ -1124,22 +1124,22 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
       yAxis: { type: 'value', position: 'left' },
     });
     expect(resolved.yAxes[0]!.position).toBe('left');
-    // Left Y remains → dual-Y-safe left gutter 60; right still soft-defaults to 70
+    // Left Y remains → dual-Y-safe left gutter 60; right still soft-defaults to 80
     expect(resolved.grid.left).toBe(60);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
   });
 
-  it('soft-sets only unset grid keys (user left only → keep left, right 70)', () => {
+  it('soft-sets only unset grid keys (user left only → keep left, right 80)', () => {
     const resolved = resolveOptions({
       series: [candleSeries],
       grid: { left: 80 },
     });
     expect(resolved.grid.left).toBe(80);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
     expect(resolved.yAxes[0]!.position).toBe('right');
   });
 
-  it('soft-sets only unset grid keys (user right only → keep right, left 20)', () => {
+  it('soft-sets only unset grid keys (user right only ≥ soft → keep right, left 20)', () => {
     const resolved = resolveOptions({
       series: [candleSeries],
       grid: { right: 90 },
@@ -1148,16 +1148,35 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
     expect(resolved.grid.right).toBe(90);
   });
 
-  it('honors both explicit grid margins', () => {
+  it('honors both explicit grid margins when right is large enough for the price rail', () => {
     const resolved = resolveOptions({
       series: [candleSeries],
-      grid: { left: 12, right: 34 },
+      grid: { left: 12, right: 90 },
     });
     expect(resolved.grid.left).toBe(12);
-    expect(resolved.grid.right).toBe(34);
+    expect(resolved.grid.right).toBe(90);
   });
 
-  it('dual-Y with left secondary keeps left gutter 60 and right 70', () => {
+  it('floors undersized right gutters on candle-primary with right Y (left-Y template footgun)', () => {
+    // Common line-chart gutters clip tick labels + last-price badge when Y defaults to right.
+    const resolved = resolveOptions({
+      series: [candleSeries],
+      grid: { left: 70, right: 24, top: 24, bottom: 44 },
+    });
+    expect(resolved.yAxes[0]!.position).toBe('right');
+    expect(resolved.grid.left).toBe(70);
+    expect(resolved.grid.right).toBe(80);
+  });
+
+  it('preserves grid.right: 0 full-bleed on candle-primary', () => {
+    const resolved = resolveOptions({
+      series: [candleSeries],
+      grid: { right: 0 },
+    });
+    expect(resolved.grid.right).toBe(0);
+  });
+
+  it('dual-Y with left secondary keeps left gutter 60 and right 80', () => {
     const resolved = resolveOptions({
       series: [
         { ...candleSeries, yAxis: 'price' },
@@ -1173,7 +1192,7 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
     expect(resolved.yAxes[0]!.position).toBe('right');
     expect(resolved.yAxes[1]!.position).toBe('left');
     expect(resolved.grid.left).toBe(60);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
   });
 
   it('does not flip secondary Y position when first is candle-primary', () => {
@@ -1238,7 +1257,7 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
     });
     expect(resolved.yAxes.every((a) => a.position === 'right')).toBe(true);
     expect(resolved.grid.left).toBe(20);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
   });
 
   it('preserves grid.left: 0 (nullish only — zero is not missing)', () => {
@@ -1247,10 +1266,10 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
       grid: { left: 0 },
     });
     expect(resolved.grid.left).toBe(0);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
   });
 
-  it('axes.y-only single axis defaults first Y to right with left 20 / right 70', () => {
+  it('axes.y-only single axis defaults first Y to right with left 20 / right 80', () => {
     const resolved = resolveOptions({
       series: [candleSeries],
       axes: {
@@ -1261,7 +1280,7 @@ describe('OptionResolver - candle-primary Y-axis and grid defaults', () => {
     expect(resolved.yAxes[0]!.id).toBe('price');
     expect(resolved.yAxes[0]!.position).toBe('right');
     expect(resolved.grid.left).toBe(20);
-    expect(resolved.grid.right).toBe(70);
+    expect(resolved.grid.right).toBe(80);
   });
 
   it('passes through AxisConfig.header on yAxis and axes.y', () => {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -25,8 +25,11 @@ export const candlePrimaryGridDefaults = {
   leftNoLeftY: 20,
   /** At least one left-positioned Y (e.g. volume dual-Y). */
   leftWithLeftY: 60,
-  /** Room for right-side price ladder labels. */
-  right: 70,
+  /**
+   * Room for right-side price ladder labels + last-price badge.
+   * ~70 was tight for 6-sig badge text (padding + tick) and clipped at the canvas edge.
+   */
+  right: 80,
 } as const;
 
 export const defaultPalette = [

--- a/src/utils/__tests__/niceAxisTicks.test.ts
+++ b/src/utils/__tests__/niceAxisTicks.test.ts
@@ -104,6 +104,27 @@ describe('generateNiceAxisTicks', () => {
       expect(Number.isFinite(t)).toBe(true);
     }
   });
+
+  it('does not cliff mid-majors when domain grows just past a nice end (2D clamp)', () => {
+    // Regression: continuous/animated auto-range grows max from 2 → 2.1 and used to
+    // jump step 0.5 → 1, dropping 0.5 / 1.5 mid labels in one frame.
+    const at2 = generateNiceAxisTicks(0, 2, 5, { clampToDomain: true });
+    const past2 = generateNiceAxisTicks(0, 2.1, 5, { clampToDomain: true });
+    expect(at2).toEqual([0, 0.5, 1, 1.5, 2]);
+    expect(past2).toContain(0.5);
+    expect(past2).toContain(1.5);
+    // Still a 1–2–5 ladder (step 0.5), not equal-split endpoints alone.
+    expect(past2).toEqual([0, 0.5, 1, 1.5, 2]);
+  });
+
+  it('keeps 0.5 mid label across a dense rising-max sequence (2D clamp)', () => {
+    for (const max of [1.5, 1.6, 1.8, 2, 2.05, 2.1, 2.2, 2.4]) {
+      const ticks = generateNiceAxisTicks(0, max, 5, { clampToDomain: true });
+      if (max >= 0.5) {
+        expect(ticks.some((t) => Math.abs(t - 0.5) < 1e-9)).toBe(true);
+      }
+    }
+  });
 });
 
 describe('generateValueAxisTicks', () => {

--- a/src/utils/niceAxisTicks.ts
+++ b/src/utils/niceAxisTicks.ts
@@ -78,8 +78,18 @@ export function generateNiceAxisTicks(
     hi = t;
   }
 
-  const range = niceNum(hi - lo, false);
-  const step = niceNum(range / (count - 1), true);
+  // Step selection:
+  // - clampToDomain (2D presentation): derive step from the *raw* span.
+  //   The classic Graphics Gems path first ceils the span (`niceNum(span, false)`),
+  //   which cliffs under continuous auto-range — e.g. domain [0, 2] → step 0.5
+  //   (labels 0, 0.5, 1, 1.5, 2) but [0, 2.1] → expanded range 5 → step 1
+  //   (labels 0, 1, 2 only) so mid-majors like 0.5 vanish on the tiniest grow.
+  // - unclamped (3D): keep the classic expand-then-step so nice endpoints can sit
+  //   slightly outside the raw domain.
+  const span = hi - lo;
+  const step = clampToDomain
+    ? niceNum(span / (count - 1), true)
+    : niceNum(niceNum(span, false) / (count - 1), true);
   if (!(step > 0) || !Number.isFinite(step)) {
     return [lo, hi];
   }


### PR DESCRIPTION
## Summary

- **Candle right-rail clipping:** candle-primary charts default the first Y to the right and auto-enable the last-price badge. Left-Y grid templates (`right: 20/24`) clipped tick labels and the badge. Floor small positive `grid.right` to the candle soft default (**80**, was 70 — still tight for 6-sig badges); preserve `right: 0` full-bleed and larger explicit rights.
- **Mid-tick vanish under auto-range:** 2D `clampToDomain` nice ticks used classic span-ceil step selection, so growing the domain from e.g. `[0, 2]` → `[0, 2.1]` jumped step `0.5` → `1` and dropped majors like `0.5` in one frame. Derive step from the raw span for 2D; keep classic expand for 3D unclamped.

## Test plan

- [x] `bun run test -- src/config/__tests__/OptionResolver.test.ts`
- [x] `bun run test -- src/utils/__tests__/niceAxisTicks.test.ts` (+ related tick tests)
- [x] `bun run acceptance:candle-price-axis`
- [x] Stress suite candlestick group: price badge fits inside chart root; mid Y labels no longer blink off on small domain grow
- [ ] Spot-check `examples/candlestick` and `examples/axis-streaming-smooth` in browser