### PR TITLE
fix(animation): stop line update tween from snapping to end state

### DIFF
--- a/src/core/renderCoordinator/animation/__tests__/animationHelpers.test.ts
+++ b/src/core/renderCoordinator/animation/__tests__/animationHelpers.test.ts
@@ -13,6 +13,7 @@ import {
   lerpDomain,
   lerpLogDomain,
   interpolateCartesianData,
+  withAnimatedCartesianSeriesData,
   interpolatePieData,
   isDomainEqual,
   computeNextIntroPhase,
@@ -434,6 +435,56 @@ describe('interpolateCartesianData', () => {
     const result = interpolateCartesianData(from, to, 1, null);
 
     expect(result![0]).toEqual([0, 100]);
+  });
+});
+
+describe('withAnimatedCartesianSeriesData', () => {
+  it('points both data and rawData at the animated samples (line GPU upload path)', () => {
+    const targetRaw = [
+      [0, 100],
+      [1, 200],
+    ] as const;
+    const animated = [
+      [0, 10],
+      [1, 20],
+    ];
+    const toSeries = {
+      type: 'line',
+      name: 'Line',
+      data: targetRaw,
+      rawData: targetRaw,
+      rawBounds: { xMin: 0, xMax: 1, yMin: 100, yMax: 200 },
+      sampling: 'lttb',
+      color: '#ff00aa',
+    };
+
+    const result = withAnimatedCartesianSeriesData(toSeries, animated);
+
+    expect(result.data).toBe(animated);
+    expect(result.rawData).toBe(animated);
+    expect(result.rawBounds).toBe(null);
+    // Presentation fields preserved from target.
+    expect(result.type).toBe('line');
+    expect(result.color).toBe('#ff00aa');
+    expect(result.sampling).toBe('lttb');
+    // Target rewrite must not leak into upload paths mid-transition.
+    expect(result.rawData).not.toBe(targetRaw);
+  });
+
+  it('does not mutate the target series object', () => {
+    const targetRaw = [[0, 1]] as const;
+    const toSeries = {
+      type: 'line',
+      data: targetRaw,
+      rawData: targetRaw,
+      rawBounds: { xMin: 0, xMax: 0, yMin: 1, yMax: 1 },
+    };
+    const animated = [[0, 0.5]];
+
+    withAnimatedCartesianSeriesData(toSeries, animated);
+
+    expect(toSeries.data).toBe(targetRaw);
+    expect(toSeries.rawData).toBe(targetRaw);
   });
 });
 

--- a/src/core/renderCoordinator/animation/animationHelpers.ts
+++ b/src/core/renderCoordinator/animation/animationHelpers.ts
@@ -352,6 +352,30 @@ export function interpolateCartesianData(
 }
 
 /**
+ * Attach index-aligned update-animation samples to a cartesian series config.
+ *
+ * Spreading the **to** series alone leaves `rawData` at the target rewrite.
+ * Line prepare then prefers `rawData` on the GPU-decimation path and for
+ * `sampling: 'none'`, so the stroke snaps to the end state for the whole
+ * transition while only domains (and bar `data`) appear to animate.
+ *
+ * Both `data` and `rawData` must reference the animated samples for the
+ * duration of the transition. `rawBounds` is cleared so nothing treats the
+ * target extents as current geometry mid-lerp.
+ */
+export function withAnimatedCartesianSeriesData<T extends Record<string, unknown>>(
+  toSeries: T,
+  animatedData: unknown
+): T {
+  return {
+    ...toSeries,
+    data: animatedData,
+    rawData: animatedData,
+    rawBounds: null,
+  };
+}
+
+/**
  * Interpolates pie series data between from and to states.
  *
  * Returns the toSeries unchanged if data array lengths don't match.

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -198,6 +198,7 @@ import {
   isSnapOnlyUpdateAnimationSeries,
   createEasingWithDelay,
   interpolateCartesianData,
+  withAnimatedCartesianSeriesData,
   interpolatePieData,
   computeNextIntroPhase,
   applyBarIntroProgress,
@@ -1321,7 +1322,10 @@ export function createRenderCoordinator(
       }
       if (caches) caches.cartesianDataBySeriesIndex[i] = animatedData;
 
-      out[i] = { ...(b as any), data: animatedData };
+      // Keep rawData on the animated samples (not the target rewrite). Line GPU
+      // decimation and sampling:'none' upload rawData — leaving target rawData
+      // caused a pre-tween snap to the end state on every setOption update.
+      out[i] = withAnimatedCartesianSeriesData(b as any, animatedData) as (typeof out)[number];
     }
 
     return out;


### PR DESCRIPTION
## Summary
- Fix pre-tween snap on line series during `setOption` data-update animations (Story 5.17 / data-update-animation example).
- Root cause: cartesian update interpolation spread the **to** series and only overwrote `data`, leaving `rawData` at the final rewrite. Line prepare prefers `rawData` on the GPU-decimation path and for `sampling: 'none'`, so the stroke jumped to the end state for the whole transition.
- Mid-transition configs now attach animated samples to both `data` and `rawData` via `withAnimatedCartesianSeriesData` (and clear `rawBounds`).

## Test plan
- [x] `bun run test -- src/core/renderCoordinator/animation/__tests__/animationHelpers.test.ts`
- [x] Typecheck clean
- [x] Manual: `examples/data-update-animation` — Randomize / Update Data; line morphs from previous shape without a one-frame end-state snap
- [ ] Spot-check multi-series-animation (line + area) under animate updates