### PR TITLE
fix: keep fixed-radius scatter streams updating

### DIFF
--- a/src/core/renderCoordinator/data/__tests__/appendFlush.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/appendFlush.test.ts
@@ -2,7 +2,17 @@ import { describe, it, expect, vi } from 'vitest';
 import { createAppendFlush, type AppendFlushDeps } from '../appendFlush';
 import { canRangedAppendLine } from '../canRangedAppendLine';
 import { demoteStagingViewAfterRebindFailure } from '../stagingThinPath';
-import { createStagingRingView } from '../../../../data/cartesianData';
+import {
+  appendIntoRingXY,
+  createRingXYColumns,
+  createStagingRingView,
+  getPointCount,
+  getSize,
+  getX,
+  getY,
+  isRingXYColumns,
+} from '../../../../data/cartesianData';
+import { planMaxPointsWindow } from '../../../../data/maxPointsWindow';
 
 function baseDeps(overrides: Partial<AppendFlushDeps> = {}): AppendFlushDeps {
   const pendingAppendByIndex = new Map<
@@ -131,6 +141,134 @@ describe('appendFlush module ownership', () => {
     expect(lastSetSeriesCache.has(0)).toBe(true);
     // Runtime columns extended (owned mutable path)
     expect(raw.x.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('ranged-appends fixed-radius point scatter with maxPoints', () => {
+    const appendSeries = vi.fn(() => true);
+    const raw = { x: [0, 1] as number[], y: [10, 11] as number[] };
+    const scatter = {
+      type: 'scatter',
+      mode: 'points',
+      sampling: 'none',
+      samplingThreshold: 0,
+      data: raw,
+      rawData: raw,
+    } as any;
+    const deps = baseDeps({
+      currentOptions: { series: [scatter], autoScroll: false, xAxis: {} } as any,
+      runtimeRawDataByIndex: [raw],
+      gpuSeriesKindByIndex: ['fullRawLine'],
+      isOwnedMutableColumns: () => true,
+      ensureMutableRuntimeColumns: () => raw,
+      normalizeMaxPoints: (value) => (typeof value === 'number' ? value : undefined),
+      dataStore: {
+        appendSeries,
+        getSeriesXOffset: vi.fn(() => 0),
+      } as any,
+    });
+    deps.pendingAppendByIndex.set(0, [{ points: { x: [2], y: [12] }, maxPoints: 4 }]);
+    deps.runtimeBaseSeries = [scatter];
+    deps.renderSeries = [scatter];
+
+    expect(createAppendFlush(() => deps)()).toBe(true);
+
+    expect(appendSeries).toHaveBeenCalledWith(0, { x: [2], y: [12] }, { maxPoints: 4 });
+    expect(deps.appendedGpuThisFrame.has(0)).toBe(true);
+    expect(deps.lastSetSeriesCache.has(0)).toBe(true);
+  });
+
+  it('preserves the option seed when scatter appends before its first resident prepare', () => {
+    const appendSeries = vi.fn(() => true);
+    const raw = { x: [0, 1] as number[], y: [10, 11] as number[] };
+    const scatter = {
+      type: 'scatter',
+      mode: 'points',
+      sampling: 'none',
+      samplingThreshold: 0,
+      symbolSize: 4,
+      data: raw,
+      rawData: raw,
+    } as any;
+    const deps = baseDeps({
+      currentOptions: { series: [scatter], autoScroll: false, xAxis: {} } as any,
+      runtimeRawDataByIndex: [raw],
+      gpuSeriesKindByIndex: ['unknown'],
+      isOwnedMutableColumns: () => true,
+      ensureMutableRuntimeColumns: () => raw,
+      normalizeMaxPoints: (value) => (typeof value === 'number' ? value : undefined),
+      planMaxPointsWindow: (prev, next, maxPoints) => planMaxPointsWindow(prev, next, maxPoints ?? undefined),
+      getPointCount: (data) => getPointCount(data as any),
+      getX: (data, index) => getX(data as any, index),
+      getY: (data, index) => getY(data as any, index),
+      getSize: (data, index) => getSize(data as any, index),
+      createRingXYColumns: (capacity, withSize) => createRingXYColumns(capacity, withSize),
+      appendIntoRingXY: (ring, data, newSrcOffset, keepNewCount, dropPrevCount) =>
+        appendIntoRingXY(ring as any, data as any, newSrcOffset, keepNewCount, dropPrevCount),
+      isRingXYColumns,
+      dataStore: {
+        appendSeries,
+        getSeriesXOffset: vi.fn(() => 0),
+      } as any,
+    });
+    deps.pendingAppendByIndex.set(0, [{ points: { x: [2], y: [12] }, maxPoints: 4 }]);
+    deps.runtimeBaseSeries = [scatter];
+    deps.renderSeries = [scatter];
+
+    expect(createAppendFlush(() => deps)()).toBe(true);
+
+    expect(appendSeries).not.toHaveBeenCalled();
+    expect(deps.lastSetSeriesCache.has(0)).toBe(false);
+    const retained = deps.runtimeRawDataByIndex[0] as any;
+    expect(getPointCount(retained)).toBe(3);
+    expect([getX(retained, 0), getX(retained, 1), getX(retained, 2)]).toEqual([0, 1, 2]);
+    expect([getY(retained, 0), getY(retained, 1), getY(retained, 2)]).toEqual([10, 11, 12]);
+  });
+
+  it('keeps every coalesced scatter batch on the private path when a later batch has sizes', () => {
+    const appendSeries = vi.fn(() => true);
+    const raw: { x: number[]; y: number[]; size?: (number | undefined)[] } = {
+      x: [0, 1],
+      y: [10, 11],
+    };
+    const scatter = {
+      type: 'scatter',
+      mode: 'points',
+      sampling: 'none',
+      samplingThreshold: 0,
+      symbolSize: 4,
+      data: raw,
+      rawData: raw,
+    } as any;
+    const deps = baseDeps({
+      currentOptions: { series: [scatter], autoScroll: false, xAxis: {} } as any,
+      runtimeRawDataByIndex: [raw],
+      gpuSeriesKindByIndex: ['fullRawLine'],
+      isOwnedMutableColumns: () => true,
+      ensureMutableRuntimeColumns: () => raw,
+      normalizeMaxPoints: (value) => (typeof value === 'number' ? value : undefined),
+      planMaxPointsWindow: (prev, next, maxPoints) => planMaxPointsWindow(prev, next, maxPoints ?? undefined),
+      getPointCount: (data) => getPointCount(data as any),
+      getX: (data, index) => getX(data as any, index),
+      getY: (data, index) => getY(data as any, index),
+      getSize: (data, index) => getSize(data as any, index),
+      dataStore: {
+        appendSeries,
+        getSeriesXOffset: vi.fn(() => 0),
+      } as any,
+    });
+    deps.pendingAppendByIndex.set(0, [
+      { points: { x: [2], y: [12] } },
+      { points: { x: [3], y: [13], size: [9] } },
+    ]);
+    deps.runtimeBaseSeries = [scatter];
+    deps.renderSeries = [scatter];
+
+    expect(createAppendFlush(() => deps)()).toBe(true);
+
+    expect(appendSeries).not.toHaveBeenCalled();
+    expect(raw.x).toEqual([0, 1, 2, 3]);
+    expect(raw.y).toEqual([10, 11, 12, 13]);
+    expect(raw.size?.[3]).toBe(9);
   });
 
   it('calls recomputeRuntimeBaseSeries when ranged append is not available', () => {

--- a/src/core/renderCoordinator/data/__tests__/canRangedAppendLine.test.ts
+++ b/src/core/renderCoordinator/data/__tests__/canRangedAppendLine.test.ts
@@ -80,13 +80,126 @@ describe('canRangedAppendLine', () => {
     ).toBe(false);
   });
 
-  it('rejects non-line non-area series', () => {
+  it('rejects non-cartesian streaming series', () => {
+    expect(
+      canRangedAppendLine({
+        seriesType: 'bar',
+        sampling: 'none',
+        kind: 'fullRawLine',
+        rawData: raw,
+      })
+    ).toBe(false);
+  });
+
+  it('allows fixed-radius point scatter with sampling none', () => {
+    const scatter = {
+      type: 'scatter' as const,
+      mode: 'points' as const,
+      sampling: 'none' as const,
+      symbolSize: 4,
+    };
+    expect(
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: 'none',
+        kind: 'unknown',
+        rawData: raw,
+        series: scatter as any,
+      })
+    ).toBe(true);
     expect(
       canRangedAppendLine({
         seriesType: 'scatter',
         sampling: 'none',
         kind: 'fullRawLine',
         rawData: raw,
+        series: scatter as any,
+      })
+    ).toBe(true);
+    expect(
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: 'none',
+        kind: 'unknown',
+        rawData: raw,
+        series: { ...scatter, symbolSize: undefined } as any,
+      })
+    ).toBe(true);
+  });
+
+  it('keeps a non-empty cold scatter seed until the first prepare', () => {
+    const scatter = {
+      type: 'scatter' as const,
+      mode: 'points' as const,
+      sampling: 'none' as const,
+      symbolSize: 4,
+    };
+    expect(
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: 'none',
+        kind: 'unknown',
+        rawData: raw,
+        appendedData: [{ x: [3], y: [4] }],
+        series: scatter as any,
+      })
+    ).toBe(false);
+    expect(
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: 'none',
+        kind: 'unknown',
+        rawData: { x: [], y: [] },
+        appendedData: [{ x: [3], y: [4] }],
+        series: scatter as any,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects scatter paths that need private geometry', () => {
+    const baseScatter = {
+      type: 'scatter' as const,
+      mode: 'points' as const,
+      sampling: 'none' as const,
+      symbolSize: 4,
+    };
+    const eligible = (overrides: Record<string, unknown>) =>
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: (overrides.sampling ?? 'none') as any,
+        kind: 'unknown',
+        rawData: raw,
+        series: { ...baseScatter, ...overrides } as any,
+      });
+
+    expect(eligible({ mode: 'density' })).toBe(false);
+    expect(eligible({ sampling: 'lttb' })).toBe(false);
+    expect(eligible({ symbolSize: () => 4 })).toBe(false);
+    expect(
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: 'none',
+        kind: 'unknown',
+        rawData: [
+          [0, 1, 3],
+          [1, 2, 5],
+        ],
+        series: baseScatter as any,
+      })
+    ).toBe(false);
+    expect(
+      canRangedAppendLine({
+        seriesType: 'scatter',
+        sampling: 'none',
+        kind: 'fullRawLine',
+        rawData: raw,
+        appendedData: [
+          [
+            [3, 4, 9],
+            [4, 5, 11],
+          ],
+        ],
+        series: baseScatter as any,
       })
     ).toBe(false);
   });

