### PR TITLE
docs: restore Awesome WebGPU badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/chartgpu/chartgpu/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="MIT"></a>
   <a href="https://chartgpu.io/docs/getting-started/"><img src="https://img.shields.io/badge/docs-getting%20started-blue" alt="docs"></a>
   <a href="https://chartgpu.io"><img src="https://img.shields.io/badge/demo-chartgpu.io-brightgreen" alt="demo"></a>
+  <a href="https://github.com/mikbry/awesome-webgpu"><img src="https://awesome.re/mentioned-badge.svg" alt="Featured in Awesome WebGPU" height="20" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Description

Restores the Awesome WebGPU badge on the README badge row, linking to https://github.com/mikbry/awesome-webgpu.

## Type of Change

- [x] Documentation update

## Related Issues

N/A

## Testing

- [x] README markdown only (no runtime / browser change)

## Documentation

- [x] Updated README (if relevant)

## Additional Notes

Keeps the thinner badge row from the recent README rewrite; only re-adds the Awesome listing badge.