### PR TITLE
fix: anchor candlestick tooltips on price Y scale

### DIFF
--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -2297,7 +2297,7 @@ export function createRenderCoordinator(
     interactionScales: NonNullable<ReturnType<typeof computeInteractionScalesGridCssPx>>
   ): {
     params: TooltipParams;
-    match: { point: OHLCDataPoint };
+    match: { point: OHLCDataPoint; yAxisId: string };
     seriesIndex: number;
   } | null => {
     // Iterate from last to first for correct z-ordering (last series drawn on top)
@@ -2308,6 +2308,18 @@ export function createRenderCoordinator(
       if (s.visible === false) continue;
 
       const cs = s as FinanceOhlcHitSeriesConfig;
+      // Prefer series.yAxis; fall back to 'price' then 'y' (dual-Y candle+volume
+      // charts put vol first — 'y' alone can miss the price scale id).
+      const yAxisId =
+        (typeof (s as { yAxis?: string }).yAxis === 'string' && (s as { yAxis?: string }).yAxis) ||
+        (interactionScales.yScales.has('price') ? 'price' : 'y');
+      const yScaleForHit =
+        interactionScales.yScales.get(yAxisId) ??
+        interactionScales.yScales.get('price') ??
+        interactionScales.yScales.get('y') ??
+        interactionScales.yScales.values().next().value;
+      if (!yScaleForHit) continue;
+
       const barWidthClip = computeCandlestickBodyWidthRange(
         cs,
         cs.data,
@@ -2320,7 +2332,7 @@ export function createRenderCoordinator(
         gridX,
         gridY,
         interactionScales.xScale,
-        interactionScales.yScales.get((s as any).yAxis || 'y')!,
+        yScaleForHit,
         barWidthClip,
         // OHLC bars: hit stem [low, high] (same as ChartGPU.hitTest). Candles stay body-only.
         { yHitMode: s.type === 'ohlc' ? 'lowHigh' : 'openClose' }
@@ -2328,7 +2340,7 @@ export function createRenderCoordinator(
       if (!m) continue;
 
       const params = buildCandlestickTooltipParams(i, m.dataIndex, m.point);
-      return { params, match: { point: m.point }, seriesIndex: i };
+      return { params, match: { point: m.point, yAxisId }, seriesIndex: i };
     }
     return null;
   };

--- a/src/core/renderCoordinator/ui/__tests__/tooltipLegendHelpers.test.ts
+++ b/src/core/renderCoordinator/ui/__tests__/tooltipLegendHelpers.test.ts
@@ -204,6 +204,44 @@ describe('computeCandlestickTooltipAnchorFromMatch', () => {
     const anchor = computeCandlestickTooltipAnchorFromMatch({ point }, xScale, yScales, gridArea as any, canvas);
     expect(anchor).toBe(null);
   });
+
+  it('anchors on price yAxis when vol scale is first in the map (dual-Y)', () => {
+    // Volume first — bar renderer contract. Price values must not use this scale.
+    const volScale = createLinearScale().domain(0, 100_000).range(300, 0);
+    const priceScale = createLinearScale().domain(70, 110).range(300, 0);
+    const dualY = new Map([
+      ['vol', volScale],
+      ['price', priceScale],
+    ]);
+    const point: [number, number, number, number, number] = [50, 80, 90, 70, 95];
+    // body mid = 85 → priceScale maps near mid of 70–110 range
+    const anchor = computeCandlestickTooltipAnchorFromMatch(
+      { point, yAxisId: 'price' },
+      xScale,
+      dualY,
+      gridArea as any,
+      canvas
+    );
+    expect(anchor).not.toBe(null);
+    // priceScale: domain 70→110, range 300→0; 85 is (85-70)/(110-70)=0.375 → y=300*0.625=187.5
+    const expectedY = 5 + 20 + priceScale.scale(85);
+    expect(anchor!.y).toBeCloseTo(expectedY, 0);
+    // Must not be near the floor (vol-scale would map 85 ~ 300)
+    expect(anchor!.y).toBeLessThan(5 + 20 + 280);
+  });
+
+  it('prefers price scale over first map entry when yAxisId omitted', () => {
+    const volScale = createLinearScale().domain(0, 100_000).range(300, 0);
+    const priceScale = createLinearScale().domain(70, 110).range(300, 0);
+    const dualY = new Map([
+      ['vol', volScale],
+      ['price', priceScale],
+    ]);
+    const point: [number, number, number, number, number] = [50, 80, 90, 70, 95];
+    const anchor = computeCandlestickTooltipAnchorFromMatch({ point }, xScale, dualY, gridArea as any, canvas);
+    expect(anchor).not.toBe(null);
+    expect(anchor!.y).toBeCloseTo(5 + 20 + priceScale.scale(85), 0);
+  });
 });
 
 describe('isOHLCDataPoint', () => {

--- a/src/core/renderCoordinator/ui/tooltipLegendHelpers.ts
+++ b/src/core/renderCoordinator/ui/tooltipLegendHelpers.ts
@@ -103,8 +103,31 @@ export function isOHLCDataPoint(point: any): point is OHLCDataPoint {
   return false;
 }
 
+/**
+ * Resolve the Y scale for candlestick tooltip anchoring.
+ *
+ * Dual-Y candle+volume charts put `vol` first in the scale map (bar renderer
+ * samples the first Y). Anchoring OHLC body mid against that scale maps price
+ * domain values near the plot floor. Prefer the series `yAxis` id, then common
+ * price ids, then the first scale as last resort.
+ */
+function resolveCandlestickYScale(
+  yScales: Map<string, LinearScale>,
+  yAxisId?: string
+): LinearScale | undefined {
+  if (yAxisId) {
+    const byId = yScales.get(yAxisId);
+    if (byId) return byId;
+  }
+  for (const id of ['price', 'y', 'default'] as const) {
+    const s = yScales.get(id);
+    if (s) return s;
+  }
+  return yScales.values().next().value;
+}
+
 export function computeCandlestickTooltipAnchorFromMatch(
-  match: { readonly point: OHLCDataPoint },
+  match: { readonly point: OHLCDataPoint; readonly yAxisId?: string },
   xScale: LinearScale,
   yScales: Map<string, LinearScale>,
   gridArea: GridArea,
@@ -123,9 +146,9 @@ export function computeCandlestickTooltipAnchorFromMatch(
   // Body center in domain space
   const bodyMidY = (open + close) / 2;
 
-  // Transform to grid-local CSS pixels
+  // Transform to grid-local CSS pixels on the *price* Y scale (not volume).
   const xGridCss = xScale.scale(timestamp);
-  const yScale = yScales.values().next().value;
+  const yScale = resolveCandlestickYScale(yScales, match.yAxisId);
   const yGridCss = yScale ? yScale.scale(bodyMidY) : 0;
 
   if (!Number.isFinite(xGridCss) || !Number.isFinite(yGridCss)) {


### PR DESCRIPTION
## Summary
- Candlestick tooltip anchor uses the series price Y scale, not the first map entry (often `vol`)
- Hit-test path passes `yAxisId` into the anchor helper
- Unit tests for dual-Y vol-first scale maps

## Test plan
- [ ] Candle+volume dual-Y: hover a candle — tooltip sits at body mid, not volume band
- [ ] `bun test src/core/renderCoordinator/ui/__tests__/tooltipLegendHelpers.test.ts`