--- a/src/core/renderCoordinator/data/appendFlush.ts
+++ b/src/core/renderCoordinator/data/appendFlush.ts
@@ -359,6 +359,10 @@ function flushPendingAppendsImplInner(d: any): boolean {
         kind,
         rawData: rawForAppend,
         series: s as any,
+        appendedData:
+          s.type === 'scatter'
+            ? batches.map((batch: PendingAppendBatch) => batch.points as CartesianSeriesData)
+            : undefined,
       });
 
       // Thin path = GPU append fast path: bind coordinator raw to DataStore
@@ -769,7 +773,11 @@ function flushPendingAppendsImplInner(d: any): boolean {
     d.lastSampledData[seriesIndex] = null;
     d.filterGapsCache.delete(seriesIndex);
     const reseedRaw = d.runtimeRawDataByIndex[seriesIndex];
-    if (reseedRaw != null) {
+    // Scatter's private/cold fallback has not updated DataStore. A cache hit on
+    // the next prepare would skip the required seed/full upload before binding
+    // a resident buffer. Only reseed scatter after a successful GPU append.
+    const canReseedDataStoreCache = s.type !== 'scatter' || d.appendedGpuThisFrame.has(seriesIndex);
+    if (reseedRaw != null && canReseedDataStoreCache) {
       let reseedXOffset = 0;
       if (d.isStagingRingView(reseedRaw)) {
         reseedXOffset = reseedRaw.xOffset;

--- a/src/core/renderCoordinator/data/canRangedAppendLine.ts
+++ b/src/core/renderCoordinator/data/canRangedAppendLine.ts
@@ -1,5 +1,5 @@
 /**
- * Pure eligibility for O(k) DataStore.appendSeries on line / area series.
+ * Pure eligibility for O(k) DataStore.appendSeries on append-safe XY series.
  *
  * Full raw resident kinds (`fullRawLine`, `gpuDecimationRaw`) are append-safe at
  * any zoom — the buffer holds full raw, not a zoomed sampled slice.
@@ -16,6 +16,7 @@
 
 import type { ResolvedSeriesConfig } from '../../../config/OptionResolver';
 import type { CartesianSeriesData, SeriesSampling, SeriesType } from '../../../config/types';
+import { getPointCount, hasAnyPerPointSize } from '../../../data/cartesianData';
 import { isGpuDecimationEligible } from '../../../data/gpuDecimationEligibility';
 import { isStackedMountainSeries } from '../../../data/stackedArea';
 import { resolveStepMode } from '../../../data/stepGeometry';
@@ -31,12 +32,42 @@ export type CanRangedAppendLineInput = {
   readonly rawData: CartesianSeriesData | null | undefined;
   /** Full series config when available (areaStyle, samplingThreshold, etc.). */
   readonly series?: ResolvedSeriesConfig | null;
+  /** Coalesced append batches, used to keep scatter size channels on the private path. */
+  readonly appendedData?: ReadonlyArray<CartesianSeriesData>;
 };
 
 /**
  * True when ranged append may write only the new points without full setSeries.
  */
 export function canRangedAppendLine(input: CanRangedAppendLineInput): boolean {
+  // Fixed-radius point scatter can bind the same interleaved XY DataStore buffer
+  // as line/area. Ordering inside a modular ring is irrelevant for point marks.
+  // Density and variable/per-point radius need their dedicated geometry paths.
+  if (input.seriesType === 'scatter') {
+    const series = input.series;
+    const raw = input.rawData ?? null;
+    const symbolSize = series?.type === 'scatter' ? series.symbolSize : undefined;
+    if (
+      series?.type !== 'scatter' ||
+      series.mode === 'density' ||
+      input.sampling !== 'none' ||
+      (symbolSize !== undefined &&
+        (typeof symbolSize !== 'number' || !Number.isFinite(symbolSize) || symbolSize <= 0)) ||
+      raw == null ||
+      hasAnyPerPointSize(raw) ||
+      input.appendedData?.some(hasAnyPerPointSize)
+    ) {
+      return false;
+    }
+    // During append flush, `unknown` can mean the first render has not seeded
+    // DataStore yet. Its maxPoints cold seed contains only the appended batch,
+    // so keep non-empty option data on the CPU path for the first prepare.
+    if (input.kind === 'unknown' && input.appendedData != null && getPointCount(raw) > 0) {
+      return false;
+    }
+    return input.kind === 'fullRawLine' || input.kind === 'unknown';
+  }
+
   // Line and pure area share the XY storage layout; both may ranged-append when
   // the resident buffer is full raw. GPU decimation remains line-only (predicate).
   if (input.seriesType !== 'line' && input.seriesType !== 'area') return false;

--- a/src/core/renderCoordinator/render/__tests__/scatterResidentPrepare.test.ts
+++ b/src/core/renderCoordinator/render/__tests__/scatterResidentPrepare.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Fixed-radius scatter streaming must share the DataStore resident XY buffer.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { ResolvedScatterSeriesConfig } from '../../../../config/OptionResolver';
+import type { ScatterRenderer } from '../../../../renderers/createScatterRenderer';
+import { createLinearScale } from '../../../../utils/scales';
+import { createStackedMountainCache } from '../stackedMountainCache';
+import { prepareSeries, type SeriesPrepareContext, type SeriesRenderers } from '../renderSeries';
+
+function scatterConfig(data: ResolvedScatterSeriesConfig['data']): ResolvedScatterSeriesConfig {
+  return {
+    type: 'scatter',
+    name: 'stream',
+    data,
+    rawData: data,
+    color: '#0af',
+    symbolSize: 4,
+    mode: 'points',
+    binSize: 2,
+    densityColormap: 'viridis',
+    densityNormalization: 'log',
+    sampling: 'none',
+    samplingThreshold: 5000,
+    yAxis: 'y',
+    visible: true,
+  } as ResolvedScatterSeriesConfig;
+}
+
+function scatterRenderer(): ScatterRenderer {
+  return {
+    prepare: vi.fn(),
+    invalidateGeometry: vi.fn(),
+    render: vi.fn(),
+    isDenseDeferred: vi.fn(() => false),
+    renderDense: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function renderers(scatter: ScatterRenderer): SeriesRenderers {
+  return {
+    lineRenderers: [],
+    areaRenderers: [],
+    barRenderer: { prepare: vi.fn(), render: vi.fn(), dispose: vi.fn() } as any,
+    scatterRenderers: [scatter],
+    scatterDensityRenderers: [],
+    pieRenderers: [],
+    heatmapRenderers: [],
+    candlestickRenderers: [],
+    ohlcRenderers: [],
+    bandRenderers: [],
+    errorBarRenderers: [],
+    impulseRenderers: [],
+    decimationComputes: [],
+  };
+}
+
+describe('prepareSeries fixed-radius scatter residency', () => {
+  it('seeds once, then keeps the appended DataStore buffer bound', () => {
+    const data = {
+      x: new Float32Array([0, 1, 2]),
+      y: new Float32Array([1, 2, 3]),
+    };
+    const series = scatterConfig(data);
+    const residentBuffer = { size: 4096 } as unknown as GPUBuffer;
+    const pointCount = { value: 3 };
+    const dataStore = {
+      setSeries: vi.fn(),
+      getSeriesBuffer: vi.fn(() => residentBuffer),
+      getSeriesPointCount: vi.fn(() => pointCount.value),
+      isSeriesRingMode: vi.fn(() => false),
+    } as any;
+    const scatter = scatterRenderer();
+    const gpuSeriesKindByIndex: SeriesPrepareContext['gpuSeriesKindByIndex'] = ['unknown'];
+    const xScale = createLinearScale().domain(0, 3).range(-1, 1);
+    const yScale = createLinearScale().domain(0, 3).range(-1, 1);
+    const context: SeriesPrepareContext = {
+      currentOptions: {
+        series: [series],
+        yAxes: [{ id: 'y', type: 'value' }],
+        xAxis: { type: 'value' },
+        theme: { backgroundColor: '#000' },
+        performance: { lod: 'auto' },
+      } as any,
+      seriesForRender: [series],
+      xScale: xScale as any,
+      yScales: new Map([['y', yScale as any]]),
+      gridArea: {
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        canvasWidth: 200,
+        canvasHeight: 100,
+        devicePixelRatio: 1,
+      },
+      dataStore,
+      appendedGpuThisFrame: new Set(),
+      gpuSeriesKindByIndex,
+      zoomState: null,
+      visibleXDomain: { min: 0, max: 3 },
+      introPhase: 'done',
+      introProgress01: 1,
+      withAlpha: (color) => color,
+      maxRadiusCss: 50,
+      lastSetSeriesCache: new Map(),
+      filterGapsCache: new Map(),
+      stackedMountainCache: createStackedMountainCache(),
+    };
+
+    prepareSeries(renderers(scatter), context);
+
+    expect(dataStore.setSeries).toHaveBeenCalledTimes(1);
+    expect(gpuSeriesKindByIndex[0]).toBe('fullRawLine');
+    expect(scatter.prepare).toHaveBeenLastCalledWith(
+      series,
+      data,
+      xScale,
+      yScale,
+      context.gridArea,
+      false,
+      true,
+      { buffer: residentBuffer, pointCount: 3 }
+    );
+
+    pointCount.value = 4;
+    context.appendedGpuThisFrame.add(0);
+    prepareSeries(renderers(scatter), context);
+
+    expect(dataStore.setSeries).toHaveBeenCalledTimes(1);
+    expect(scatter.prepare).toHaveBeenLastCalledWith(
+      series,
+      data,
+      xScale,
+      yScale,
+      context.gridArea,
+      false,
+      true,
+      { buffer: residentBuffer, pointCount: 4 }
+    );
+  });
+});

--- a/src/core/renderCoordinator/render/renderSeries.ts
+++ b/src/core/renderCoordinator/render/renderSeries.ts
@@ -51,6 +51,7 @@ import { getPointCount, isRingXYColumns, isStagingRingView } from '../../../data
 import { type FilterGapsCache, getFilteredGapsCached } from './filterGapsCache';
 import { getStackedMountainGeometryMap, type StackedMountainCache } from './stackedMountainCache';
 import { getExpandedStepPolyline, getExpandedStepStacked, type StepExpandCache } from './stepExpandCache';
+import { canRangedAppendLine } from '../data/canRangedAppendLine';
 
 // Re-export only production-used symbols for coordinator / frameRender.
 export { createStackedMountainCache, invalidateStackedMountainCache } from './stackedMountainCache';
@@ -954,6 +955,29 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
           gpuSeriesKindByIndex[i] = 'other';
         } else {
           const animated = introP < 1 ? ({ ...s, color: withAlpha(s.color, introP) } as const) : s;
+          const rawData = (s.rawData ?? s.data) as CartesianSeriesData;
+          const useResidentBuffer = canRangedAppendLine({
+            seriesType: s.type,
+            sampling: s.sampling,
+            kind: gpuSeriesKindByIndex[i] ?? 'unknown',
+            rawData,
+            series: s,
+          });
+          let residentData: Readonly<{ buffer: GPUBuffer; pointCount: number }> | undefined;
+          if (useResidentBuffer) {
+            if (!appendedGpuThisFrame.has(i)) {
+              setSeriesIfChanged(i, rawData);
+            }
+            residentData = {
+              buffer: dataStore.getSeriesBuffer(i),
+              pointCount: dataStore.getSeriesPointCount(i),
+            };
+            // Legacy name: this kind denotes append-safe full-raw XY residency
+            // for line, pure area, and now fixed-radius point scatter.
+            gpuSeriesKindByIndex[i] = 'fullRawLine';
+          } else {
+            gpuSeriesKindByIndex[i] = 'other';
+          }
           renderers.scatterRenderers[i].prepare(
             animated,
             s.data,
@@ -961,7 +985,8 @@ export function prepareSeries(renderers: SeriesRenderers, context: SeriesPrepare
             getYScale(s),
             gridArea,
             forceStandardDrawLod,
-            allowScatterPostResolveDense
+            allowScatterPostResolveDense,
+            residentData
           );
         }
         break;

--- a/src/renderers/__tests__/scatterConstRadius.test.ts
+++ b/src/renderers/__tests__/scatterConstRadius.test.ts
@@ -219,6 +219,54 @@ describe('scatter const-radius instance stride', () => {
   });
 });
 
+describe('scatter resident DataStore buffer', () => {
+  it('draws fixed-radius points from an interleaved resident buffer without private geometry uploads', () => {
+    const device = createMockDevice();
+    const writeBuffer = device.queue.writeBuffer as ReturnType<typeof vi.fn>;
+    const createBuffer = device.createBuffer as ReturnType<typeof vi.fn>;
+    const renderer = createScatterRenderer(device, { sampleCount: 1 });
+    const residentBuffer = { size: 4096 } as unknown as GPUBuffer;
+    const residentPointCount = 4;
+    const data = {
+      x: new Float32Array([0, 1, 2, 3]),
+      y: new Float32Array([1, 2, 3, 4]),
+    };
+
+    writeBuffer.mockClear();
+    createBuffer.mockClear();
+    renderer.prepare(
+      baseSeries(5),
+      data as unknown as never,
+      identityScale,
+      identityScale,
+      gridArea,
+      false,
+      true,
+      { buffer: residentBuffer, pointCount: residentPointCount }
+    );
+
+    expect(createBuffer).not.toHaveBeenCalled();
+    expect(writeBuffer).not.toHaveBeenCalled();
+
+    const pass = {
+      setPipeline: vi.fn(),
+      setBindGroup: vi.fn(),
+      setVertexBuffer: vi.fn(),
+      draw: vi.fn(),
+      setScissorRect: vi.fn(),
+    } as unknown as GPURenderPassEncoder & {
+      setVertexBuffer: ReturnType<typeof vi.fn>;
+      draw: ReturnType<typeof vi.fn>;
+    };
+    renderer.render(pass);
+
+    expect(pass.setVertexBuffer).toHaveBeenCalledWith(0, residentBuffer);
+    expect(pass.setVertexBuffer).not.toHaveBeenCalledWith(1, expect.anything());
+    expect(pass.draw).toHaveBeenCalledWith(6, residentPointCount);
+    renderer.dispose();
+  });
+});
+
 describe('scatter geometry identity cache (issue 1.2)', () => {
   it('skips instance writeBuffer on second prepare with same data ref', () => {
     const device = createMockDevice();

--- a/src/renderers/createScatterRenderer.ts
+++ b/src/renderers/createScatterRenderer.ts
@@ -29,7 +29,12 @@ export interface ScatterRenderer {
      * MSAA pass (preserves z-order under standard main-pass line strokes).
      * Default true. Coordinator sets false when any visible line series is present.
      */
-    allowPostResolveDense?: boolean
+    allowPostResolveDense?: boolean,
+    /**
+     * Optional append-safe interleaved XY buffer owned by DataStore. Fixed-radius
+     * point scatter can draw it directly and avoid private full-window repacks.
+     */
+    residentData?: Readonly<{ buffer: GPUBuffer; pointCount: number }>
   ): void;
   /**
    * Drop cached instance geometry so the next `prepare` re-packs.
@@ -314,14 +319,64 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
         )
       : null;
 
+  let pipelineConstRadiusResident: GPURenderPipeline | null = null;
+  let pipelineConstRadiusResidentDenseSS1: GPURenderPipeline | null = null;
+  const createResidentPipeline = (residentSampleCount: number, label: string): GPURenderPipeline =>
+    createRenderPipeline(
+      device,
+      {
+        label,
+        bindGroupLayouts: [bindGroupLayout],
+        vertex: {
+          code: scatterWgsl,
+          label: 'scatter.wgsl',
+          entryPoint: 'vsMainConstRadius',
+          buffers: [
+            {
+              arrayStride: 8,
+              stepMode: 'instance',
+              attributes: [{ shaderLocation: 0, format: 'float32x2', offset: 0 }],
+            },
+          ],
+        },
+        fragment: {
+          code: scatterWgsl,
+          label: 'scatter.wgsl',
+          formats: targetFormat,
+          blend: blendState,
+        },
+        primitive: { topology: 'triangle-list', cullMode: 'none' },
+        multisample: { count: residentSampleCount },
+      },
+      pipelineCache
+    );
+  const getResidentPipeline = (): GPURenderPipeline => {
+    pipelineConstRadiusResident ??= createResidentPipeline(
+      sampleCount,
+      'scatterRenderer/pipelineConstRadiusResident'
+    );
+    return pipelineConstRadiusResident;
+  };
+  const getResidentDensePipeline = (): GPURenderPipeline | null => {
+    if (sampleCount <= 1) return null;
+    pipelineConstRadiusResidentDenseSS1 ??= createResidentPipeline(
+      1,
+      'scatterRenderer/pipelineConstRadiusResidentDenseSS1'
+    );
+    return pipelineConstRadiusResidentDenseSS1;
+  };
+
   /** Variable-radius interleaved instance buffer (x,y,r,pad). */
   let instanceBuffer: GPUBuffer | null = null;
+  /** DataStore-owned interleaved XY buffer; borrowed, never destroyed here. */
+  let residentInstanceBuffer: GPUBuffer | null = null;
   /** Const-radius dual buffers. */
   let xInstanceBuffer: GPUBuffer | null = null;
   let yInstanceBuffer: GPUBuffer | null = null;
   let instanceCount = 0;
   /** True when the last prepare used the constant-radius (dual-buffer) path. */
   let useConstRadiusPipeline = false;
+  let useResidentConstRadius = false;
   let lastConstRadiusDevicePx = 0;
   /**
    * When true, main-pass `render` is a no-op and draws go through `renderDense`
@@ -449,7 +504,8 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     yScale,
     gridArea,
     forceStandardDraw,
-    allowPostResolveDense
+    allowPostResolveDense,
+    residentData
   ) => {
     assertNotDisposed();
 
@@ -494,8 +550,15 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     const constantRadiusDevicePx =
       constantSymbolSizeCss != null ? (hasValidDpr ? constantSymbolSizeCss * dpr : constantSymbolSizeCss) : null;
     const useConstRadius = constantRadiusDevicePx != null && constantRadiusDevicePx > 0 && !hasAnyPerPointSize(data);
+    const residentPointCount =
+      residentData != null && Number.isFinite(residentData.pointCount)
+        ? Math.max(0, Math.floor(residentData.pointCount))
+        : 0;
+    const useResident = useConstRadius && residentData != null;
 
     useConstRadiusPipeline = useConstRadius;
+    useResidentConstRadius = useResident;
+    residentInstanceBuffer = useResident ? residentData.buffer : null;
     lastConstRadiusDevicePx = useConstRadius ? constantRadiusDevicePx! : 0;
 
     const viewportW = gridArea?.canvasWidth ?? lastViewportPx[0];
@@ -518,7 +581,7 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
       const plotH = lastScissor?.h ?? viewportH;
       const drawPol = resolveScatterDrawPolicy({
         constRadius: true,
-        pointCount: count,
+        pointCount: useResident ? residentPointCount : count,
         plotWidthDevicePx: plotW,
         plotHeightDevicePx: plotH,
         radiusDevicePx: lastConstRadiusDevicePx,
@@ -537,6 +600,18 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     fsUniformScratchF32[2] = b;
     fsUniformScratchF32[3] = clamp01(a);
     writeUniformBuffer(device, fsUniformBuffer, fsUniformScratchF32);
+
+    if (useResident) {
+      instanceCount = residentPointCount;
+      // A later transition back to private geometry must repack even if it
+      // happens to reuse the data reference from before resident streaming.
+      boundDataRef = null;
+      boundSizeMode = null;
+      boundConstRadiusCss = null;
+      boundDpr = Number.NaN;
+      boundConstPointCount = 0;
+      return;
+    }
 
     // Geometry identity skip: same data ref + size layout → uniforms only.
     // Policy verb shared with line/DataStore via seriesResidency (issue 3.4 / 2.2).
@@ -808,12 +883,14 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
 
   const isDenseDeferred: ScatterRenderer['isDenseDeferred'] = () => {
     assertNotDisposed();
+    const hasConstGeometry = useResidentConstRadius
+      ? residentInstanceBuffer != null
+      : xInstanceBuffer != null && yInstanceBuffer != null;
     return (
       deferDenseToPostResolve &&
       useConstRadiusPipeline &&
       instanceCount > 0 &&
-      xInstanceBuffer != null &&
-      yInstanceBuffer != null
+      hasConstGeometry
     );
   };
 
@@ -842,6 +919,28 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     }
   };
 
+  const drawResidentConstRadiusInstances = (
+    passEncoder: GPURenderPassEncoder,
+    pipeline: GPURenderPipeline,
+    options?: Readonly<{ manageScissor?: boolean }>
+  ): void => {
+    if (!residentInstanceBuffer || instanceCount === 0) return;
+
+    const manageScissor = options?.manageScissor !== false;
+    if (manageScissor && lastScissor && lastCanvasWidth > 0 && lastCanvasHeight > 0) {
+      passEncoder.setScissorRect(lastScissor.x, lastScissor.y, lastScissor.w, lastScissor.h);
+    }
+
+    passEncoder.setPipeline(pipeline);
+    passEncoder.setBindGroup(0, bindGroup);
+    passEncoder.setVertexBuffer(0, residentInstanceBuffer);
+    passEncoder.draw(6, instanceCount);
+
+    if (manageScissor && lastScissor && lastCanvasWidth > 0 && lastCanvasHeight > 0) {
+      passEncoder.setScissorRect(0, 0, lastCanvasWidth, lastCanvasHeight);
+    }
+  };
+
   const render: ScatterRenderer['render'] = (passEncoder) => {
     assertNotDisposed();
     if (instanceCount === 0) return;
@@ -849,7 +948,11 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
     if (deferDenseToPostResolve && useConstRadiusPipeline) return;
 
     if (useConstRadiusPipeline) {
-      drawConstRadiusInstances(passEncoder, pipelineConstRadius);
+      if (useResidentConstRadius) {
+        drawResidentConstRadiusInstances(passEncoder, getResidentPipeline());
+      } else {
+        drawConstRadiusInstances(passEncoder, pipelineConstRadius);
+      }
       return;
     }
 
@@ -869,8 +972,17 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
 
   const renderDense: ScatterRenderer['renderDense'] = (passEncoder) => {
     assertNotDisposed();
-    if (!isDenseDeferred() || !pipelineConstRadiusDenseSS1) return;
-    drawConstRadiusInstances(passEncoder, pipelineConstRadiusDenseSS1, { manageScissor: false });
+    if (!isDenseDeferred()) return;
+    if (useResidentConstRadius) {
+      const residentDensePipeline = getResidentDensePipeline();
+      if (residentDensePipeline) {
+        drawResidentConstRadiusInstances(passEncoder, residentDensePipeline, { manageScissor: false });
+      }
+      return;
+    }
+    if (pipelineConstRadiusDenseSS1) {
+      drawConstRadiusInstances(passEncoder, pipelineConstRadiusDenseSS1, { manageScissor: false });
+    }
   };
 
   const dispose: ScatterRenderer['dispose'] = () => {
@@ -885,6 +997,8 @@ export function createScatterRenderer(device: GPUDevice, options?: ScatterRender
       }
     }
     instanceBuffer = null;
+    residentInstanceBuffer = null;
+    useResidentConstRadius = false;
     if (xInstanceBuffer) {
       try {
         xInstanceBuffer.destroy();

--- a/src/shaders/scatter.wgsl
+++ b/src/shaders/scatter.wgsl
@@ -4,8 +4,8 @@
 // - Const-radius dual-buffer (vsMainConstRadiusSplit, production Option A):
 //   separate float32 x and y instance buffers (shaderLocation 0/1); radius from
 //   VSUniforms.radiusPx. Enables equal-N y-only upload of N×4 y bytes only.
-// - Legacy interleaved const-radius entry (vsMainConstRadius): float32x2 centers
-//   in one buffer — kept for shader completeness; renderer uses split path.
+// - Resident interleaved const-radius entry (vsMainConstRadius): float32x2 centers
+//   borrowed directly from DataStore for append-safe point scatter.
 // - Draw call: draw(6, instanceCount) using triangle-list expansion in VS
 // - Uniforms:
 //   - @group(0) @binding(0): VSUniforms { transform, viewportPx, radiusPx }


### PR DESCRIPTION
## Description

Fixes fixed-radius scatter series freezing after the first rolling `appendData(..., { maxPoints })` update.

The fallback scatter path mutated `RingXYColumns` in place, while the scatter renderer's identity cache treated the stable data reference as unchanged and skipped the next geometry upload. Forcing full rewrites restored the display but repacked and uploaded the entire retained window on every append.

This change routes append-safe point scatter through the existing resident `DataStore` ring and draws its interleaved XY buffer directly. Eligibility is intentionally limited to:

- `mode: 'points'`
- `sampling: 'none'`
- the default radius or a finite positive numeric `symbolSize`
- no existing or newly appended per-point size channel

Density scatter, sampled scatter, symbol-size callbacks, and per-point radii keep their existing private geometry paths. Coalesced append batches are checked together so a later sized batch cannot lose its radius data. A cold append before the first prepare also preserves the original option seed before creating the resident buffer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues

No linked issue; reproduced in a downstream rolling X-Y waveform view.

## Testing

- `npm run build`
- `npx vitest run` — 134 files / 2155 tests passed
- Focused append-policy, coordinator-prepare, and renderer tests — 54 tests passed after review fixes
- `npm run lint:deps`
- `npm run lint:duplication`

- [ ] Tested in Chrome/Edge 113+
- [ ] Tested in Safari 18+
- [ ] Added or updated examples in `examples/` (when behavior changes)
- [ ] Verified WebGPU validation is clean (no console warnings)
- [ ] Tested on different GPUs/platforms (if applicable)

## Documentation

- [ ] Updated `docs/` when public API or behavior changes
- [ ] Updated `CHANGELOG.md` when public behavior changes
- [ ] Updated README (if relevant)
- [x] Added code comments for complex logic

No public API or configuration contract changes.

## WebGPU Correctness

- [x] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes
- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [x] Render pipeline target formats match render pass attachment formats
- [x] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.)

The resident buffer remains owned by `DataStore`; `ScatterRenderer` borrows it and never destroys it.

## Browser Testing Checklist

- [ ] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify):

## Screenshots / Videos

Not applicable; this is a streaming update and upload-path fix.

## Performance Impact

After the initial seed, steady rolling appends write only the new interleaved XY batch into the resident ring instead of repacking and uploading the retained scatter window. The hot path changes from O(retained points) to O(appended points). No browser benchmark was recorded for this PR.

## Additional Notes

`npm run lint` and `npm run format:check` are already not clean on the current upstream `main` checkout; unrelated baseline findings were left untouched to keep this PR focused.
