### PR TITLE
Fix setOption after completed update transition

### DIFF
--- a/src/__tests__/ChartGPU.externalRender.test.ts
+++ b/src/__tests__/ChartGPU.externalRender.test.ts
@@ -559,6 +559,45 @@ describe('ChartGPU - External Render Mode', () => {
   });
 
   describe('Multiple changes coalesce', () => {
+    it('does not throw when setOption is called after an update transition has just completed', async () => {
+      let nowMs = 0;
+      const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+
+      const buildOptions = (offset: number): ChartGPUOptions => ({
+        animation: { duration: 120, easing: 'cubicOut' },
+        xAxis: { type: 'value', min: 0, max: 10 },
+        yAxis: { type: 'value', min: 0, max: 100 },
+        series: [
+          {
+            type: 'line',
+            data: {
+              x: new Float32Array([0, 1, 2, 3]),
+              y: new Float32Array([10 + offset, 30 + offset, 20 + offset, 40 + offset]),
+            },
+          },
+        ],
+      });
+
+      const chart = await ChartGPU.create(mockContainer, buildOptions(0), {
+        adapter: mockAdapter,
+        device: mockDevice,
+      });
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        chart.setOption(buildOptions(10));
+        nowMs = 1;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        nowMs = 200;
+        expect(() => chart.setOption(buildOptions(20))).not.toThrow();
+      } finally {
+        await chart.dispose();
+        nowSpy.mockRestore();
+      }
+    });
+
     it('multiple setOption calls work with manual renderFrame', async () => {
       const options: ChartGPUOptions = {
         renderMode: 'external',

--- a/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
+++ b/src/core/renderCoordinator/createRenderCoordinatorImpl.ts
@@ -2921,7 +2921,10 @@ export function createRenderCoordinator(
         } catch {
           // best-effort
         }
-        return computeUpdateSnapshotAtProgress(updateTransition, updateProgress01, fromZoomRange);
+        const activeTransition = updateTransition;
+        if (activeTransition !== null) {
+          return computeUpdateSnapshotAtProgress(activeTransition, updateProgress01, fromZoomRange);
+        }
       }
 
       const fromXBase = computeBaseXDomain(currentOptions, runtimeRawBoundsByIndex);


### PR DESCRIPTION

## Description

Fixes a `setOption` crash when a previous update transition completes while `setOptions` is rebasing the next update. Advancing the animation controller can clear `updateTransition`; the coordinator now re-checks it before reading the transition snapshot and otherwise falls back to the current-state path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues

None.

## Testing

- [x] Added a regression test for calling `setOption` immediately after an update transition has completed
- [x] `bun run test --run src/__tests__/ChartGPU.externalRender.test.ts`
- [x] `bun run test --run`
- [x] `npx tsc --noEmit`
- [x] `bun run lint:duplication`
- [x] `bun run lint:deps` (passes with existing warnings)
- [ ] Tested in Chrome/Edge 113+ (not applicable; mocked WebGPU unit regression)
- [ ] Tested in Safari 18+ (not applicable; mocked WebGPU unit regression)
- [ ] Added or updated examples in `examples/` (not applicable; internal bug fix)
- [ ] Verified WebGPU validation is clean (not applicable; mocked WebGPU unit regression)
- [ ] Tested on different GPUs/platforms (not applicable; mocked WebGPU unit regression)

## Documentation

- [ ] Updated `docs/` when public API or behavior changes (not applicable)
- [ ] Updated `CHANGELOG.md` when public behavior changes (not applicable)
- [ ] Updated README (if relevant)
- [ ] Added code comments for complex logic

## WebGPU Correctness

- [ ] All `queue.writeBuffer()` calls use 4-byte aligned offsets and sizes (not applicable)
- [ ] Uniform buffer sizes are properly aligned (typically 16 bytes) (not applicable)
- [ ] Dynamic uniform buffer offsets respect `minUniformBufferOffsetAlignment` (if applicable)
- [ ] Render pipeline target formats match render pass attachment formats (not applicable)
- [ ] GPU resources are properly cleaned up (`buffer.destroy()`, `device.destroy()`, etc.) (not applicable)

## Browser Testing Checklist

- [ ] Chrome 113+
- [ ] Edge 113+
- [ ] Safari 18+
- [ ] Other (specify): mocked WebGPU unit regression only

## Screenshots / Videos

Not applicable.

## Performance Impact

No expected runtime performance impact; this only avoids using a transition snapshot after the transition has been cleared.

## Additional Notes

The failing case was reproducible before the source fix with `TypeError: Cannot read properties of null (reading 'from')` in the new regression.

Co-authored-by: Codex <noreply@openai.com>
