### PR TITLE
chore: bump version to 0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary
- Bump package version **0.3.8 → 0.3.9** for npm publish after recent main merges.

## Included since 0.3.8
- Line data-update animation no longer snaps to end state via stale `rawData` (#209)
- README demo GIF refresh + Prettier formatting pass (#210)
- Prior axis/FIFO/presentation work already on main

## Test plan
- [x] `package.json` version is `0.3.9`
- [ ] Publish / release workflow as usual after merge