### PR TITLE
perf: scale setSeries staging headroom to seed size

### DIFF
--- a/docs/guides/multichart-dashboard-cookbook.md
+++ b/docs/guides/multichart-dashboard-cookbook.md
@@ -75,6 +75,10 @@ disconnect();
 
 Zoom sync ignores `'auto-scroll'` zoom changes by design to prevent streaming charts from shifting other charts' views.
 
+## Memory (JS staging vs shared device)
+
+Sharing one `GPUDevice` avoids N× adapter/device overhead, but each chart still owns **per-series CPU staging** sized to buffer capacity (interleaved Float32 xy). Cold `setSeries` headroom is **proportional to seed** (`nextPow2(seedBytes × 2)` for mid-size series) — not a fixed ~1M-point floor — so dozens of 100k-point panels stay on the order of **seed × modest pad** of JS heap, not **N × 8 MiB**. Unbounded `appendData` without `maxPoints` still grows with a 2× pad up to a **2M-point cap**. Prefer `{ maxPoints }` on long-lived dashboard streams. Details: [performance — multi-chart staging](../performance.md#multi-chart-datastore-staging-js-heap).
+
 ## Streaming Data
 
 Each chart streams data independently using `appendData()`. Always batch multiple points into a single call for optimal performance.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -138,6 +138,18 @@ ChartGPU.create(el, {
 - Buffer growth: geometric (power-of-two). No shrinking until disposal.
 - Time axis: ChartGPU rebases epoch-ms internally for Float32 precision.
 
+### Multi-chart DataStore staging (JS heap)
+
+Each series keeps a **capacity-sized CPU staging `Float32Array`** (interleaved xy, 8 B/point) for pack + ranged upload. Capacity policy:
+
+| Path | Policy |
+|------|--------|
+| **`setSeries` cold seed** (≥10k points) | `nextPow2(seedBytes × 2)` — **proportional to seed**, no absolute 1M-point floor. A 100k seed → ~2 MiB staging, not ~8 MiB. |
+| **`appendSeries` unbounded growth** (≥100k) | ~2× pad, **capped at 2M points** so N concurrent line slots stay safe. |
+| **FIFO `maxPoints`** | Capacity = ring capacity (exact). |
+
+**Dashboard tip:** Prefer shared `GPUDevice` + `pipelineCache` (see [multi-chart cookbook](guides/multichart-dashboard-cookbook.md)). For long-running streams, pass `{ maxPoints }` on `appendData` so staging does not grow without bound. Suite “Memory (MB)” is often **`usedJSHeapSize` only** — SciChart’s WASM heap is undercounted by that metric; prefer ChartGPU before/after self-comparisons for multi-chart memory claims.
+
 ## Performance baseline (regression tracking)
 
 **Location:** [`examples/performance-baseline/`](../examples/performance-baseline/)

--- a/scripts/multi-chart-staging-headroom-probe.ts
+++ b/scripts/multi-chart-staging-headroom-probe.ts
@@ -1,0 +1,136 @@
+/**
+ * Phase 0 isolation protocol + H1 causal proof (multi-chart staging headroom).
+ *
+ * Goal: docs/plans/2026-07-31-multi-chart-memory-staging-headroom-goal.md
+ *
+ * This script is an **offline unit/math probe** — no browser WebGPU required.
+ * It mirrors DataStore setSeries capacity math (A = legacy 1M floor, B = ship
+ * policy: nextPow2(seedBytes × 2)) and reports sum staging bytes for N charts.
+ *
+ * **Source of truth:** unit tests in
+ * `src/data/__tests__/createDataStore.test.ts` →
+ * `streaming headroom policy (setSeries modest vs append cap)`
+ * (especially `live setSeries capacity matches ship formula for key sizes`).
+ * If mult/threshold changes in createDataStore, update those tests first, then
+ * this probe’s `capacityBytesShip` / `capacityBytesLegacy` to match.
+ *
+ * Primary causal instrument (GC-independent):
+ *   sumStagingBytes = N × capacityBytes(policy, pointsPerChart)
+ *
+ * Run:
+ *   bunx tsx scripts/multi-chart-staging-headroom-probe.ts
+ *   bunx tsx scripts/multi-chart-staging-headroom-probe.ts --n=64 --points=100000
+ *
+ * Multi‑M note: production also runs `clampSeriesCapacityBytes` against
+ * `maxStorageBufferBindingSize` (often 128 MiB). This probe does **not** apply
+ * that clamp — use mid-size seeds (e.g. 100k) for H1; for multi‑M compare
+ * against unit tests that use a mock device with realistic limits.
+ *
+ * Browser A/B (optional, production dist; E1 deferred if not run):
+ *   1. bun run build
+ *   2. Suite: http://localhost:5173/chartgpu/chartgpu.html?test_group_id=10
+ *      (single-row only — do not run N=1…128 ladder for causal measurement)
+ *   3. Chrome with --js-flags=--expose-gc; call gc() before create when available
+ *   4. Compare usedJSHeapSize after_seed A vs B; expect Δ ≈ N×8 MiB order of magnitude
+ *   5. Archive under baselines/multi-chart-mem-ab-YYYYMMDD/
+ */
+
+function nextPow2(bytes: number): number {
+  if (!Number.isFinite(bytes) || bytes <= 0) return 1;
+  const n = Math.ceil(bytes);
+  return 2 ** Math.ceil(Math.log2(n));
+}
+
+/** Legacy (pre-fix) setSeries mid-size policy: mult 4 + absolute 1M-point floor. */
+function capacityBytesLegacy(pointCount: number): number {
+  const targetBytes = pointCount * 8;
+  if (pointCount < 10_000) return nextPow2(targetBytes);
+  const mult = pointCount >= 1_000_000 ? 2 : 4;
+  const minReservePts = pointCount >= 1_000_000 ? pointCount : 1_000_000;
+  return nextPow2(Math.max(targetBytes * mult, minReservePts * 2 * 4));
+}
+
+/**
+ * Ship policy: mult 2, no absolute 1M floor (mid-size and multi-M).
+ * Omits device clampSeriesCapacityBytes — see header multi‑M note.
+ */
+function capacityBytesShip(pointCount: number): number {
+  const targetBytes = pointCount * 8;
+  if (pointCount < 10_000) return nextPow2(targetBytes);
+  return nextPow2(targetBytes * 2);
+}
+
+function parseArgs(argv: string[]): { n: number; points: number } {
+  let n = 64;
+  let points = 100_000;
+  for (const a of argv) {
+    const mN = /^--n=(\d+)$/.exec(a);
+    if (mN) n = Number(mN[1]);
+    const mP = /^--points=(\d+)$/.exec(a);
+    if (mP) points = Number(mP[1]);
+  }
+  return { n, points };
+}
+
+function mb(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(3);
+}
+
+function main(): void {
+  const { n, points } = parseArgs(process.argv.slice(2));
+  const targetBytes = points * 8;
+  const capA = capacityBytesLegacy(points);
+  const capB = capacityBytesShip(points);
+  const sumA = n * capA;
+  const sumB = n * capB;
+  const delta = sumA - sumB;
+  const expectedFloorDelta = n * 1_000_000 * 8; // H1 rough order: N × 8 MiB before pow2
+
+  // Plan ±40% on N×8 MiB → ratio in [0.6, 1.4]
+  const h1_confirmed =
+    delta >= expectedFloorDelta * 0.6 &&
+    delta <= expectedFloorDelta * 1.4 &&
+    sumB < sumA &&
+    capB < 1_000_000 * 8 &&
+    capB <= targetBytes * 4;
+
+  const log = {
+    protocol: 'unit_math_staging_sum',
+    variant_A: 'A_legacy_1M_floor',
+    variant_B: 'B_no_1M_floor_mult2',
+    chartsN: n,
+    pointsPerChart: points,
+    phase: 'after_seed',
+    targetBytesPerSeries: targetBytes,
+    capacityBytes_A: capA,
+    capacityBytes_B: capB,
+    sumStagingBytes_A: sumA,
+    sumStagingBytes_B: sumB,
+    deltaBytes: delta,
+    sumStagingMB_A: Number(mb(sumA)),
+    sumStagingMB_B: Number(mb(sumB)),
+    deltaMB: Number(mb(delta)),
+    expectedFloorBytes_Nx8MiB: expectedFloorDelta,
+    deltaVsNx8MiB_ratio: delta / expectedFloorDelta,
+    h1_confirmed,
+    note:
+      'Staging sum is GC-independent causal instrument for H1. Full browser usedJSHeapSize A/B is optional corroboration (production dist + expose-gc). Multi-M omit clamp — see header.',
+  };
+
+  console.log(JSON.stringify(log, null, 2));
+
+  console.log('\n--- Protocol checklist (browser optional) ---');
+  console.log('1. Single-row only (N=32 or 64 primary)');
+  console.log('2. Force GC before create when window.gc available');
+  console.log('3. Shared GPUDevice + pipelineCache (G10 harness already does)');
+  console.log('4. Seed pointsPerChart per chart; sample after_seed');
+  console.log('5. Primary causal signal: sumStaging or Δ heap ≈ N×8 MiB order');
+  console.log(`6. This run: N=${n} points=${points} Δ_staging=${mb(delta)} MiB (A−B)`);
+  if (points >= 1_000_000) {
+    console.log(
+      '7. WARNING: multi-M ship capacity here is unclamped; production clamps to maxStorageBufferBindingSize'
+    );
+  }
+}
+
+main();

--- a/src/data/__tests__/createDataStore.test.ts
+++ b/src/data/__tests__/createDataStore.test.ts
@@ -1363,33 +1363,150 @@ describe('createDataStore', () => {
   });
 
   describe('streaming headroom policy (setSeries modest vs append cap)', () => {
-    it('setSeries ≥10k reserves ~1M-point headroom (not multi-M hard floor)', () => {
-      const store = createDataStore(device);
-      const n = 10_000;
+    /**
+     * nextPow2 matching createDataStore production form (non-finite / ceil guards).
+     * Live setSeries capacity for ≥10k is nextPow2(n*8*2); below 10k geometric only.
+     * Probe script (scripts/multi-chart-staging-headroom-probe.ts) must track these
+     * unit expectations as source of truth for the ship formula.
+     */
+    function nextPow2(bytes: number): number {
+      if (!Number.isFinite(bytes) || bytes <= 0) return 1;
+      const n = Math.ceil(bytes);
+      return 2 ** Math.ceil(Math.log2(n));
+    }
+
+    /** Ship setSeries capacity formula (mirror of createDataStore; no device clamp). */
+    function expectedSetSeriesCapacityBytes(pointCount: number): number {
+      const targetBytes = pointCount * 8;
+      if (pointCount < 10_000) return nextPow2(targetBytes);
+      return nextPow2(targetBytes * 2);
+    }
+
+    function fillXy(n: number): { x: Float64Array; y: Float64Array } {
       const x = new Float64Array(n);
       const y = new Float64Array(n);
       for (let i = 0; i < n; i++) {
         x[i] = i;
         y[i] = i;
       }
+      return { x, y };
+    }
+
+    it('setSeries just-under-10k (9999) uses geometric only (no 2× mid-size headroom)', () => {
+      const store = createDataStore(device);
+      const n = 9999;
+      const { x, y } = fillXy(n);
       store.setSeries(0, { x, y });
       const buf = store.getSeriesBuffer(0) as unknown as { size: number };
-      // 1M points * 8 bytes = 8_388_608 (pow2). Exact target is 80_000; headroom >> target.
-      expect(buf.size).toBeGreaterThanOrEqual(1_000_000 * 8);
-      // Must not jump to the old 4M-point hard floor on setSeries.
-      expect(buf.size).toBeLessThan(4_000_000 * 8);
+      const staging = store.getSeriesStagingBuffer(0);
+      const expected = nextPow2(n * 8); // geometric only — threshold is >= 10_000
+      expect(buf.size).toBe(expected);
+      expect(staging.byteLength).toBe(expected);
+      expect(staging.length).toBe(expected / 4);
+      // Must not apply 2× mid-size headroom.
+      expect(buf.size).toBe(nextPow2(n * 8));
+      expect(buf.size).not.toBe(nextPow2(n * 8 * 2));
+      expect(buf.size).toBeLessThan(1_000_000 * 8);
     });
 
-    it('unbounded append ≥100k grows with 2× pad but caps at 2M points', () => {
+    it('setSeries mid-size (10k) capacity is proportional to seed, not 1M-point floor', () => {
+      const store = createDataStore(device);
+      const n = 10_000;
+      const { x, y } = fillXy(n);
+      store.setSeries(0, { x, y });
+      const buf = store.getSeriesBuffer(0) as unknown as { size: number };
+      const staging = store.getSeriesStagingBuffer(0);
+      const targetBytes = n * 8;
+      // Policy: nextPow2(targetBytes * 2) — no absolute 1M floor.
+      const expected = nextPow2(targetBytes * 2);
+      expect(buf.size).toBe(expected);
+      expect(staging.byteLength).toBe(expected);
+      expect(staging.length).toBe(expected / 4);
+      // Hard: must be ≪ 1M points (old floor was ≥ 1e6 * 8).
+      expect(buf.size).toBeLessThan(1_000_000 * 8);
+      // Pad ≤ 4× seed bytes (2× then nextPow2 may round up but stays ≤ 4× for 10k).
+      expect(buf.size).toBeLessThanOrEqual(targetBytes * 4);
+    });
+
+    it('setSeries mid-size (100k) capacity is seed×pad (pad ≤ 4×), not ~1M×8', () => {
+      const store = createDataStore(device);
+      const n = 100_000;
+      const { x, y } = fillXy(n);
+      store.setSeries(0, { x, y });
+      const buf = store.getSeriesBuffer(0) as unknown as { size: number };
+      const staging = store.getSeriesStagingBuffer(0);
+      const targetBytes = n * 8; // 800_000
+      const expected = nextPow2(targetBytes * 2); // nextPow2(1_600_000) = 2_097_152
+      expect(buf.size).toBe(expected);
+      expect(staging.byteLength).toBe(expected);
+      expect(staging.length).toBe(expected / 4);
+      expect(buf.size).toBeLessThan(1_000_000 * 8);
+      // On the order of seed×pad with pad ≤ 4× (not 10×).
+      expect(buf.size).toBeLessThanOrEqual(targetBytes * 4);
+      expect(buf.size / targetBytes).toBeLessThanOrEqual(4);
+      expect(buf.size / targetBytes).toBeGreaterThanOrEqual(1);
+    });
+
+    it('setSeries multi-M (1M) capacity is nextPow2(target×2), not multi-GB floor', () => {
+      const store = createDataStore(device);
+      const n = 1_000_000;
+      const { x, y } = fillXy(n);
+      store.setSeries(0, { x, y });
+      const buf = store.getSeriesBuffer(0) as unknown as { size: number };
+      const staging = store.getSeriesStagingBuffer(0);
+      // nextPow2(1e6 * 8 * 2) = nextPow2(16_000_000) = 16_777_216
+      const expected = nextPow2(n * 8 * 2);
+      expect(expected).toBe(16_777_216);
+      expect(buf.size).toBe(expected);
+      expect(staging.byteLength).toBe(expected);
+      expect(staging.length).toBe(expected / 4);
+    });
+
+    it('live setSeries capacity matches ship formula for key sizes (probe lock)', () => {
+      // Source of truth for scripts/multi-chart-staging-headroom-probe.ts capacityBytesShip.
+      const cases = [9999, 10_000, 100_000, 1_000_000] as const;
+      for (const n of cases) {
+        const store = createDataStore(device);
+        const { x, y } = fillXy(n);
+        store.setSeries(0, { x, y });
+        const buf = store.getSeriesBuffer(0) as unknown as { size: number };
+        const staging = store.getSeriesStagingBuffer(0);
+        const expected = expectedSetSeriesCapacityBytes(n);
+        expect(buf.size).toBe(expected);
+        expect(staging.byteLength).toBe(expected);
+      }
+    });
+
+    it('N×100k setSeries staging sum ≪ N × 1M-point floor (multi-chart H1)', () => {
+      const store = createDataStore(device);
+      const n = 100_000;
+      // Primary goal N is 32/64; 32 keeps linear-scale equality without multi-GB fixture cost.
+      const chartsN = 32;
+      const { x, y } = fillXy(n);
+      let sumStaging = 0;
+      const perSeries = nextPow2(n * 8 * 2);
+      for (let s = 0; s < chartsN; s++) {
+        store.setSeries(s, { x, y });
+        const buf = store.getSeriesBuffer(s) as unknown as { size: number };
+        const staging = store.getSeriesStagingBuffer(s);
+        expect(buf.size).toBe(perSeries);
+        expect(staging.byteLength).toBe(perSeries);
+        expect(staging.length).toBe(perSeries / 4);
+        sumStaging += staging.byteLength;
+      }
+      const targetBytes = n * 8;
+      const legacyFloorPerSeries = 1_000_000 * 8; // pre-fix absolute floor (before nextPow2)
+      expect(sumStaging).toBe(perSeries * chartsN);
+      expect(sumStaging).toBeLessThan(legacyFloorPerSeries * chartsN);
+      // Order-of-magnitude: new total is ~N × seed×pad, not N × 8 MiB.
+      expect(sumStaging).toBeLessThanOrEqual(targetBytes * 4 * chartsN);
+    });
+
+    it('unbounded append ≥100k grows with exact 2× stream pad', () => {
       const store = createDataStore(device);
       // Seed just under growth path; small capacity then force past 100k.
       const seedN = 1000;
-      const x0 = new Float64Array(seedN);
-      const y0 = new Float64Array(seedN);
-      for (let i = 0; i < seedN; i++) {
-        x0[i] = i;
-        y0[i] = i;
-      }
+      const { x: x0, y: y0 } = fillXy(seedN);
       store.setSeries(0, { x: x0, y: y0 });
 
       // Grow to 100k+ in one append (unbounded).
@@ -1404,14 +1521,55 @@ describe('createDataStore', () => {
       const nextCount = seedN + add;
       expect(store.getSeriesPointCount(0)).toBe(nextCount);
       const buf = store.getSeriesBuffer(0) as unknown as { size: number };
+      const staging = store.getSeriesStagingBuffer(0);
       const targetBytes = nextCount * 8;
       // Pure geometric nextPow2(target) for 121k pts = 1_048_576.
       // 2× stream pad nextPow2(target*2) = 2_097_152 — must use the larger pad.
-      const pureGeometric = 2 ** Math.ceil(Math.log2(targetBytes));
-      const streamPad = 2 ** Math.ceil(Math.log2(targetBytes * 2));
+      const pureGeometric = nextPow2(targetBytes);
+      const streamPad = nextPow2(targetBytes * 2);
       expect(streamPad).toBeGreaterThan(pureGeometric);
+      expect(streamPad).toBeLessThan(2_000_000 * 8); // not yet at product 2M-point headroom cap
       expect(buf.size).toBe(streamPad);
-      expect(buf.size).toBeLessThanOrEqual(2_000_000 * 8);
+      expect(staging.byteLength).toBe(buf.size);
+      expect(staging.length).toBe(buf.size / 4);
+    });
+
+    it('unbounded append headroom caps at 2M points when 2× pad would exceed', () => {
+      // Cap is on *stream pad headroom* (min(nextPow2(target*2), 2M*8)), not a hard
+      // ceiling below pure geometric nextPow2(target). Bind the min() when:
+      //   nextPow2(target*2) > 2M*8  AND  nextPow2(target) < 2M*8
+      // nextCount = 600_000 → target = 4_800_000;
+      //   pure geo = 8_388_608; preferred = 16_777_216; capped = 16_000_000.
+      const store = createDataStore(device);
+      const seedN = 1000;
+      const { x: x0, y: y0 } = fillXy(seedN);
+      store.setSeries(0, { x: x0, y: y0 });
+
+      const nextCount = 600_000;
+      const add = nextCount - seedN;
+      const x1 = new Float64Array(add);
+      const y1 = new Float64Array(add);
+      for (let i = 0; i < add; i++) {
+        x1[i] = seedN + i;
+        y1[i] = i;
+      }
+      store.appendSeries(0, { x: x1, y: y1 });
+      expect(store.getSeriesPointCount(0)).toBe(nextCount);
+
+      const targetBytes = nextCount * 8;
+      const pureGeometric = nextPow2(targetBytes);
+      const preferred = nextPow2(targetBytes * 2);
+      const MAX_STREAM_HEADROOM_BYTES = 2_000_000 * 8;
+      expect(preferred).toBeGreaterThan(MAX_STREAM_HEADROOM_BYTES);
+      expect(pureGeometric).toBeLessThan(MAX_STREAM_HEADROOM_BYTES);
+      expect(targetBytes).toBeLessThanOrEqual(MAX_STREAM_HEADROOM_BYTES);
+
+      const buf = store.getSeriesBuffer(0) as unknown as { size: number };
+      const staging = store.getSeriesStagingBuffer(0);
+      // Cap binds: capacity is exactly 2M points × 8 B, not preferred 16_777_216.
+      expect(buf.size).toBe(MAX_STREAM_HEADROOM_BYTES);
+      expect(staging.byteLength).toBe(MAX_STREAM_HEADROOM_BYTES);
+      expect(staging.length).toBe(MAX_STREAM_HEADROOM_BYTES / 4);
     });
   });
 });

--- a/src/data/createDataStore.ts
+++ b/src/data/createDataStore.ts
@@ -682,18 +682,17 @@ export function createDataStore(device: GPUDevice): DataStore {
       }
 
       const grownCapacityBytes = computeGrownCapacityBytes(capacityBytes, targetBytes);
-      // Streaming headroom: series compression / multi-chart line
-      // slots seed ~100k then append 10k/frame unbounded. Pre-reserve headroom for
-      // mid-size seeds, but **do not** 4× multi-M seeds (5M×5 FIFO was reserving
-      // ~256MB/series → multi-GB + Invalid BindGroup under memory pressure).
-      // High-rate pure growth headroom remains on appendSeries (2× / 2M cap).
-      // Always clamp to maxStorageBufferBindingSize (10M seed 2× → 256MB would
+      // setSeries cold headroom: modest pad proportional to seed (2× + nextPow2).
+      // Do **not** pre-reserve an absolute 1M-point floor for mid-size seeds —
+      // multi-chart dashboards (N×100k) were paying ~8 MiB JS staging per series
+      // even when the seed was 10k–100k. High-rate pure growth headroom remains
+      // on appendSeries (2× pad / 2M-point cap). Multi-M also uses 2× and is
+      // always clamped to maxStorageBufferBindingSize (10M seed 2× → 256MB would
       // fail bind-group validation on 128 MiB devices).
       let desired = grownCapacityBytes;
       if (pointCount >= 10_000) {
-        const mult = pointCount >= 1_000_000 ? 2 : 4;
-        const minReservePts = pointCount >= 1_000_000 ? pointCount : 1_000_000;
-        const headroom = nextPow2(Math.max(targetBytes * mult, minReservePts * 2 * 4));
+        const SET_SERIES_HEADROOM_MULT = 2;
+        const headroom = nextPow2(targetBytes * SET_SERIES_HEADROOM_MULT);
         desired = Math.max(desired, headroom);
       }
       capacityBytes = clampSeriesCapacityBytes(desired, targetBytes, maxBufferSize, maxStorageBinding);


### PR DESCRIPTION
## Description

Cold `setSeries` loads for mid-size series (roughly 10k–1M points) no longer pre-reserve a fixed ~1M-point CPU staging buffer. Capacity is sized from the seed with a modest 2× pad (`nextPow2`), so dashboards with many charts each holding ~100k points allocate far less JavaScript heap per series.

Streaming growth is unchanged: unbounded `appendSeries` still uses aggressive growth with the existing 2M-point headroom cap, and fixed-capacity FIFO (`maxPoints`) is untouched. Multi-million-point cold seeds keep the same 2× + device-limit clamp path.

## Type of Change

- [x] Performance improvement
- [x] Documentation update

## Related Issues

N/A

## Testing

- [x] Unit tests updated for the new headroom policy (`createDataStore` streaming headroom suite)
- [x] Append growth path and 2M-point cap still covered
- [x] Offline capacity probe documents expected staging bytes for multi-chart seeds
- [x] Production dist rebuild exercised; multi-million FIFO smoke showed no setup hangs and steady-state FPS in line with prior archives on the same machine

## Documentation

- [x] Updated `docs/performance.md` (DataStore staging policy)
- [x] Updated multi-chart dashboard cookbook note

## Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| Cold `setSeries` ~100k points | ~8 MiB JS staging per series (fixed 1M-point floor) | ~2 MiB JS staging per series (seed × 2, rounded) |
| Cold `setSeries` ~10k points | Same ~8 MiB floor | ~0.25 MiB (proportional) |
| Unbounded append growth | 2× pad, 2M-point cap | Unchanged |
| FIFO `maxPoints` | Capacity = ring size | Unchanged |

Largest practical win is multi-chart layouts: staging no longer scales as if every chart were pre-reserved at 1M points. Absolute process memory still includes GPU buffers, canvas, and app-side data; this PR targets the **capacity-sized CPU staging** path that was oversizing cold seeds.

## Additional Notes

No public API change. Headroom math is internal to `DataStore.setSeries`. Optional probe: `scripts/multi-chart-staging-headroom-probe.ts`.