### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chartgpu/chartgpu",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "High-performance WebGPU charting library",
   "keywords": [
     "webgpu",


### PR DESCRIPTION
## Summary
- Bump `@chartgpu/chartgpu` from `0.3.10` to `0.4.0` in `package.json`.

## Test plan
- [ ] Confirm `package.json` version is `0.4.0`
- [ ] Publish / release workflow (if any) picks up the new version as expected