### PR TITLE
fix: preserve sampling-none series during zoom

### DIFF
--- a/src/__tests__/ChartGPU.dataAppend.test.ts
+++ b/src/__tests__/ChartGPU.dataAppend.test.ts
@@ -9,7 +9,22 @@
 import { describe, it, expect, beforeEach, vi, beforeAll, afterEach } from 'vitest';
 import { ChartGPU } from '../ChartGPU';
 import type { ChartGPUInstance, ChartGPUDataAppendPayload } from '../ChartGPU';
-import type { ChartGPUOptions } from '../config/types';
+import type { CartesianSeriesData, ChartGPUOptions } from '../config/types';
+
+const sliceVisibleRangeByXSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('../core/renderCoordinator/data/computeVisibleSlice', async (importOriginal) => {
+  const actual = await importOriginal<{
+    sliceVisibleRangeByX: (data: CartesianSeriesData, xMin: number, xMax: number) => CartesianSeriesData;
+  }>();
+  return {
+    ...actual,
+    sliceVisibleRangeByX: (...args: Parameters<typeof actual.sliceVisibleRangeByX>) => {
+      sliceVisibleRangeByXSpy();
+      return actual.sliceVisibleRangeByX(...args);
+    },
+  };
+});
 
 // Mock WebGPU globals before importing the module
 beforeAll(() => {
@@ -31,6 +46,10 @@ beforeAll(() => {
           style: {},
           appendChild: vi.fn(),
           removeChild: vi.fn(),
+          setAttribute: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          remove: vi.fn(),
         };
       },
     };
@@ -1380,6 +1399,54 @@ describe('ChartGPU - appendData maxPoints (FIFO)', () => {
     expect(hitLeft.match).not.toBeNull();
     expect(hitLeft.match!.value[0]).toBeCloseTo(2, 0);
     expect(hitLeft.match!.value[0]).not.toBe(0);
+
+    await chart.dispose();
+  });
+
+  it("keeps a sampling 'none' ring out of CPU slicing when zoom changes", async () => {
+    const chart = await ChartGPU.create(mockContainer, {
+      animation: false,
+      renderMode: 'external',
+      tooltip: { show: true },
+      dataZoom: [{ type: 'inside' }],
+      grid: { left: 0, right: 0, top: 0, bottom: 0 },
+      yAxis: { min: -10, max: 60 },
+      series: [{ type: 'line', data: [], sampling: 'none' }],
+    });
+
+    const maxPoints = 4;
+    chart.appendData(
+      0,
+      {
+        x: new Float64Array([0, 1, 2, 3]),
+        y: new Float64Array([0, 10, 20, 50]),
+      },
+      { maxPoints }
+    );
+    expect(chart.renderFrame()).toBe(true);
+    chart.appendData(
+      0,
+      {
+        x: new Float64Array([4, 5]),
+        y: new Float64Array([40, 50]),
+      },
+      { maxPoints }
+    );
+    expect(chart.renderFrame()).toBe(true);
+
+    const hitLeft = chart.hitTest(makePointer(1, 343));
+    expect(hitLeft.match).not.toBeNull();
+    expect(hitLeft.match?.value[0]).toBeCloseTo(2, 0);
+    const hitRight = chart.hitTest(makePointer(799, 86));
+    expect(hitRight.match).not.toBeNull();
+    expect(hitRight.match?.value[0]).toBeCloseTo(5, 0);
+
+    sliceVisibleRangeByXSpy.mockClear();
+    chart.setZoomRange(50, 100);
+    expect(chart.renderFrame()).toBe(true);
+
+    expect(chart.getZoomRange()).toEqual({ start: 50, end: 100 });
+    expect(sliceVisibleRangeByXSpy).not.toHaveBeenCalled();
 
     await chart.dispose();
   });

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -2736,6 +2736,24 @@ export function createRenderCoordinator(
         continue;
       }
 
+      // Sparse stems already keep full raw and zoom via scales.
+      if (baseline.type === 'errorBar' || baseline.type === 'impulse') {
+        next[i] = baseline;
+        continue;
+      }
+
+      // sampling:'none' keeps the full raw series resident and lets the x-scale
+      // select the viewport. Slicing again here scans and materializes streaming
+      // rings after the zoom resample path has already preserved their identity.
+      if (
+        baseline.sampling === 'none' &&
+        baseline.type !== 'candlestick' &&
+        baseline.type !== 'ohlc'
+      ) {
+        next[i] = baseline;
+        continue;
+      }
+
       const cache = lastSampledData[i];
 
       // Strategy 1: Use cache if it covers visible range
@@ -2750,9 +2768,6 @@ export function createRenderCoordinator(
             ...baseline,
             data: sliceBandByX(cache.data as BandSeriesData, visibleX.min, visibleX.max),
           };
-        } else if (baseline.type === 'errorBar' || baseline.type === 'impulse') {
-          // sampling 'none' / sparse stems — keep full raw; zoom via scales.
-          next[i] = baseline;
         } else {
           next[i] = {
             ...baseline,
@@ -2773,8 +2788,6 @@ export function createRenderCoordinator(
           ...baseline,
           data: sliceBandByX(baseline.data, visibleX.min, visibleX.max),
         };
-      } else if (baseline.type === 'errorBar' || baseline.type === 'impulse') {
-        next[i] = baseline;
       } else {
         next[i] = {
           ...baseline,


### PR DESCRIPTION
## Description

Fixes a secondary CPU-side visible-range slice that still ran after zoom changes for Cartesian series configured with `sampling: 'none'`.

The render coordinator already preserves the full raw series during zoom resampling for this mode, but the same frame subsequently ran `sliceRenderSeriesToVisibleRange()`. For modular ring-backed data, that path scanned the visible range and materialized a new tuple array even though the renderer should keep the resident data and change only the viewport.

This change makes the visible-range slice follow the same preservation rule:

- preserve full raw data for non-candlestick/OHLC series using `sampling: 'none'`;
- keep the existing candlestick/OHLC visible-range behavior unchanged;
- keep error-bar and impulse preservation explicit;
- add a public-API regression test proving that zoom does not invoke the secondary slice after a ring buffer wraps.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues

No linked issue.

## Testing

- [ ] Tested in Chrome/Edge 113+
- [ ] Tested in Safari 18+
- [ ] Added or updated examples in `examples/` (when behavior changes)
- [ ] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested on different GPUs/platforms (if applicable)

Automated checks completed:

- Regression test is red on `f53f78e` (one `sliceVisibleRangeByX` call after zoom) and green with this patch (zero calls).
- `bun x vitest run src/__tests__/ChartGPU.dataAppend.test.ts`: 56/56 passed.
- Adjacent render/data test set: 145/145 passed.
- `bun x vitest run`: 133 files, 2147 tests passed.
- `bun run build`: passed.
- `bun run lint:duplication`: passed.
- `bun run lint:deps`: passed.

## Documentation

- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)
- [x] Added code comments for complex logic

No public API or configuration semantics changed.

## WebGPU Correctness

- [ ] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [ ] Render pipeline target formats match render pass attachment formats
- [ ] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)

Not applicable: this patch does not change GPU resources, buffers, pipelines, or render passes.

## Browser Testing Checklist

- [ ] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify):

## Screenshots / Videos

Not applicable; the externally visible chart result is unchanged.

## Performance Impact

For `sampling: 'none'`, zoom changes no longer trigger the redundant O(n) CPU visible-range scan and tuple materialization for ring-backed data. The regression test verifies the call is eliminated while the wrapped ring data remains available through the public hit-test API.

## Additional Notes

- Candlestick and OHLC series continue to use visible-range slicing.
- The repository-wide `format:check` and general `lint` commands are already non-clean on the upstream base; no unrelated bulk formatting or lint cleanup is included in this surgical fix.

---

**For Reviewers:**

- Does this PR follow the functional-first architecture patterns?
- Are WebGPU resources properly managed?
- Are examples updated and working?
- Is documentation complete and accurate?
