### PR TITLE
docs: redirect GitHub Pages to chartgpu.io

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,11 @@
-name: Deploy Examples to GitHub Pages
+name: Deploy GitHub Pages redirect
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'pages-redirect/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -15,37 +18,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build library
-        run: bun run build
-
-      - name: Build GitHub Pages site (landing + examples)
-        run: bun run build:pages
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './pages-dist'
-
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      # Client-side redirect to chartgpu.io (index + 404 for deep paths).
+      # No library/examples build — product demos live on chartgpu.io.
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './pages-redirect'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/dev-site/vite.config.ts
+++ b/dev-site/vite.config.ts
@@ -98,7 +98,8 @@ function flattenPagesPlugin() {
 }
 
 export default defineConfig(({ command }) => ({
-  // Project Pages: https://chartgpu.github.io/ChartGPU/
+  // Local preview of the former GH Pages layout only (`npm run build:pages`).
+  // Live GitHub Pages now serves pages-redirect/ → https://chartgpu.io/
   // Dev keeps base `/` so /examples/... resolves from the Vite root (repo).
   base: command === 'build' ? '/ChartGPU/' : '/',
   root: repoRoot,

--- a/pages-redirect/404.html
+++ b/pages-redirect/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ChartGPU has moved</title>
+  <meta name="description" content="ChartGPU demos and docs live at chartgpu.io.">
+  <link rel="canonical" href="https://chartgpu.io/">
+  <meta http-equiv="refresh" content="0; url=https://chartgpu.io/">
+  <script>
+    // Cover deep paths such as /ChartGPU/<example>/ once the old demo tree is gone.
+    location.replace('https://chartgpu.io/');
+  </script>
+</head>
+<body>
+  <p>
+    This path is no longer hosted on GitHub Pages.
+    ChartGPU demos and documentation live at
+    <a href="https://chartgpu.io/">chartgpu.io</a>.
+  </p>
+</body>
+</html>

--- a/pages-redirect/README.md
+++ b/pages-redirect/README.md
@@ -1,0 +1,13 @@
+# GitHub Pages redirect
+
+Static site published to `https://chartgpu.github.io/ChartGPU/`.
+
+All traffic (root and deep paths via `404.html`) client-redirects to
+[https://chartgpu.io/](https://chartgpu.io/). GitHub Pages does not support
+server-side HTTP redirects; this uses meta refresh + `location.replace`.
+
+Deployed by [`.github/workflows/deploy-pages.yml`](../.github/workflows/deploy-pages.yml).
+
+Local demos: `npm run dev` in the repo root (see `examples/`).
+The former full Pages build (`npm run build:pages` / `dev-site/`) remains for
+local preview only and is no longer what GitHub Pages serves.

--- a/pages-redirect/index.html
+++ b/pages-redirect/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ChartGPU has moved</title>
+  <meta name="description" content="ChartGPU demos and docs live at chartgpu.io.">
+  <link rel="canonical" href="https://chartgpu.io/">
+  <meta http-equiv="refresh" content="0; url=https://chartgpu.io/">
+  <script>
+    location.replace('https://chartgpu.io/');
+  </script>
+</head>
+<body>
+  <p>
+    ChartGPU demos and documentation live at
+    <a href="https://chartgpu.io/">chartgpu.io</a>.
+  </p>
+  <p>
+    For local examples from this repository, clone the repo and run
+    <code>npm run dev</code>.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
## Description

Stop hosting a second product/examples surface on GitHub Pages. Publish a minimal static site that client-redirects all traffic to [chartgpu.io](https://chartgpu.io/).

- `pages-redirect/index.html` — root redirect (meta refresh + `location.replace`)
- `pages-redirect/404.html` — same for deep paths (old `/ChartGPU/<example>/` URLs)
- Slim `.github/workflows/deploy-pages.yml` — no `bun install` / `build` / `build:pages`; only uploads `pages-redirect/`
- `dev-site/` + `npm run build:pages` remain for **local** preview only

GitHub Pages does not support server-side HTTP 301s; this is the standard static approach.

## Type of Change

- [x] Documentation update
- [x] Other (please describe): CI / hosting change for GitHub Pages

## Related Issues

N/A

## Testing

- [x] Static HTML verified by inspection (redirect target `https://chartgpu.io/`)
- [ ] After merge: confirm `https://chartgpu.github.io/ChartGPU/` and a deep path (e.g. `/ChartGPU/basic-line/`) leave for chartgpu.io

## Documentation

- [x] Updated README (if relevant) — n/a; README already points at chartgpu.io
- [x] Added `pages-redirect/README.md` for maintainers

## Additional Notes

- Workflow path filters: redeploys only when `pages-redirect/**` or this workflow changes (plus `workflow_dispatch`).
- First merge to `main` will deploy the redirect via the changed workflow/files.
- Product demos continue on chartgpu.io; local examples via `npm run dev`.